### PR TITLE
Release 1.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 ## Change log
+### 1.30.0  (20260808)
+* Wrote a labelled reducing end as itself, where every label wrote what a free reducing end wrote
+  * PA, 2AB, AA and the other eight are reductive aminations, so each leaves its sugar acyclic -
+    only the alditol marker was recorded as doing so
+  * A 2AB glycan weighed 120 Da more than a free one and produced the same WURCS, so two
+    structures registered as one
+  * Which reducing ends reduce is asked of the residue type rather than listed
+* Kept the ring form and the alditol and aldehyde flags saying one thing
+  * Setting the ring form now sets the flags the exporters actually read, so a caller that is not
+    the desktop canvas no longer leaves a residue that says it is acyclic and writes as a ring
+  * A saved alditol came back a ring, and undo, which goes through GWS, quietly un-reduced
+    whatever it touched
+* Stored the open-chain form in GWS, which its ring codes did not include
+  * A structure drawn as an open chain could be saved and then not opened
+* Drew a labelled reducing end on an acyclic sugar
+  * An acyclic sugar suppressed the reducing-end symbol whatever it was, which hid every label
+    once labels were correctly recorded as making their sugar acyclic
+  * A plain alditol still draws none: the sugar's own marker says it
+* Fixed Ctrl+Left navigating down, which it has done since the first commit
+* Fixed cloning a structure built through the API rather than parsed
+  * It has no bracket, which the clone reached through regardless - taking computeMass(String)
+    with it, since that clones before changing the isotope
+
 ### 1.29.0  (20260808)
 * Wrote eleven residues that no WURCS string could be produced for
   * Kdo, Mur, MurNAc, MurNGc, Bac, Dha, Api, and both manno-heptoses

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.29.0</version>
+	<version>1.30.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -172,6 +172,11 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 				root_residues.addLast(linkage.getChildResidue());
 
 			if( !current.isSaccharide() ) continue;
+			// A structure built through the API rather than parsed has no bracket, and there is
+			// nothing to attach to its children when there are none. Reaching through it regardless
+			// made every clone of such a structure throw - which took computeMass(String) with it,
+			// since that clones before it changes the isotope.
+			if( bracket==null ) continue;
 			for( Linkage linkage : bracket.getChildrenLinkages() )
 				linkage.getChildResidue().addParentOfFragment(current);
 		}
@@ -401,17 +406,16 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 		//if( redend!=null && redend.isReducingEnd() && !redend.isCleavage() && !redend.getTypeName().equals(new_type.getName()) ) {
 		redend.setType(new_type);
 
