### PR TITLE
Give the generic deoxy-HexNAc its missing oxygen

### DIFF
--- a/src/main/resources/conf/residue_types
+++ b/src/main/resources/conf/residue_types
@@ -84,7 +84,7 @@ GulNAc	HexNAc	Hex	C8H15N1O6	-	Gul$2NAc		1	D	p	yes	yes	no	0	5	no	4	no	4	3,4,5,6	-
 %BacNAc	HexNAc	Hex	C10H18N2O5	-	Bac$2NAc4NAc	1	D	p	yes	yes	no	0	4	no	2	no	3	1,3,5		-	no	no	yes	N-acetylbacillosamine
 %
 %DeoxyhexNAc
-dHexNAc	DeoxyhexNAc	Hex	C8H15N1O4	-	6-deoxy-Hex$2NAc	1	D	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	DeoxyhexNAc
+dHexNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	6-deoxy-Hex$2NAc	1	D	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	DeoxyhexNAc
 RhaNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	Rha$2NAc	1	L	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	N-acetylrhamnosamine
 QuiNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	Qui$2NAc	1	D	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	N-acetylquinovosamine
 FucNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	Fuc$2NAc	1	L	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	N-acetylfucosamine

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/DeoxyHexNAcMassTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/DeoxyHexNAcMassTest.java
@@ -1,0 +1,55 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.ResidueType;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * The mass of the generic deoxy-HexNAc, which was one oxygen short (#26).
+ *
+ * <p>A generic residue is the same sugar with the stereochemistry left unsaid, so it weighs exactly
+ * what its specific forms weigh: dHex weighs what Fuc weighs, and dHexNAc has to weigh what FucNAc,
+ * RhaNAc and QuiNAc weigh. It did not - the dictionary gave it C8H15NO4 where the deoxy form of
+ * HexNAc (C8H15NO6) is C8H15NO5 - so a structure drawn with the generic was quietly 15.9949 lighter
+ * than the same structure drawn with any specific residue it stands for.</p>
+ */
+public class DeoxyHexNAcMassTest {
+
+	/** One oxygen, which is what a deoxy takes away and what the generic was missing. */
+	private static final double OXYGEN = 15.9949;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The generic weighs what every one of its specific forms weighs. */
+	@Test
+	public void theGenericWeighsWhatItsSpecificFormsWeigh() throws Exception {
+		double generic = massOf("dHexNAc");
+
+		assertEquals("FucNAc", massOf("FucNAc"), generic, 0.0001);
+		assertEquals("RhaNAc", massOf("RhaNAc"), generic, 0.0001);
+		assertEquals("QuiNAc", massOf("QuiNAc"), generic, 0.0001);
+	}
+
+	/** And a deoxy takes away one oxygen from its parent, no more. */
+	@Test
+	public void aDeoxyTakesAwayOneOxygen() throws Exception {
+		assertEquals("dHexNAc is HexNAc less an oxygen",
+				massOf("HexNAc") - OXYGEN, massOf("dHexNAc"), 0.0001);
+		assertEquals("as dHex has always been Hex less an oxygen",
+				massOf("Hex") - OXYGEN, massOf("dHex"), 0.0001);
+	}
+
+	private static double massOf(String name) throws Exception {
+		ResidueType type = ResidueDictionary.getResidueType(name);
+
+		return type.getResidueMassMain();
+	}
+}


### PR DESCRIPTION
A generic residue weighs what its specific forms weigh — dHex weighs what Fuc weighs. dHexNAc did not: the dictionary gave it C8H15NO4 where the deoxy form of HexNAc (C8H15NO6) is C8H15NO5, so the generic came out at **189.1001** against FucNAc/RhaNAc/QuiNAc at **205.0950** — one oxygen, subtracted twice. A structure drawn with the generic was quietly 15.9949 lighter everywhere a mass is shown or exported.

One token in `conf/residue_types`, plus a test that holds the generic to its specific forms and the deoxy rule to one oxygen.

Fixes #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)