### PR TITLE
Read the alditol back from the reducing end's type

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
@@ -190,6 +190,22 @@ public class GWSParser implements GlycanParser {
 					false,mass_opt);        
 		}    
 
+		// The reducing end's type implies the sugar's form: redEnd and every reductive-amination
+		// label reduce their sugar, leaving it acyclic. A file saved since the ring letter began
+		// carrying that fact says ",o" and needs nothing here; one saved before 1.30.0 - or written
+		// by hand - says ",p", and reading it back turned the alditol into a ring again, quietly:
+		// the WURCS reverted from [h2122h] to a cyclic residue and the mass lost the reduction's
+		// two hydrogens (#133). This is setReducingEndType's own rule, applied on the way in.
+		Residue root = ret.getRoot();
+		if( root!=null && root.isReducingEnd() && !root.isCleavage()
+				&& root.getNoChildren()>0 && root.getType().makesAlditol() ) {
+			Residue sugar = root.getChildAt(0);
+			if( sugar.isSaccharide() && !sugar.isAlditol() ) {
+				sugar.setAnomericState('?');
+				sugar.setRingSize('o');
+			}
+		}
+
 		return ret;
 	}
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GwsAlditolRestoreTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GwsAlditolRestoreTest.java
@@ -1,0 +1,104 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a reduced structure stays reduced across a save and a reload (#133).
+ *
+ * <p>The reducing end's type implies the sugar's form: redEnd and every reductive-amination label
+ * reduce their sugar, leaving it acyclic. A file saved by 1.30.0 carries that as the ring letter
+ * {@code ,o} and read back correctly; a file saved by anything earlier - or written by hand - says
+ * {@code ,p}, and reading it back turned the alditol into a ring again: the WURCS reverted from
+ * {@code [h2122h]} to a cyclic residue, two hydrogens lighter, with nothing said. Every .gws file
+ * saved before 1.30.0 is in the second group.</p>
+ */
+public class GwsAlditolRestoreTest {
+
+	private static final String ALDITOL_WURCS = "WURCS=2.0/1,1,0/[h2122h]/1/";
+
+	private static BuilderWorkspace workspace;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		workspace = new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A pre-1.30.0 file - redEnd with the ring letter still "p" - reads back reduced. */
+	@Test
+	public void aLegacyRedEndFileReadsBackReduced() throws Exception {
+		Glycan reloaded = Glycan.fromString("redEnd--?b1D-Glc,p$MONO,Und,0,0,redEnd");
+
+		Residue sugar = reloaded.getRoot().getChildAt(0);
+		assertTrue("the sugar came back unreduced", sugar.isAlditol());
+		assertEquals('o', sugar.getRingSize());
+		assertEquals('?', sugar.getAnomericState());
+		assertEquals(ALDITOL_WURCS, wurcsOf(reloaded));
+	}
+
+	/** A label reduces its sugar the same way, so a legacy labelled file reads back reduced too. */
+	@Test
+	public void aLegacyLabelledFileReadsBackReduced() throws Exception {
+		Glycan reloaded = Glycan.fromString("2AB--?b1D-Glc,p$MONO,Und,0,0,2AB");
+
+		assertTrue(reloaded.getRoot().getChildAt(0).isAlditol());
+		assertEquals("the label is not carried by WURCS, but the reduction is",
+				ALDITOL_WURCS, wurcsOf(reloaded));
+	}
+
+	/** A free reducing end stays a ring - the repair only says what the root already says. */
+	@Test
+	public void aFreeEndFileStaysARing() throws Exception {
+		Glycan reloaded = Glycan.fromString("freeEnd--?b1D-Glc,p$MONO,Und,0,0,freeEnd");
+
+		assertFalse("a free sugar was reduced by loading it",
+				reloaded.getRoot().getChildAt(0).isAlditol());
+		assertEquals("WURCS=2.0/1,1,0/[a2122h-1b_1-5]/1/", wurcsOf(reloaded));
+	}
+
+	/** What the UI sets, a save and a reload keep - the round trip that was broken. */
+	@Test
+	public void settingSavingAndReloadingAgree() throws Exception {
+		Glycan edited = Glycan.fromString("freeEnd--?b1D-Glc,p$MONO,Und,0,0,freeEnd");
+		edited.setReducingEndType(ResidueDictionary.getResidueType("redEnd"));
+		String wurcsBefore = wurcsOf(edited);
+
+		Glycan reloaded = Glycan.fromString(edited.toString());
+
+		assertEquals(wurcsBefore, wurcsOf(reloaded));
+		assertEquals(ALDITOL_WURCS, wurcsBefore);
+	}
+
+	/** And a 1.30.0-style file, whose ring letter already says "o", is left exactly as it is. */
+	@Test
+	public void aFileThatAlreadySaysOIsLeftAlone() throws Exception {
+		Glycan reloaded = Glycan.fromString("redEnd--??1D-Glc,o$MONO,Und,0,0,redEnd");
+
+		assertTrue(reloaded.getRoot().getChildAt(0).isAlditol());
+		assertEquals(ALDITOL_WURCS, wurcsOf(reloaded));
+	}
+
+	/** A structure of nothing but the reducing end has no sugar to repair, and does not fall over. */
+	@Test
+	public void aBareReducingEndDoesNotFallOver() {
+		assertTrue(Glycan.fromString("redEnd$MONO,Und,0,0,redEnd") != null
+				|| Glycan.fromString("freeEnd$MONO,Und,0,0,freeEnd") != null);
+	}
+
+	private static String wurcsOf(Glycan structure) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+
+		return document.toString("wurcs2").strip();
+	}
+}


### PR DESCRIPTION
Since 1.30.0 the ring letter carries the reduction, so a file saved by 1.30.0 says `,o` and reads back correctly — but **every file saved before then says `,p`**, and reading one back turned the alditol into a ring again, quietly: the WURCS reverted from `[h2122h]` to `[a2122h-1b_1-5]`, two hydrogens lighter, with no warning.

`GWSParser.fromString` now applies `setReducingEndType`'s own rule on the way in: when the root's type `makesAlditol()` and the sugar is not already acyclic, the sugar gets the `?` anomeric state and the `o` ring the type implies. Files that already say `o`, free reducing ends, and structures with no sugar under the root are left untouched. Six tests cover the legacy spelling (redEnd and label), the 1.30.0 spelling, the free end, the UI round trip, and the bare root.

Fixes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)