### PR TITLE
Version 1.31.0 — alditol restored on GWS load, dHexNAc mass, GlycoCT substituent positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 ## Change log
+### 1.31.0  (20260809)
+* Read the alditol back from the reducing end's type when loading GWS
+  * Every .gws file saved before 1.30.0 records a reduced end with the ring letter still "p", and
+    loading one turned the alditol into a ring again: the WURCS reverted from h2122h to a cyclic
+    residue, two hydrogens lighter, with nothing said
+  * The rule is setReducingEndType's own, applied on the way in; files that already say "o", free
+    reducing ends and structures with no sugar under the root are left exactly as they are
+* Gave the generic deoxy-HexNAc its missing oxygen
+  * The dictionary said C8H15NO4 where the deoxy form of HexNAc is C8H15NO5, so the generic weighed
+    189.1001 against FucNAc, RhaNAc and QuiNAc at 205.0950 - one oxygen, subtracted twice
+  * A structure drawn with the generic was quietly 15.9949 lighter than the same structure drawn
+    with any specific residue it stands for
+* Attached a substituent's side of its bond at 1 in GlycoCT
+  * The exporter wrote whatever the bond recorded, which for the GAG templates was unknown, so
+    gagheparin exported lines like 1:1d(2+-1)2n and GlyTouCan's graphic search rejected the
+    structure: "for this substituent sulfate linkage pos must be 1"
+  * Substituents only, and only where the bond says unknown - a sugar's attachment really can be
+    unknown, and every core template is now held by test to export no "-1" substituent attachment
 ### 1.30.0  (20260808)
 * Wrote a labelled reducing end as itself, where every label wrote what a free reducing end wrote
   * PA, 2AB, AA and the other eight are reductive aminations, so each leaves its sugar acyclic -

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.30.0</version>
+	<version>1.31.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
@@ -190,6 +190,22 @@ public class GWSParser implements GlycanParser {
 					false,mass_opt);        
 		}    
 
