### PR TITLE
Put the version back until the release decides it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Change log
-### 1.28.1  (2026xxxx)
+### Unreleased
 * Fixed the application failing to start on Linux distributions that no longer ship GTK2
 * Removed the DJNativeSwing and SWT dependencies, which the application never used
   * The native interface was opened and pumped without any native component being created

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.28.1</version>
+	<version>1.28.0</version>
 	<packaging>jar</packaging>
 
 	<properties>


### PR DESCRIPTION
#113 carried a bump to `1.28.1` and a changelog heading to match, alongside the SWT removal itself. Versioning belongs to `develop` immediately before it merges to `master`, not to a branch on its way in, so `develop` was left claiming a version it has not released.

It also no longer fits. Since 1.28.0, `develop` has taken:

- a change of default configuration for `Lyx`, from L to D (#114)
- a new residue, `TalA` (#114)
- a substituent it could not write before, `Pyr` (#114)
- a new method on `Residue`, `getLegend()` (#115)

None of which a patch release describes.

## The change

- `pom.xml` goes back to `1.28.0`, which is what was last released
- the changelog entries move under `### Unreleased`, with their wording untouched

The release step gives them their number — 1.29.0 by the look of the above — and adds what has landed since.

Nothing else is touched. The SWT removal itself is untouched and stays; only the version bump that came with it is deferred. 48 tests pass.
