### PR TITLE
Give the legend to the residue rather than to its type

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -72,6 +72,8 @@ public class Residue {
 	private final ArrayList<String> modifications = new ArrayList<>();
 	
 	// cleavage
+	private String legend = null;
+
 	private Residue cleaved_residue = null;
 
 	// positioning
@@ -1617,6 +1619,24 @@ public class Residue {
 	/*
        Create a new residue that is a copy of the current one.
 	 */
+	/**
+	 * How this residue is named in the legend drawn beside a structure, which is the residue's own
+	 * name for itself when it has one, and otherwise what its type is called.
+	 *
+	 * <p>A residue drawn without a symbol is identified only by that legend, and what it should say
+	 * depends on the residue rather than on its type: two structures can hold the same type of
+	 * residue - the same 4-deoxy hexose - as an alpha in one and a beta in the other. Writing it onto
+	 * the type instead, which every residue of that name shares, made the second overwrite the first
+	 * and destroyed the type's own description along the way.
+	 */
+	public String getLegend() {
+		return (this.legend != null) ? this.legend : this.type.getDescription();
+	}
+
+	public void setLegend(String a_sLegend) {
+		this.legend = a_sLegend;
+	}
+
 	public Residue cloneResidue() {
 		Residue ret = new Residue(this.type);
 
@@ -1624,6 +1644,7 @@ public class Residue {
 		ret.anomeric_carbon = this.anomeric_carbon;
 		ret.chirality = this.chirality;
 		ret.ring_size = this.ring_size;
+		ret.legend = this.legend;
 
 		ret.cleaved_residue = (this.cleaved_residue!=null) ?this.cleaved_residue.cloneResidue() :null;
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/GlycanRendererAWT.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/GlycanRendererAWT.java
@@ -110,16 +110,16 @@ public class GlycanRendererAWT extends AbstractGlycanRenderer {
 		HashMap<String, Integer> nodeIndex = new HashMap<>();
 		int id = 1;
 		for(Residue residue : structure.getAllResidues()) {
-			if (residue.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (residue.getLegend().equals("no glycosidic linkages")) continue;
 			if(!residue.isSaccharide() || residue.getType().getSuperclass().equals("Bridge")) continue;
 			if(theGraphicOptions.NOTATION.equals(GraphicOptions.NOTATION_SNFG)) {
 				if(!theResidueStyleDictionary.containsResidue(residue)) {
-					if(!nodeIndex.containsKey(residue.getType().getDescription())) {
-						nodeIndex.put(residue.getType().getDescription(), id);
+					if(!nodeIndex.containsKey(residue.getLegend())) {
+						nodeIndex.put(residue.getLegend(), id);
 						id++;
 					}
-					if(nodeIndex.containsKey(residue.getType().getDescription())) {
-						residue.setID(nodeIndex.get(residue.getType().getDescription()));
+					if(nodeIndex.containsKey(residue.getLegend())) {
+						residue.setID(nodeIndex.get(residue.getLegend()));
 					}
 				}				
 			} else {
@@ -141,12 +141,12 @@ public class GlycanRendererAWT extends AbstractGlycanRenderer {
 		StringBuilder legend = new StringBuilder();
 		for(Residue residue : structure.getAllResidues()) {
 			if(!residue.isSaccharide() || residue.getType().getSuperclass().equals("Bridge")) continue;
-			if (residue.getType().getDescription().equals("no glycosidic linkages")) {
-				nodeIndex.put(0, residue.getType().getDescription());
+			if (residue.getLegend().equals("no glycosidic linkages")) {
+				nodeIndex.put(0, residue.getLegend());
 				continue;
 			}
-			if(!theResidueStyleDictionary.containsResidue(residue) && !nodeIndex.containsValue(residue.getType().getDescription())) {
-				nodeIndex.put(id, residue.getType().getDescription());
+			if(!theResidueStyleDictionary.containsResidue(residue) && !nodeIndex.containsValue(residue.getLegend())) {
+				nodeIndex.put(id, residue.getLegend());
 				id++;
 			}
  		}

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GRESToResidue.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GRESToResidue.java
@@ -74,10 +74,12 @@ public class GRESToResidue {
 		ResidueType newType = ResidueDictionary.findResidueType(trivialName);
 		Residue residue = new Residue(newType);
 
-		// generate monosaccharide legend, when one could be built for this residue
+		// The legend names this residue in the box drawn beside the structure, for a residue with no
+		// symbol of its own. It belongs to the residue: writing it onto the type, which every residue
+		// of that name shares, meant reading a second structure changed what the first one said.
 		if(NonSymbolicResidueDictionary.hasResidueType(trivialName)) {
 			String legend = this.makeLegend(_gres, trinConv);
-			if(legend != null) residue.getType().changeDescription(legend);
+			if(legend != null) residue.setLegend(legend);
 		}
 
 		if(!_gres.getMS().getString().contains("<Q>")  && residue.getTypeName().equals("Sugar"))

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ResidueLegendTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ResidueLegendTest.java
@@ -1,0 +1,65 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.glycoinfo.application.glycanbuilder.dataset.NonSymbolicResidueDictionary;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * The legend that identifies a residue drawn without a symbol of its own.
+ *
+ * <p>It used to be written onto the residue's type, which is the instance the dictionary holds and
+ * every residue of that name shares. So reading a second structure changed what the first one said,
+ * and the type's own description - the one the menus show - was destroyed for the rest of the
+ * session. The legend belongs to the residue.
+ */
+public class ResidueLegendTest {
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** Two structures of the same residue type, held at once, each keeping its own legend. */
+	@Test
+	public void readingOneStructureDoesNotChangeAnother() throws Exception {
+		Glycan alpha = read("WURCS=2.0/1,1,0/[a21d2h-1a_1-5]/1/");
+		Glycan beta = read("WURCS=2.0/1,1,0/[a21d2h-1b_1-5]/1/");
+
+		assertEquals("α-4-deoxy-D-xylHexp", legendOf(alpha));
+		assertEquals("β-4-deoxy-D-xylHexp", legendOf(beta));
+	}
+
+	/** And the dictionary keeps the description it was loaded with, which is what the menus show. */
+	@Test
+	public void theResidueTypeKeepsItsOwnDescription() throws Exception {
+		read("WURCS=2.0/1,1,0/[a21d2h-1a_1-5]/1/");
+
+		assertEquals("XyloHexose",
+				NonSymbolicResidueDictionary.findResidueType("xylHex").getDescription());
+	}
+
+	/** A residue with nothing of its own to say falls back to what its type is called. */
+	@Test
+	public void aResidueWithNoLegendOfItsOwnUsesItsTypes() throws Exception {
+		assertEquals("Glucose", legendOf(read("WURCS=2.0/1,1,0/[a2122h-1x_1-5]/1/")));
+	}
+
+	private String legendOf(Glycan _glycan) {
+		for (Residue residue : _glycan.getAllResidues())
+			if (residue.isSaccharide()) return residue.getLegend();
+
+		return null;
+	}
+
+	private Glycan read(String _wurcs) throws Exception {
+		return new WURCS2Parser().readGlycan(_wurcs, new MassOptions());
+	}
+}


### PR DESCRIPTION
A residue drawn without a symbol of its own is identified only by the legend beside the structure, and the importer wrote that legend by calling `changeDescription` on the residue's **type**. `getType()` hands back the instance the dictionary holds, which every residue of that name shares, so the write went to all of them and stayed there.

Measured before the fix:

```
before reading anything    xylHex -> "XyloHexose"
after reading the alpha    xylHex -> "α-4-deoxy-D-xylHexp"
after reading the beta     xylHex -> "β-4-deoxy-D-xylHexp"
```

The residue built from the first structure then reported the second's legend. Any application holding two structures at once meets this — the web app has a canvas and search results side by side.

The type's own description went with it, for the rest of the session, and that description is what `CanvasAction`, `GlycanCanvas` and the menus show. So the damage was not confined to the legend.

## The change

The legend describes one drawn residue, so it lives on `Residue` now, falling back to the type's description for a residue with nothing of its own to say. `GlycanRendererAWT` reads it there, in the two places it builds the legend box, and `cloneResidue` carries it.

`ResidueType.changeDescription` no longer has a caller.

## Checked

Three tests: two structures of the same type held at once each keep what they say; the dictionary keeps the description it was loaded with; and a residue with no legend of its own falls back to its type's. The existing 26 still pass.

Independent of #114 — no file overlaps — so the two can go in either order.
