### PR TITLE
Release the tag the run was given

### DIFF
--- a/.github/workflows/jpackage_installer_linux.yml
+++ b/.github/workflows/jpackage_installer_linux.yml
@@ -7,6 +7,11 @@ on:
   #pull_request:
   #  branches: [ main ]
   workflow_call:
+    inputs:
+      ref:
+        description: 'Tag, branch or commit to build. Defaults to the branch the run was started on.'
+        required: false
+        type: string
 
 env:
   JAVA_VERSION: '21'
@@ -22,6 +27,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # The release names a tag, so the installer has to be built from that tag rather than from
+        # whatever the branch has reached since. Empty falls back to the default ref, which is what
+        # this did before.
+        ref: ${{ inputs.ref }}
         fetch-depth: 0
 
     - name: Set up JDK ${{ env.JAVA_VERSION }}

--- a/.github/workflows/jpackage_installer_macos.yml
+++ b/.github/workflows/jpackage_installer_macos.yml
@@ -7,6 +7,11 @@ on:
   #pull_request:
   #  branches: [ main ]
   workflow_call:
+    inputs:
+      ref:
+        description: 'Tag, branch or commit to build. Defaults to the branch the run was started on.'
+        required: false
+        type: string
 
 env:
   JAVA_VERSION: '21'
@@ -29,6 +34,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # The release names a tag, so the installer has to be built from that tag rather than from
+        # whatever the branch has reached since. Empty falls back to the default ref, which is what
+        # this did before.
+        ref: ${{ inputs.ref }}
         fetch-depth: 0
 
     - name: Set up JDK ${{ env.JAVA_VERSION }}

--- a/.github/workflows/jpackage_installer_rpm.yml
+++ b/.github/workflows/jpackage_installer_rpm.yml
@@ -7,6 +7,11 @@ on:
   #pull_request:
   #  branches: [ main ]
   workflow_call:
+    inputs:
+      ref:
+        description: 'Tag, branch or commit to build. Defaults to the branch the run was started on.'
+        required: false
+        type: string
 
 env:
   JAVA_VERSION: '21'
@@ -33,6 +38,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # The release names a tag, so the installer has to be built from that tag rather than from
+        # whatever the branch has reached since. Empty falls back to the default ref, which is what
+        # this did before.
+        ref: ${{ inputs.ref }}
         fetch-depth: 0
 
     - name: Install deps

--- a/.github/workflows/jpackage_installer_windows.yml
+++ b/.github/workflows/jpackage_installer_windows.yml
@@ -7,6 +7,11 @@ on:
   #pull_request:
   #  branches: [ main ]
   workflow_call:
+    inputs:
+      ref:
+        description: 'Tag, branch or commit to build. Defaults to the branch the run was started on.'
+        required: false
+        type: string
 
 env:
   JAVA_VERSION: '21'
@@ -22,6 +27,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        # The release names a tag, so the installer has to be built from that tag rather than from
+        # whatever the branch has reached since. Empty falls back to the default ref, which is what
+        # this did before.
+        ref: ${{ inputs.ref }}
         fetch-depth: 0
 
     - name: Set up JDK ${{ env.JAVA_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ on:
   #pull_request:
   #  branches: [ main ]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to release, e.g. v1.30.0. Must already exist.'
+        required: true
+        type: string
 
 env:
   GH_TOKEN: ${{ github.token }}
@@ -14,16 +19,24 @@ env:
 jobs:
   build-installer-linux:
     uses: ./.github/workflows/jpackage_installer_linux.yml
+    with:
+      ref: ${{ inputs.tag }}
 
   build-installer-macos:
     uses: ./.github/workflows/jpackage_installer_macos.yml
+    with:
+      ref: ${{ inputs.tag }}
     secrets: inherit
 
   build-installer-windows:
     uses: ./.github/workflows/jpackage_installer_windows.yml
+    with:
+      ref: ${{ inputs.tag }}
 
   build-installer-rpm:
     uses: ./.github/workflows/jpackage_installer_rpm.yml
+    with:
+      ref: ${{ inputs.tag }}
 
   release:
     needs: [build-installer-linux, build-installer-macos, build-installer-windows, build-installer-rpm]
@@ -44,7 +57,10 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Release ${{ github.ref_name }}
+          # Started from the Actions tab, github.ref is the branch and not a tag, so the action has
+          # no tag to infer and stops with "GitHub Releases requires a tag". The tag is named here.
+          tag_name: ${{ inputs.tag }}
+          name: Release ${{ inputs.tag }}
           draft: false
           prerelease: true
           generate_release_notes: true


### PR DESCRIPTION
The release job failed with `⚠️ GitHub Releases requires a tag`, while all four installers built.

`action-gh-release` takes the tag from `github.ref` when none is given. This workflow runs only from the Actions tab, where `github.ref` is the branch the run was started on - never a tag - so there was nothing to infer and the step stopped before creating anything.

The tag is now an input and is named outright:

```yaml
on:
  workflow_dispatch:
    inputs:
      tag:
        description: 'Version tag to release, e.g. v1.30.0. Must already exist.'
        required: true
        type: string
```

```yaml
      - name: Create Release
        uses: softprops/action-gh-release@v2
        with:
          tag_name: ${{ inputs.tag }}
          name: Release ${{ inputs.tag }}
```

## The tag also reaches the builds

The four installer workflows checked out the default ref, which is the branch tip. So a release named `v1.30.0` shipped installers built from wherever `master` happened to be - the same commit today, and not necessarily the next time, with nothing to say so. Each now takes a `ref` and checks it out:

```yaml
  workflow_call:
    inputs:
      ref:
        required: false
        type: string
```

```yaml
      uses: actions/checkout@v4
      with:
        ref: ${{ inputs.ref }}
        fetch-depth: 0
```

The input is optional and empty falls back to the default ref, so calling these without one behaves as before.

`prerelease: true` is left as it is: the procedure has the Release page switched to Latest by hand after the run.

## Checked

All five workflow files parse, and each of the four installers has the ref wired into its checkout. The run itself is the real check - the failing step is the last one, so a re-run against `v1.30.0` proves it end to end.
