### PR TITLE
Stop asking macOS to start Swing on the first thread

### DIFF
--- a/.github/workflows/jpackage_installer_macos.yml
+++ b/.github/workflows/jpackage_installer_macos.yml
@@ -128,7 +128,6 @@ jobs:
           --vendor "The Noguchi Institute - Glycoinformatics Lab." \
           --description "A tool for drawing and editing glycans intuitively" \
           --copyright "Copyright © 2026 The Noguchi Institute" \
-          --java-options "-XstartOnFirstThread" \
           --mac-sign \
           --mac-signing-key-user-name "${{ steps.signing.outputs.IDENTITY }}"
       shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * The native interface was opened and pumped without any native component being created
   * Opening it forked a second JVM and pulled in a platform SWT build and its matching GTK
 * Removed the platform SWT profiles that existed only to supply those dependencies
+* Stopped passing -XstartOnFirstThread on macOS, which SWT needed and Swing cannot start under
+  * The macOS installer built an app that opened no window
 
 ### 1.28.0  (20260807)
 * Fixed bridge substituents within one monosaccharide disappearing from WURCS export

--- a/README.md
+++ b/README.md
@@ -54,11 +54,7 @@ mvn clean -P make-fat-jar package
 
 Run the JAR:
 ```
-# Windows / Linux
 java -jar ./target/glycanbuilder2-jar-with-dependencies.jar
-
-# macOS
-java -XstartOnFirstThread -jar ./target/glycanbuilder2-jar-with-dependencies.jar
 ```
 
 ## Usage


### PR DESCRIPTION
Following the README to run the application on macOS does not work: it starts and no window appears.

`-XstartOnFirstThread` is there for SWT. It hands the JVM's main thread to the caller, which is what SWT needs on macOS and what AWT cannot work around — Swing launched under it never gets its event loop going.

#113 removed SWT, so the flag is not merely unnecessary now, it is the thing stopping the application from opening.

## Measured

A plain Swing frame under the same JVM, same machine:

```
with -XstartOnFirstThread     twenty seconds, not even the first line of output (timeout)
without                       headless = false
                              displayable = true   showing = true
                              exits cleanly
```

## Where it was

| | |
|---|---|
| `README.md` | the macOS line of the run instructions |
| `.github/workflows/jpackage_installer_macos.yml` | `--java-options`, baked into the `.dmg` |

The second matters more than the first: it affects anyone who installs the signed app, not only someone building from source. Linux and Windows never passed it — their installer workflows pass no `--java-options` at all — so macOS was the only platform affected.

## The change

Both occurrences removed, and the run instructions become one command for all three platforms. A changelog entry goes under `Unreleased` alongside the rest of the SWT removal.

Worth doing before the next release, since the macOS installer is built by that workflow. 48 tests pass.
