### PR TITLE
Take a residue's configuration from the description, not from its type

### DIFF
--- a/src/main/java/org/glycoinfo/application/glycanbuilder/dataset/MonosaccharideMSDictionary.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/dataset/MonosaccharideMSDictionary.java
@@ -32,8 +32,8 @@ import org.glycoinfo.application.glycanbuilder.util.exchange.exporter.GlycanToWU
  */
 public class MonosaccharideMSDictionary {
 
-	/** skeleton code and own substituents -> residue name */
-	private static Map<String, String> descriptionToResidue = null;
+	/** skeleton code and own substituents -> the residue it names, in the configuration it names it */
+	private static Map<String, Named> descriptionToResidue = null;
 
 	/**
 	 * The residue a monosaccharide description names, ignoring anything attached to it beyond the
@@ -42,10 +42,14 @@ public class MonosaccharideMSDictionary {
 	 * @return Returns the residue type, or null when this builder writes no such residue.
 	 */
 	public static ResidueType findResidueType(String _description) {
+		Named named = findNamed(_description);
+		return (named == null) ? null : ResidueDictionary.findResidueType(named.name);
+	}
+
+	private static Named findNamed(String _description) {
 		if (_description == null || _description.isEmpty()) return null;
 
-		String name = getIndex().get(_description);
-		return (name == null) ? null : ResidueDictionary.findResidueType(name);
+		return getIndex().get(_description);
 	}
 
 	/**
@@ -62,10 +66,14 @@ public class MonosaccharideMSDictionary {
 		List<String> groups = groupsOf(_ms);
 
 		for (int owned = groups.size(); owned >= 0; owned--) {
-			ResidueType residueType = findResidueType(describe(skeleton, groups.subList(0, owned)));
+			Named named = findNamed(describe(skeleton, groups.subList(0, owned)));
+			if (named == null) continue;
+
+			ResidueType residueType = ResidueDictionary.findResidueType(named.name);
 			if (residueType == null) continue;
 
-			return new Match(residueType, new LinkedList<String>(groups.subList(owned, groups.size())));
+			return new Match(residueType, named.configuration,
+					new LinkedList<String>(groups.subList(owned, groups.size())));
 		}
 
 		return null;
@@ -105,29 +113,92 @@ public class MonosaccharideMSDictionary {
 		descriptionToResidue = null;
 	}
 
-	private static synchronized Map<String, String> getIndex() {
+	private static synchronized Map<String, Named> getIndex() {
 		if (descriptionToResidue == null) build();
 		return descriptionToResidue;
 	}
 
 	private static void build() {
-		Map<String, String> index = new HashMap<String, String>();
+		Map<String, Named> index = new HashMap<String, Named>();
+
+		indexOwnConfiguration(index);
+		indexOtherConfigurations(index);
+
+		descriptionToResidue = index;
+	}
+
+	/**
+	 * Each residue as its own definition has it. The ring form names a description outright; the other
+	 * forms take what is still free, and a description two residues both write names neither of them -
+	 * reducing a sugar removes its anomeric centre and distinct sugars become one compound, D-glucitol
+	 * and L-gulitol being the same molecule, as are D-arabinitol and D-lyxitol. Answering one of the
+	 * two would be answering wrongly half the time.
+	 */
+	private static void indexOwnConfiguration(Map<String, Named> _index) {
+		Map<String, String> alsoWrittenBy = new HashMap<String, String>();
 
 		for (ResidueType type : ResidueDictionary.allResidues()) {
 			if (!type.isSaccharide() || type.isBridge()) continue;
 
 			for (Form form : Form.values()) {
-				String ms = writeAlone(type, form);
+				String ms = writeAlone(type, form, (char) 0);
 				if (ms == null) continue;
 
-				// the ring form is written first and keeps the key if two forms ever collide
 				String description = describe(skeletonOf(ms), groupsOf(ms));
-				if (!index.containsKey(description)) index.put(description, type.getName());
+				String claimed = alsoWrittenBy.put(description, type.getName());
+
+				if (form == Form.RING) _index.put(description, new Named(type.getName(), type.getChirality()));
+				else if (claimed == null) _index.put(description, new Named(type.getName(), type.getChirality()));
+				else if (!claimed.equals(type.getName())) _index.remove(description);
 			}
 		}
-
-		descriptionToResidue = index;
 	}
+
+	/**
+	 * Then the configurations a residue can be drawn in instead of its own, which only fill what is
+	 * still free. They never displace what the pass above established, nor remove it: D-glucitol is
+	 * what Glc writes by default and what Gul reaches only as an L, and the first of those is the
+	 * answer. Two of these colliding with each other still names neither.
+	 */
+	private static void indexOtherConfigurations(Map<String, Named> _index) {
+		Map<String, String> alsoWrittenBy = new HashMap<String, String>();
+
+		for (ResidueType type : ResidueDictionary.allResidues()) {
+			if (!type.isSaccharide() || type.isBridge()) continue;
+
+			for (Form form : Form.values()) {
+				for (char configuration : OTHER_CONFIGURATIONS) {
+					String ms = writeAlone(type, form, configuration);
+					if (ms == null) continue;
+
+					String description = describe(skeletonOf(ms), groupsOf(ms));
+					if (_index.containsKey(description)) continue;
+
+					String claimed = alsoWrittenBy.put(description, type.getName());
+					if (claimed == null) _index.put(description, new Named(type.getName(), configuration));
+					else if (!claimed.equals(type.getName())) _index.remove(description);
+				}
+			}
+		}
+	}
+
+	/** A residue name together with the configuration the description was written in. */
+	private static class Named {
+		private final String name;
+		private final char configuration;
+
+		Named(String _name, char _configuration) {
+			this.name = _name;
+			this.configuration = _configuration;
+		}
+	}
+
+	/**
+	 * The configurations a residue can be drawn in besides its own. One drawn this way writes a
+	 * different skeleton - 6dTal is a1112m by default and a2221m as an L - and taking the
+	 * configuration from the residue type afterwards would read the second back as the first.
+	 */
+	private static final char[] OTHER_CONFIGURATIONS = { 'D', 'L' };
 
 	/**
 	 * The forms one residue can be written in. Indexing only the first left the rest to a name lookup
@@ -145,8 +216,8 @@ public class MonosaccharideMSDictionary {
 		ALDEHYDE
 	}
 
-	/** How this residue is written standing on its own in that form, or null when it cannot be. */
-	private static String writeAlone(ResidueType _type, Form _form) {
+	/** How this residue is written standing on its own like that, or null when it cannot be. */
+	private static String writeAlone(ResidueType _type, Form _form, char _configuration) {
 		try {
 			Residue root = ResidueDictionary.createReducingEnd("freeEnd");
 			Residue residue = ResidueDictionary.newResidue(_type.getName());
@@ -154,6 +225,7 @@ public class MonosaccharideMSDictionary {
 				residue.setAnomericCarbon('?');
 				residue.setRingSize('?');
 			}
+			if (_configuration != 0) residue.setChirality(_configuration);
 			residue.setAlditol(_form == Form.ALDITOL);
 			residue.setAldehyde(_form == Form.ALDEHYDE);
 			root.addChild(residue);
@@ -174,15 +246,25 @@ public class MonosaccharideMSDictionary {
 	/** A monosaccharide description split into the residue it names and what is attached to it. */
 	public static class Match {
 		private final ResidueType residueType;
+		private final char configuration;
 		private final LinkedList<String> attachedGroups;
 
-		Match(ResidueType _residueType, LinkedList<String> _attachedGroups) {
+		Match(ResidueType _residueType, char _configuration, LinkedList<String> _attachedGroups) {
 			this.residueType = _residueType;
+			this.configuration = _configuration;
 			this.attachedGroups = _attachedGroups;
 		}
 
 		public ResidueType getResidueType() {
 			return this.residueType;
+		}
+
+		/**
+		 * The configuration this description was written in, which is not always the one the residue
+		 * type gives by default - 6dTal writes a1112m as a D and a2221m as an L, and both name 6dTal.
+		 */
+		public char getConfiguration() {
+			return this.configuration;
 		}
 
 		/** The groups left over, each written as WURCS writes it: "6*OSO/3=O/3=O", "4-6", ... */

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GRESToResidue.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GRESToResidue.java
@@ -63,7 +63,9 @@ public class GRESToResidue {
 
 		if(match != null) {
 			trivialName = match.getResidueType().getName();
-			configuration = match.getResidueType().getChirality();
+			// from the description rather than from the type: the same residue writes a different
+			// skeleton in each configuration, and only the description says which one this is
+			configuration = match.getConfiguration();
 		} else {
 			trinConv = new TrivialNameConverter();
 			trinConv.start(_gres);

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ConverterReachTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ConverterReachTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
  * <p>A monosaccharide is normally recognised from this builder's own index. What that index does not
  * hold falls through to a naming converter in glycanformatconverter, and that fallback used to carry
  * one residue in five - it held only the ring form of each residue, so an undetermined anomeric
- * carbon, an alditol or an open chain all missed. Over this corpus it now carries 7 residues of 127.
+ * carbon, an alditol or an open chain all missed. Over this corpus it now carries 6 residues of 127.
  *
  * <p>Keeping it there is a decision rather than an accident, so it is held by this test. The symptom
  * of losing it is quiet: a residue gets named by an outside table instead of ours, and nothing looks
@@ -36,16 +36,12 @@ import org.junit.Test;
 public class ConverterReachTest {
 
 	/**
-	 * The descriptions the index does not hold. Four are residues this builder has no entry for at
-	 * all, rather than forms it failed to recognise. The fifth, a2221m, is one it does hold - 6dTal
-	 * drawn as an L - and it misses because the index records each residue in its own configuration
-	 * only. Closing that means carrying the configuration in the index rather than taking it from the
-	 * residue type, which is tracked separately.
+	 * The descriptions the index does not hold, each a residue this builder has no entry for at all
+	 * rather than a form or a configuration it failed to recognise.
 	 */
 	private static final List<String> NOT_OURS = Arrays.asList(
 			"a21EEA-1a_1-5_2*OSO/3=O/3=O",   // a hexuronate with an unsaturation
 			"a21d2h-1a_1-5",                 // a 4-deoxy hexose
-			"a2221m-1x_1-5",                 // 6dTal drawn as an L
 			"hxh",                           // glycerol
 			"o2h");                          // glyceraldehyde
 
@@ -72,7 +68,7 @@ public class ConverterReachTest {
 		}
 
 		assertEquals("residues read from the corpus", 127, residues);
-		assertEquals("residues the index could not name, which go to the converter", 7, unmatched);
+		assertEquals("residues the index could not name, which go to the converter", 6, unmatched);
 		assertEquals("which descriptions they were", NOT_OURS, new ArrayList<String>(descriptions));
 	}
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/MonosaccharideMSDictionaryTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/MonosaccharideMSDictionaryTest.java
@@ -119,6 +119,34 @@ public class MonosaccharideMSDictionaryTest {
 		assertEquals("6*OSO/3=O/3=O", sulfated.getAttachedGroups().get(0));
 	}
 
+	/**
+	 * A residue drawn in the configuration that is not its own writes a different skeleton, and the
+	 * description says which one it is. Reading the configuration off the residue type instead - the
+	 * default it happens to carry - turned 6dTal drawn as an L back into the D on the way out.
+	 */
+	@Test
+	public void theConfigurationComesFromTheDescription() {
+		MonosaccharideMSDictionary.Match asWritten = MonosaccharideMSDictionary.match("a1112m-1x_1-5");
+		assertEquals("6dTal", asWritten.getResidueType().getName());
+		assertEquals('D', asWritten.getConfiguration());
+
+		MonosaccharideMSDictionary.Match mirrored = MonosaccharideMSDictionary.match("a2221m-1x_1-5");
+		assertEquals("6dTal", mirrored.getResidueType().getName());
+		assertEquals('L', mirrored.getConfiguration());
+	}
+
+	/**
+	 * Reducing a sugar removes its anomeric centre, and distinct sugars become one compound -
+	 * D-glucitol and L-gulitol are the same molecule. The residue that writes it in its own
+	 * configuration is the answer, rather than the one that has to be drawn as its mirror image to
+	 * reach it. Both name the same thing, so the description survives either way.
+	 */
+	@Test
+	public void anAlditolIsNamedByTheResidueThatWritesItByDefault() {
+		assertResidue("Glc", "h2122h");
+		assertResidue("Ara", "h221h");
+	}
+
 	/** The substituents a residue owns are part of what names it. */
 	@Test
 	public void namesAResidueTogetherWithItsOwnSubstituents() {


### PR DESCRIPTION
The index said which residue a description named, and `GRESToResidue` then took the configuration from that residue type's **default**:

```java
trivialName   = match.getResidueType().getName();
configuration = match.getResidueType().getChirality();
```

So a residue drawn in the configuration that is not its own could not be read back. `6dTal` writes `a1112m` as a D and `a2221m` as an L; the second arrived unrecognised — and simply indexing it made the name right while the configuration collapsed to the default, so `a2221m` read in and wrote out as `a1112m`. That was attempted in an earlier pass and reverted for exactly this reason.

The index carries the configuration alongside the name now, `Match` exposes it, and the importer uses it.

## Two passes, and the order is the point

1. each residue in the configuration its own definition gives it
2. the configurations it can be drawn in instead — filling only what is still free, never displacing or removing what the first pass established

Without that separation the second pass deleted the first's entries: `Gul` drawn as an L writes D-glucitol, and it removed the entry `Glc` had made for it by default.

## The collision is real chemistry

Reducing a sugar removes its anomeric centre, and distinct sugars become one compound — D-glucitol and L-gulitol are the same molecule, as are D-arabinitol and D-lyxitol, and D-altritol and D-talitol.

- where two residues write the same description **in their own configurations**, it names neither and the key is dropped, since answering one would be wrong half the time
- where one of them reaches it only as a mirror image, the one that writes it **by default** is the answer

Six descriptions resolve to the residue that writes them by default rather than to the mirrored one. That is the same compound under its other name, and the description survives the round trip either way.

## Checked

- `ConverterReachTest` goes from 7 to 6, which is the residue this closes — the test was updated to the measured value
- the baseline row that broke on this is right again
- all 184 baseline strings read back byte-identical
- the corpus round trip is unchanged
- 48 tests pass

Builds on #114 and #116.