+		// The reducing end's type implies the sugar's form: redEnd and every reductive-amination
+		// label reduce their sugar, leaving it acyclic. A file saved since the ring letter began
+		// carrying that fact says ",o" and needs nothing here; one saved before 1.30.0 - or written
+		// by hand - says ",p", and reading it back turned the alditol into a ring again, quietly:
+		// the WURCS reverted from [h2122h] to a cyclic residue and the mass lost the reduction's
+		// two hydrogens (#133). This is setReducingEndType's own rule, applied on the way in.
+		Residue root = ret.getRoot();
+		if( root!=null && root.isReducingEnd() && !root.isCleavage()
+				&& root.getNoChildren()>0 && root.getType().makesAlditol() ) {
+			Residue sugar = root.getChildAt(0);
+			if( sugar.isSaccharide() && !sugar.isAlditol() ) {
+				sugar.setAnomericState('?');
+				sugar.setRingSize('o');
+			}
+		}
+
 		return ret;
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
@@ -661,7 +661,16 @@ public class GlycoCTParser implements GlycanParser {
 			char[] p_poss = b.getParentPositions();
 			for (int i = 0; i < p_poss.length; i++)
 				nm_link.addParentLinkage(toIntPosition(p_poss[i]));
-			nm_link.addChildLinkage(toIntPosition(b.getChildPosition()));
+
+			// A substituent attaches through its one position, so its side of the bond is 1 by
+			// definition. The bond often records it as unknown, and writing that out as "-1"
+			// produces GlycoCT the validators reject - "for this substituent sulfate linkage pos
+			// must be 1" - which is how the GAG templates failed GlyTouCan's graphic search (#45).
+			int c_pos = toIntPosition(b.getChildPosition());
+			if (c_pos == -1 && link.getChildResidue() != null
+					&& link.getChildResidue().isSubstituent())
+				c_pos = 1;
+			nm_link.addChildLinkage(c_pos);
 
 			//Append linkage type added by e15d5605 20191223
 			nm_link.setParentLinkageType(link.getParentLinkageType());

--- a/src/main/resources/conf/residue_types
+++ b/src/main/resources/conf/residue_types
@@ -84,7 +84,7 @@ GulNAc	HexNAc	Hex	C8H15N1O6	-	Gul$2NAc		1	D	p	yes	yes	no	0	5	no	4	no	4	3,4,5,6	-
 %BacNAc	HexNAc	Hex	C10H18N2O5	-	Bac$2NAc4NAc	1	D	p	yes	yes	no	0	4	no	2	no	3	1,3,5		-	no	no	yes	N-acetylbacillosamine
 %
 %DeoxyhexNAc
-dHexNAc	DeoxyhexNAc	Hex	C8H15N1O4	-	6-deoxy-Hex$2NAc	1	D	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	DeoxyhexNAc
+dHexNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	6-deoxy-Hex$2NAc	1	D	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	DeoxyhexNAc
 RhaNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	Rha$2NAc	1	L	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	N-acetylrhamnosamine
 QuiNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	Qui$2NAc	1	D	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	N-acetylquinovosamine
 FucNAc	DeoxyhexNAc	Hex	C8H15N1O5	-	Fuc$2NAc	1	L	p	yes	yes	no	0	5	no	4	no	4	2,3,4,5,6	-	no	no	yes	N-acetylfucosamine

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/DeoxyHexNAcMassTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/DeoxyHexNAcMassTest.java
@@ -1,0 +1,55 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.ResidueType;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * The mass of the generic deoxy-HexNAc, which was one oxygen short (#26).
+ *
+ * <p>A generic residue is the same sugar with the stereochemistry left unsaid, so it weighs exactly
+ * what its specific forms weigh: dHex weighs what Fuc weighs, and dHexNAc has to weigh what FucNAc,
+ * RhaNAc and QuiNAc weigh. It did not - the dictionary gave it C8H15NO4 where the deoxy form of
+ * HexNAc (C8H15NO6) is C8H15NO5 - so a structure drawn with the generic was quietly 15.9949 lighter
+ * than the same structure drawn with any specific residue it stands for.</p>
+ */
+public class DeoxyHexNAcMassTest {
+
+	/** One oxygen, which is what a deoxy takes away and what the generic was missing. */
+	private static final double OXYGEN = 15.9949;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The generic weighs what every one of its specific forms weighs. */
+	@Test
+	public void theGenericWeighsWhatItsSpecificFormsWeigh() throws Exception {
+		double generic = massOf("dHexNAc");
+
+		assertEquals("FucNAc", massOf("FucNAc"), generic, 0.0001);
+		assertEquals("RhaNAc", massOf("RhaNAc"), generic, 0.0001);
+		assertEquals("QuiNAc", massOf("QuiNAc"), generic, 0.0001);
+	}
+
+	/** And a deoxy takes away one oxygen from its parent, no more. */
+	@Test
+	public void aDeoxyTakesAwayOneOxygen() throws Exception {
+		assertEquals("dHexNAc is HexNAc less an oxygen",
+				massOf("HexNAc") - OXYGEN, massOf("dHexNAc"), 0.0001);
+		assertEquals("as dHex has always been Hex less an oxygen",
+				massOf("Hex") - OXYGEN, massOf("dHex"), 0.0001);
+	}
+
+	private static double massOf(String name) throws Exception {
+		ResidueType type = ResidueDictionary.getResidueType(name);
+
+		return type.getResidueMassMain();
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCTSubstituentPositionTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCTSubstituentPositionTest.java
@@ -1,0 +1,103 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.dataset.CoreDictionary;
+import org.eurocarbdb.application.glycanbuilder.CoreType;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That GlycoCT gives a substituent's own side of its bond as position 1 (#45).
+ *
+ * <p>A substituent attaches through its one position, so its side of the bond is 1 by definition -
+ * and the validators insist: "for this substituent sulfate linkage pos must be 1". The exporter
+ * wrote whatever the bond recorded, which for the GAG templates was unknown, so gagheparin's
+ * GlycoCT carried lines like {@code 1:1d(2+-1)2n} and GlyTouCan's graphic search rejected the
+ * whole structure.</p>
+ */
+public class GlycoCTSubstituentPositionTest {
+
+	private static BuilderWorkspace workspace;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		workspace = new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * The GAG templates write no "-1" attachments - the case GlyTouCan rejected.
+	 *
+	 * <p>Every core the dictionary offers is held, not only heparin: a template that exports
+	 * invalid GlycoCT fails silently for whoever picks it from the menu.</p>
+	 */
+	@Test
+	public void everyCoreTemplateWritesValidSubstituentAttachments() throws Exception {
+		List<String> wrong = new ArrayList<String>();
+		int cores = 0;
+
+		for (CoreType core : CoreDictionary.getCores()) {
+			Glycan structure = Glycan.fromString(core.getStructure());
+			if (structure == null) continue;
+			cores++;
+
+			String glycoct = glycoctOf(structure);
+			for (String line : glycoct.split("\n")) {
+				if (line.contains("+-1)") && line.strip().endsWith("n")) {
+					wrong.add(core.getName() + ": " + line.strip());
+				}
+			}
+		}
+
+		assertEquals("substituents attached at -1: " + wrong, List.of(), wrong);
+		assertTrue("no cores were tested at all", cores > 10);
+	}
+
+	/** gagheparin in particular - the structure the report came in on - names its positions. */
+	@Test
+	public void gagheparinAttachesItsSulfatesAtOne() throws Exception {
+		CoreType heparin = CoreDictionary.getCoreType("gagheparin");
+		String glycoct = glycoctOf(Glycan.fromString(heparin.getStructure()));
+
+		assertTrue("no n-sulfate in the export at all", glycoct.contains("n-sulfate"));
+		assertTrue("still attaching at -1:\n" + glycoct, !glycoct.contains("+-1)"));
+	}
+
+	/** A substituent whose position was written down is left exactly as written. */
+	@Test
+	public void aKnownPositionIsLeftAsItIs() throws Exception {
+		String glycoct = glycoctOf(Glycan.fromString("freeEnd--?b1D-Glc,p--6b1S$MONO,Und,0,0,freeEnd"));
+
+		assertTrue(glycoct, glycoct.contains("(6+1)2n"));
+	}
+
+	/**
+	 * And an unknown position between two sugars stays unknown.
+	 *
+	 * <p>The repair is for substituents only: a sugar's attachment really can be unknown, and
+	 * writing 1 there would be inventing data.</p>
+	 */
+	@Test
+	public void anUnknownPositionBetweenSugarsStaysUnknown() throws Exception {
+		String glycoct = glycoctOf(
+				Glycan.fromString("freeEnd--?b1D-Glc,p--??1D-Gal,p$MONO,Und,0,0,freeEnd"));
+
+		assertTrue("a sugar-sugar unknown was invented away:\n" + glycoct,
+				glycoct.contains("(-1+1)"));
+	}
+
+	private static String glycoctOf(Glycan structure) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+
+		return document.toString("glycoct_condensed");
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GwsAlditolRestoreTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GwsAlditolRestoreTest.java
@@ -1,0 +1,104 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a reduced structure stays reduced across a save and a reload (#133).
+ *
+ * <p>The reducing end's type implies the sugar's form: redEnd and every reductive-amination label
+ * reduce their sugar, leaving it acyclic. A file saved by 1.30.0 carries that as the ring letter
+ * {@code ,o} and read back correctly; a file saved by anything earlier - or written by hand - says
+ * {@code ,p}, and reading it back turned the alditol into a ring again: the WURCS reverted from
+ * {@code [h2122h]} to a cyclic residue, two hydrogens lighter, with nothing said. Every .gws file
+ * saved before 1.30.0 is in the second group.</p>
+ */
+public class GwsAlditolRestoreTest {
+
+	private static final String ALDITOL_WURCS = "WURCS=2.0/1,1,0/[h2122h]/1/";
+
+	private static BuilderWorkspace workspace;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		workspace = new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A pre-1.30.0 file - redEnd with the ring letter still "p" - reads back reduced. */
+	@Test
+	public void aLegacyRedEndFileReadsBackReduced() throws Exception {
+		Glycan reloaded = Glycan.fromString("redEnd--?b1D-Glc,p$MONO,Und,0,0,redEnd");
+
+		Residue sugar = reloaded.getRoot().getChildAt(0);
+		assertTrue("the sugar came back unreduced", sugar.isAlditol());
+		assertEquals('o', sugar.getRingSize());
+		assertEquals('?', sugar.getAnomericState());
+		assertEquals(ALDITOL_WURCS, wurcsOf(reloaded));
+	}
+
+	/** A label reduces its sugar the same way, so a legacy labelled file reads back reduced too. */
+	@Test
+	public void aLegacyLabelledFileReadsBackReduced() throws Exception {
+		Glycan reloaded = Glycan.fromString("2AB--?b1D-Glc,p$MONO,Und,0,0,2AB");
+
+		assertTrue(reloaded.getRoot().getChildAt(0).isAlditol());
+		assertEquals("the label is not carried by WURCS, but the reduction is",
+				ALDITOL_WURCS, wurcsOf(reloaded));
+	}
+
+	/** A free reducing end stays a ring - the repair only says what the root already says. */
+	@Test
+	public void aFreeEndFileStaysARing() throws Exception {
+		Glycan reloaded = Glycan.fromString("freeEnd--?b1D-Glc,p$MONO,Und,0,0,freeEnd");
+
+		assertFalse("a free sugar was reduced by loading it",
+				reloaded.getRoot().getChildAt(0).isAlditol());
+		assertEquals("WURCS=2.0/1,1,0/[a2122h-1b_1-5]/1/", wurcsOf(reloaded));
+	}
+
+	/** What the UI sets, a save and a reload keep - the round trip that was broken. */
+	@Test
+	public void settingSavingAndReloadingAgree() throws Exception {
+		Glycan edited = Glycan.fromString("freeEnd--?b1D-Glc,p$MONO,Und,0,0,freeEnd");
+		edited.setReducingEndType(ResidueDictionary.getResidueType("redEnd"));
+		String wurcsBefore = wurcsOf(edited);
+
+		Glycan reloaded = Glycan.fromString(edited.toString());
+
+		assertEquals(wurcsBefore, wurcsOf(reloaded));
+		assertEquals(ALDITOL_WURCS, wurcsBefore);
+	}
+
+	/** And a 1.30.0-style file, whose ring letter already says "o", is left exactly as it is. */
+	@Test
+	public void aFileThatAlreadySaysOIsLeftAlone() throws Exception {
+		Glycan reloaded = Glycan.fromString("redEnd--??1D-Glc,o$MONO,Und,0,0,redEnd");
+
+		assertTrue(reloaded.getRoot().getChildAt(0).isAlditol());
+		assertEquals(ALDITOL_WURCS, wurcsOf(reloaded));
+	}
+
+	/** A structure of nothing but the reducing end has no sugar to repair, and does not fall over. */
+	@Test
+	public void aBareReducingEndDoesNotFallOver() {
+		assertTrue(Glycan.fromString("redEnd$MONO,Und,0,0,redEnd") != null
+				|| Glycan.fromString("freeEnd$MONO,Und,0,0,freeEnd") != null);
+	}
+
+	private static String wurcsOf(Glycan structure) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+
+		return document.toString("wurcs2").strip();
+	}
+}


### PR DESCRIPTION
Three bug fixes, no new features.

* **#133** — every `.gws` file saved before 1.30.0 records a reduced end with the ring letter still `p`, and loading one turned the alditol back into a ring: the WURCS reverted from `[h2122h]` to a cyclic residue, two hydrogens lighter, silently. `GWSParser.fromString` now applies `setReducingEndType`'s own rule on the way in.
* **#26** — the generic dHexNAc weighed 189.1001 against FucNAc/RhaNAc/QuiNAc at 205.0950: its dictionary composition said C8H15NO4 where the deoxy form of HexNAc is C8H15NO5. One oxygen, subtracted twice.
* **#45** — gagheparin's GlycoCT attached its sulfates at `-1`, which GlyTouCan's validator rejects ("for this substituent sulfate linkage pos must be 1"), so the GAG templates failed the graphic search. Substituent bonds with an unknown position now export their side as 1; written-down positions and sugar–sugar unknowns are untouched.

A minor rather than a patch, by 1.30.0's own rule: existing input produces a different string.

66 tests pass (54 → 66; each fix carries the test that would have caught it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)