-		//20211215, S.TSUCHIYA add
-		if (redend.getTypeName().equals("redEnd")) {
-			redend.getChildAt(0).setAlditol(true);
+		// Every reducing end that reduces its sugar leaves it acyclic - the alditol marker, and each
+		// of the labels, which are reductive aminations. Their masses say so: a label adds its own
+		// mass, less the water of the condensation, plus the 2H of the reduction. ResidueType
+		// records which they are, so this asks rather than naming redEnd alone - which had a 2AB
+		// writing the same WURCS as a free reducing end while weighing 120 Da more.
+		if (new_type.makesAlditol()) {
 			redend.getChildAt(0).setAnomericState('?');
 			redend.getChildAt(0).setRingSize('o');
-		}
-		if (!redend.getTypeName().equals("redEnd")) {
-			redend.getChildAt(0).setAlditol(false);
-			if (redend.getChildAt(0).getRingSize() == 'o') {
-				redend.getChildAt(0).setRingSize(redend.getChildAt(0).getType().getRingSize());
-			}
+		} else if (redend.getChildAt(0).getRingSize() == 'o') {
+			redend.getChildAt(0).setRingSize(redend.getChildAt(0).getType().getRingSize());
 		}
 
 		//20211215, S.TSUCHIYA comment out

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanCanvas.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanCanvas.java
@@ -4268,7 +4268,7 @@ public class GlycanCanvas extends JComponent implements ActionListener,
 		if(a_enumAction.equals(CanvasActionDescriptor.MOVECW)) onMoveCW();
 		if(a_enumAction.equals(CanvasActionDescriptor.NAVUP)) onNavigateUp();
 		if(a_enumAction.equals(CanvasActionDescriptor.NAVDOWN)) onNavigateDown();
-		if(a_enumAction.equals(CanvasActionDescriptor.NAVLEFT)) onNavigateDown();
+		if(a_enumAction.equals(CanvasActionDescriptor.NAVLEFT)) onNavigateLeft();
 		if(a_enumAction.equals(CanvasActionDescriptor.NAVRIGHT)) onNavigateRight();
 		if(a_enumAction.equals(CanvasActionDescriptor.EXPLODE)) explode();
 		if(a_enumAction.equals(CanvasActionDescriptor.IMPLODE)) implode();

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -362,11 +362,21 @@ public class Residue {
 	}
 
 	/*
-       Set the ring size as [p - pyranose, f - furanose, o - open, ? -
-       unspecified]
+       Set the ring size as [p - pyranose, f - furanose, o - alditol, a - open
+       chain, ? - unspecified].
+
+       The two acyclic forms are also carried as flags, which is what the
+       exporters read: a Glc flagged alditol writes [h2122h] and one flagged
+       aldehyde writes [o2122h], where the ring letter alone reaches neither.
+       Setting them here keeps the one fact in one state, so that a caller
+       which sets only the ring size - the GWS parser, and any front end that
+       is not GlycanCanvas - does not leave a residue that says it is acyclic
+       and writes as a ring.
 	 */
 	public void setRingSize(char _ring_size) {
 		ring_size = _ring_size;
+		alditol = (_ring_size == 'o');
+		a_bIsAldehyde = (_ring_size == 'a');
 	}
 
 	/*

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
@@ -58,7 +58,9 @@ public class GWSParser implements GlycanParser {
 
 		String start_repeat_str = "\\[";
 		String end_repeat_str = "](?:_(-?[0-9]+))?+(?:\\^(-?[0-9]+))?+";
-		String residue_str = "([abo?][1-9N?])?+([DL]-)?+([a-zA-z0-9_#=.]+)(?:,([?opf]))?+";
+		// Ring forms: pyranose, furanose, alditol and the open chain, which a residue can be set to
+		// through setRingSize and which this used to write without being able to read back.
+		String residue_str = "([abo?][1-9N?])?+([DL]-)?+([a-zA-z0-9_#=.]+)(?:,([?opfa]))?+";
 		String cleaved_str = "/([a-zA-z0-9_#]+)";
 		String place_str = "@(-?[0-9]+s?)";
 		String cord_str="<bounding_box>([0-9]+),([0-9]+),([0-9]+),([0-9]+)</bounding_box>";

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/GlycanUtils.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/GlycanUtils.java
@@ -94,13 +94,30 @@ public class GlycanUtils {
 
 		if(a_oRoot.isSaccharide() && isFacingAnom(a_oRoot)) ret = false;
 		if(a_oRoot.isStartCyclic()) ret = false;
+		// In SNFG an acyclic sugar carries its own marker, so a free or reduced reducing end has
+		// nothing left to draw beside it. A label does: it names what the sample was tagged with,
+		// and it is most of the difference in mass. Since every label reduces its sugar - each is a
+		// reductive amination - suppressing all acyclic sugars suppressed every label with them.
 		if(theGraphicOptions.NOTATION.equals(GraphicOptions.NOTATION_SNFG)) {
-			if(a_oRoot.isAlditol() || a_oRoot.isAldehyde()) return false;
+			if((a_oRoot.isAlditol() || a_oRoot.isAldehyde())
+					&& !isLabelledReducingEnd(a_oGlycan.getRoot())) return false;
 		}
 		
 		return ret;
 	}
 	
+	/**
+	 * Whether the reducing end is one that names a label rather than one of the two plain states.
+	 * @param a_oRedEnd Reducing end residue of the structure.
+	 */
+	private static boolean isLabelledReducingEnd(Residue a_oRedEnd) {
+		if(a_oRedEnd == null || a_oRedEnd.getType() == null) return false;
+
+		String name = a_oRedEnd.getTypeName();
+		return !"freeEnd".equals(name) && !"redEnd".equals(name)
+				&& a_oRedEnd.getType().canBeReducingEnd();
+	}
+
 	/**local utility*/
 	private void getCoreResidue(Residue _residue) {
 		if(_residue != null && !_residue.isReducingEnd()) this.a_aResidues.addLast(_residue);

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GRESToResidue.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GRESToResidue.java
@@ -88,13 +88,13 @@ public class GRESToResidue {
 			throw new WURCSToGlycanException(_gres.getMS().getString() + " is not handled in GlycanBuilder");
 		
 		residue.setWasSticky(isSticky(trivialName));
-		residue.setAlditol(this.isAlditol());
-		residue.setAldehyde(this.isAldehyde());
-	
+
 		residue.setAnomericCarbon(this.checkAnomerPosition());
 		residue.setAnomericState(this.checkAnomerSymbol());
 		residue.setChirality(configuration);
-		residue.setRingSize(residue.isAlditol() ? 'o' : this.ringSize);
+		// The ring letter carries the acyclic forms now, and setting it sets the flags that go with
+		// them - so the two are set together here rather than either being able to undo the other.
+		residue.setRingSize(this.isAlditol() ? 'o' : this.isAldehyde() ? 'a' : this.ringSize);
 
 		// the skeleton is matched whole, so a recognised residue leaves no core modification behind
 		this.modifications = (trinConv == null) ? new ArrayList<String>() : trinConv.getModifications();

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AcyclicFormTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AcyclicFormTest.java
@@ -1,0 +1,183 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * The two acyclic forms a sugar can be drawn in, and what a reducing end has to do with them.
+ *
+ * <p>A sugar is acyclic when it has been reduced, and it is reduced by its reducing end - the
+ * alditol marker, and every one of the labels, each of which is a reductive amination. That fact is
+ * carried on the residue as {@code alditol} and {@code aldehyde}, and it is those flags rather than
+ * the ring letter that the exporters read: a Glc flagged alditol writes {@code [h2122h]}, one
+ * flagged aldehyde writes {@code [o2122h]}, and one flagged neither writes a ring.</p>
+ *
+ * <p>Three places wrote only half of it, and each is measured here.</p>
+ */
+public class AcyclicFormTest {
+
+	private static BuilderWorkspace workspace;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.setNotation("snfg");
+	}
+
+	/**
+	 * A reducing end that reduces its sugar leaves it acyclic, which the WURCS then says. Only the
+	 * alditol marker used to, so a 2AB wrote what a free reducing end wrote while weighing 120 Da
+	 * more - two structures, one string.
+	 */
+	@Test
+	public void everyReducingEndThatReducesItsSugarSaysSo() {
+		assertEquals("freeEnd", "WURCS=2.0/1,1,0/[a2122h-1b_1-5]/1/", wurcsWithReducingEnd("freeEnd"));
+
+		for (String reduced : new String[] {"redEnd", "PA", "2AB", "AA", "DH"}) {
+			assertEquals(reduced, "WURCS=2.0/1,1,0/[h2122h]/1/", wurcsWithReducingEnd(reduced));
+		}
+	}
+
+	/** And the masses differ, which is what says the one string was wrong rather than the drawing. */
+	@Test
+	public void theyDifferInMassByTheirOwnLabel() {
+		double free = massWithReducingEnd("freeEnd");
+
+		assertEquals("the alditol adds 2H", 2.0157, massWithReducingEnd("redEnd") - free, 0.001);
+		assertEquals("2AB", 120.0687, massWithReducingEnd("2AB") - free, 0.001);
+		assertEquals("PA", 78.0582, massWithReducingEnd("PA") - free, 0.001);
+	}
+
+	/**
+	 * Setting the ring letter sets the flags that go with it. Every caller that is not the desktop
+	 * canvas set only the letter, and the GWS parser is one of them - so a saved alditol came back
+	 * as a ring, and undo, which goes through GWS, quietly un-reduced whatever it touched.
+	 */
+	@Test
+	public void theRingLetterAndTheFlagsSayOneThing() {
+		Residue sugar = ResidueDictionary.findResidueType("Glc") == null ? null : newGlc();
+
+		sugar.setRingSize('o');
+		assertTrue("alditol", sugar.isAlditol());
+		assertFalse("not an aldehyde", sugar.isAldehyde());
+
+		sugar.setRingSize('a');
+		assertTrue("aldehyde", sugar.isAldehyde());
+		assertFalse("not an alditol", sugar.isAlditol());
+
+		sugar.setRingSize('p');
+		assertFalse("a ring is neither", sugar.isAlditol());
+		assertFalse("a ring is neither", sugar.isAldehyde());
+	}
+
+	/** So both acyclic forms survive being written to GWS and read back. */
+	@Test
+	public void bothAcyclicFormsSurviveGws() {
+		assertEquals("alditol", "WURCS=2.0/1,1,0/[h2122h]/1/", afterGwsRoundTrip('o'));
+		assertEquals("open chain", "WURCS=2.0/1,1,0/[o2122h]/1/", afterGwsRoundTrip('a'));
+	}
+
+	/**
+	 * A label is still drawn on an acyclic sugar. In SNFG an acyclic sugar carries its own marker, so
+	 * a free or reduced reducing end has nothing left to add beside it - but a label names what the
+	 * sample was tagged with. Suppressing every acyclic sugar suppressed every label with them, and
+	 * since every label reduces its sugar, that was all of them.
+	 */
+	@Test
+	public void aLabelIsDrawnOnAnAcyclicSugarAndAPlainAlditolIsNot() {
+		assertNotNull("2AB", reducingEndBox("2AB"));
+		assertNotNull("PA", reducingEndBox("PA"));
+		assertNotNull("a free reducing end", reducingEndBox("freeEnd"));
+
+		assertEquals("the alditol marker is the sugar's own", null, reducingEndBox("redEnd"));
+	}
+
+	/**
+	 * A structure built through the API rather than parsed has no bracket, and cloning one reached
+	 * through it regardless - which took {@code computeMass(String)} with it, since that clones
+	 * before it changes the isotope.
+	 */
+	@Test
+	public void aStructureBuiltRatherThanParsedCanBeCloned() {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		root.addChild(newGlc());
+
+		Glycan built = new Glycan(root, false, new MassOptions());
+
+		assertNotNull(built.clone());
+		assertTrue(built.computeMass(MassOptions.ISOTOPE_MONO) > 0);
+	}
+
+	private static Residue newGlc() {
+		try {
+			return ResidueDictionary.newResidue("Glc");
+		} catch (Exception noSuchResidue) {
+			throw new AssertionError(noSuchResidue);
+		}
+	}
+
+	/** A Glc on the given reducing end, reached by changing it rather than by naming it in the GWS. */
+	private static Glycan glcOn(String reducingEnd) {
+		Glycan structure = Glycan.fromString("freeEnd--?b1D-Glc,p$MONO,Und,0,0,freeEnd");
+		structure.setReducingEndType(ResidueDictionary.findResidueType(reducingEnd));
+
+		return structure;
+	}
+
+	private static String wurcsWithReducingEnd(String reducingEnd) {
+		return wurcsOf(glcOn(reducingEnd));
+	}
+
+	private static double massWithReducingEnd(String reducingEnd) {
+		return glcOn(reducingEnd).computeMass();
+	}
+
+	/** What the structure writes after its ring letter has been set and it has been through GWS. */
+	private static String afterGwsRoundTrip(char form) {
+		Glycan structure = Glycan.fromString("freeEnd--?b1D-Glc,p$MONO,Und,0,0,freeEnd");
+		structure.getRoot().getChildAt(0).setRingSize(form);
+
+		Glycan readBack = Glycan.fromString(structure.toString());
+		assertNotNull("GWS could not be read back for form " + form, readBack);
+
+		return wurcsOf(readBack);
+	}
+
+	/** The box the layout gives the reducing end, or null when it draws none. */
+	private static java.awt.Rectangle reducingEndBox(String reducingEnd) {
+		Glycan structure = glcOn(reducingEnd);
+		BBoxManager boxes = new BBoxManager();
+		workspace.getGlycanRenderer().computeBoundingBoxes(
+				Collections.singletonList(structure), false, true, new PositionManager(), boxes);
+
+		return boxes.getComplete(structure.getRoot(true));
+	}
+
+	private static String wurcsOf(Glycan structure) {
+		try {
+			GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+			document.setStructures(List.of(structure));
+
+			return document.toString("wurcs2").trim();
+		} catch (Exception cannotBeWritten) {
+			throw new AssertionError(cannotBeWritten);
+		}
+	}
+}


### PR DESCRIPTION
Release of **1.30.0**. `develop` is versioned and its changelog written, which is the last thing that happens before this merge.

## What is in it

**A labelled reducing end now writes as itself.** PA, 2AB, AA and the other eight are reductive aminations - each adds its own mass less the water of the condensation plus the 2H of the reduction, which is what the masses say - so each leaves its sugar acyclic. Only the alditol marker was recorded as doing so, and the consequence was that a 2AB glycan weighed 120 Da more than a free one and produced the same WURCS. Two structures, one string, one accession.

**The ring form and the flags that carry it say one thing.** It is `Residue.alditol` and `Residue.aldehyde` that the exporters read, not the ring letter, and setting the letter left them behind - so every caller had to remember them and the GWS parser did not. A saved alditol came back a ring, and undo, which goes through GWS, quietly un-reduced whatever it touched.

**GWS can store the open chain.** Its ring codes were `?opf`, so a structure drawn as an open chain could be saved and then not opened.

**A labelled reducing end is drawn on an acyclic sugar.** An acyclic sugar suppressed the reducing-end symbol whatever it was - harmless while no label made its sugar acyclic, and once they correctly did, it hid every label. A plain alditol still draws none, because the sugar's own marker says it.

**Two found on the way.** `Ctrl+Left` navigated down, which it has done since the first commit in 2017. And a structure built through the API rather than parsed could not be cloned - it has no bracket and the clone reached through it regardless, taking `computeMass(String)` with it.

Closes #124, #126, #128, and the clone half of #127.

## Why a minor

A labelled reducing end writes a different WURCS than it did, so an existing drawing produces a different string - the same reason 1.29.0 was a minor for `Lyx`. `Residue.setRingSize` gains a documented effect on the two flags, and GWS accepts a ring code it did not. Nothing is removed from the API.

## Checked

54 tests, up from 48, and `mvn -P make-fat-jar package` builds `glycanbuilder2-1.30.0.jar` and the fat jar.

Every residue this builder holds was exported before and after and compared - 121 residues, 82 written, byte for byte identical. These fixes reach reducing ends and acyclic forms and nothing else.

The drawing was checked as an image rather than only as a layout: the five reducing ends render with 2AB, PA and DH labelled, the plain alditol carrying only the sugar's own marker, and the free one unchanged. The navigation fix was checked in the compiled class, where the four directions now call four different methods.

## After this merges

Tag this merge commit `v1.30.0`, then `mvn deploy` locally and run the installer workflow against that tag.
