### PR TITLE
Version 1.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## Change log
-### Unreleased
+### 1.29.0  (20260808)
+* Wrote eleven residues that no WURCS string could be produced for
+  * Kdo, Mur, MurNAc, MurNGc, Bac, Dha, Api, and both manno-heptoses
+  * Residues that could not be written now say which residue and why, instead of failing silently
+  * dHexA is still refused: its definition records no carbon for the deoxy the name claims
+* Added TalA, the one hexuronate SNFG names that had a symbol here but no residue
+* Wrote monovalent pyruvate, using the MAP the WURCS 2.0 specification defines for it
+* Changed the default configuration of Lyx from L to D
+  * SNFG and PubChem both give the symbol as D-Lyxose, and the symbol drawn for it already meant D
+  * A structure saved before this keeps its meaning: GWS records the configuration explicitly
+* Corrected Dha, which had no anomeric carbon, configuration or ring recorded, and Api, which was
+  recorded as a pyranose where it is the one furanose SNFG makes an exception of
+* Read WURCS through this project's own dictionaries rather than a converter's tables
+  * A residue is now recognised in every form it is written in, not only with a ring - an
+    undetermined anomeric carbon, an alditol and an open chain were all going unrecognised
+  * A residue drawn in the configuration that is not its default is read back as itself
+  * Substituents on a residue written without a ring are no longer lost
+* Fixed the legend under a residue drawn without a symbol overwriting its residue type
+  * Reading one structure changed what another said, and the type's own description - the one the
+    menus show - was replaced for the rest of the session
 * Fixed the application failing to start on Linux distributions that no longer ship GTK2
 * Removed the DJNativeSwing and SWT dependencies, which the application never used
   * The native interface was opened and pumped without any native component being created

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.28.0</version>
+	<version>1.29.0</version>
 	<packaging>jar</packaging>
 
 	<properties>


### PR DESCRIPTION
Versioning ahead of the merge to master, which is where the procedure puts it.

`pom.xml` goes to **1.29.0** and the changelog's `Unreleased` heading takes that number.

## Why a minor and not a patch

| | |
|---|---|
| `Lyx` default configuration | L → D, so an existing drawing writes a different string |
| `TalA` | a residue that was not there before |
| `Pyr` | writes where it did not |
| `Residue.getLegend()` | new method; nothing removed from the API |
| residues WURCS cannot write | 12 → 3 |

## Checked

48 tests pass, and `mvn -P make-fat-jar package` builds `glycanbuilder2-1.29.0.jar` and the fat jar.

## What follows

The PR to master, the `v1.29.0` tag on that merge commit, `mvn deploy` locally, and the installer workflow — the last of which needs #120 to be in, and it is.
