### PR TITLE
Move FOP off CVE-2017-5661, with the batik family it was built against

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,55 @@
 		</plugins>
 	</build>
 
+	<!-- fop 2.2 (the first release past CVE-2017-5661) ships the batik 1.9 family, while the
+	     flamingo ribbon drags in batik-transcoder 1.7 - and a 1.7 transcoder in front of 1.9 jars
+	     fails at runtime with NoClassDefFoundError on the first PDF/PS/EPS export. One batik, the
+	     one fop was built against. TranscoderSmokeTest is what holds this true at runtime. -->
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-transcoder</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-swing</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-dom</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-svggen</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-util</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-xml</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-css</artifactId>
+				<version>1.9</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.xmlgraphics</groupId>
+				<artifactId>batik-gui-util</artifactId>
+				<version>1.9</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.glycoinfo</groupId>
@@ -163,7 +212,10 @@
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>fop</artifactId>
-			<version>2.0</version>
+			<!-- 2.2 is the first release past CVE-2017-5661 (XXE in the FO/area-tree readers).
+			     Kept at the minimum that clears the advisory rather than the newest, since this is
+			     a security revision and not an upgrade. -->
+			<version>2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>jdom</groupId>

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/TranscoderSmokeTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/TranscoderSmokeTest.java
@@ -1,0 +1,78 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That the PDF, PS and EPS exports actually produce their formats.
+ *
+ * <p>These are the only callers of Apache FOP, and none of them was exercised by any test - so a
+ * FOP upgrade could only be judged by whether the code still compiled. It is exercised here at
+ * runtime: a structure is transcoded and the output has to begin with the magic bytes of the format
+ * it claims to be. This is what let FOP move off 2.0, which carries CVE-2017-5661 (an XXE in its
+ * readers), with something more than compilation as evidence.</p>
+ */
+public class TranscoderSmokeTest {
+
+	private static BuilderWorkspace workspace;
+	private static Glycan chitobiose;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.setNotation("snfg");
+		chitobiose = Glycan.fromString("freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p$MONO,Und,0,0,freeEnd");
+	}
+
+	/** A PDF starts with %PDF, or it is not a PDF. */
+	@Test
+	public void thePdfExportIsAPdf() {
+		byte[] pdf = SVGUtils.getPDFGraphics(
+				workspace.getGlycanRenderer(), Collections.singleton(chitobiose));
+
+		assertTrue("nothing came out", pdf != null && pdf.length > 100);
+		assertTrue("does not start with %PDF", startsWith(pdf, "%PDF"));
+	}
+
+	/** PostScript announces itself with %!PS. */
+	@Test
+	public void thePsExportIsPostScript() {
+		byte[] ps = SVGUtils.getPSGraphics(
+				workspace.getGlycanRenderer(), Collections.singleton(chitobiose));
+
+		assertTrue("nothing came out", ps != null && ps.length > 100);
+		assertTrue("does not start with %!PS", startsWith(ps, "%!PS"));
+	}
+
+	/** And EPS is PostScript with the EPSF marker on its first line. */
+	@Test
+	public void theEpsExportIsEncapsulatedPostScript() {
+		byte[] eps = SVGUtils.getEPSGraphics(
+				workspace.getGlycanRenderer(), Collections.singleton(chitobiose));
+
+		assertTrue("nothing came out", eps != null && eps.length > 100);
+		assertTrue("does not start with %!PS", startsWith(eps, "%!PS"));
+		assertTrue("first line carries no EPSF marker",
+				new String(eps, 0, Math.min(80, eps.length), StandardCharsets.US_ASCII)
+						.contains("EPSF"));
+	}
+
+	private static boolean startsWith(byte[] bytes, String magic) {
+		byte[] expected = magic.getBytes(StandardCharsets.US_ASCII);
+		if (bytes.length < expected.length) return false;
+		for (int at = 0; at < expected.length; at++) {
+			if (bytes[at] != expected[at]) return false;
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
fop 2.0 carries **CVE-2017-5661** (high; XXE in its readers - dependabot alert 5). 2.2 is the first release past it, and this stays at that minimum: a security revision, not an upgrade.

The bump alone was **not** enough, and compiling did not say so: fop 2.2 ships the batik **1.9** family while the flamingo ribbon drags in batik-transcoder **1.7**, and a 1.7 transcoder in front of 1.9 jars fails at runtime with NoClassDefFoundError on the first PDF export. The batik family is pinned to 1.9 via dependencyManagement. (Dependabot's own PR #52 bumped fop alone and would have hit exactly this - it can be closed as superseded.)

None of the three FOP call sites (PDF/PS/EPS export) had ever run under a test, which is why this was invisible to the build. TranscoderSmokeTest now transcodes a structure to all three and checks the magic bytes, so the next dependency move is judged by more than compilation. 69 tests pass.

One residual manual check: the desktop SVG canvas widget uses batik-swing, now 1.9 - worth one interactive look before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
