### PR TITLE
Write bridges to GlycoCT as the typed substituents they are

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
@@ -244,6 +244,17 @@ public class GlycoCTParser implements GlycanParser {
 			// create repeat unit
 			nm_current = toSugarUnitRepeat(current, bboxManager);
 			parent = current.findEndRepetition();
+		} else if ("Bridge".equals(current.getType().getSuperclass())
+				&& glycoCTNameOfBridge(current.getTypeName()) != null) {
+			// A bridge is a substituent with two attachments. Sent through the namescheme
+			// converter it dies one way or another: decorated it becomes "?-P", which nothing can
+			// resolve, and bare it resolves to a substituent whose exchange table only describes
+			// the single-attachment form, so the second linkage throws. The node is therefore
+			// created already typed, in GlycoCT's own vocabulary, and the namespace visitor
+			// passes it through untouched (#27).
+			nm_current = new Substituent(
+					SubstituentType.forName(glycoCTNameOfBridge(current.getTypeName())));
+			parent = current;
 		} else {
 			// translate current residue
 			UnvalidatedGlycoNode toadd = new UnvalidatedGlycoNode();
@@ -527,7 +538,11 @@ public class GlycoCTParser implements GlycanParser {
 			char anomeric_carbon, char anomeric_state, char chirality,
 			char ring_size) {
 		String iupac_name = type.getIupacName();
-		if (type.isSaccharide()) {
+		// A bridge is dictionary-flagged as a saccharide, but its name must go to the namescheme
+		// converter bare, exactly like a simple substituent's: the saccharide decorations below
+		// turned P into "?-P", which nothing could resolve, and the whole export came back empty
+		// for any structure with a phosphate bridge in it (#27).
+		if (type.isSaccharide() && !"Bridge".equals(type.getSuperclass())) {
 			// add chirality
 			if (type.hasChirality())
 				iupac_name = chirality + "-" + iupac_name;
@@ -652,6 +667,55 @@ public class GlycoCTParser implements GlycanParser {
 		return null;
 	}
 
+	/**
+	 * The GlycoCT substituent name of a bridge, or null for one GlycoCT has no word for.
+	 *
+	 * <p>Every entry of the cross-linked dictionary, named in {@code SubstituentType}'s own
+	 * vocabulary. An unmapped bridge falls back to the old path and fails as it always did, rather
+	 * than exporting under a guessed name.</p>
+	 *
+	 * @param bridgeName The GlycanBuilder2 type name, e.g. "P".
+	 * @return Returns the GlycoCT name, e.g. "phosphate", or null.
+	 */
+	static String glycoCTNameOfBridge(String bridgeName) {
+		switch (bridgeName) {
+			case "N": return "amino";
+			case "Suc": return "succinate";
+			case "SH": return "thio";
+			case "S": return "sulfate";
+			case "P": return "phosphate";
+			case "PyrP": return "pyrophosphate";
+			case "Tri-P": return "triphosphate";
+			case "Py": return "pyruvate";
+			case "(S)Py": return "(s)-pyruvate";
+			case "(R)Py": return "(r)-pyruvate";
+			case "Anhydro": return "anhydro";
+			// NS, PEtn and PPEtn attach through two different atoms (N on one side, S or O on the
+			// other), and nothing here records which sugar got which side - so they keep the old
+			// failing path rather than exporting with a guessed linkage type.
+			default: return null;
+		}
+	}
+
+	/**
+	 * The linkage type of the sugar's side of a bridge's bond, from the atom the bridge attaches
+	 * through: oxygen keeps the sugar's OH ({@code o}), nitrogen and sulfur replace it ({@code d}).
+	 * Only bridges whose two attachments go through the same atom are mapped at all, so one answer
+	 * serves both edges.
+	 *
+	 * @param bridgeName The GlycanBuilder2 type name, e.g. "P".
+	 * @return Returns the sugar-side linkage type.
+	 */
+	static org.eurocarbdb.MolecularFramework.sugar.LinkageType sugarSideLinkageTypeOfBridge(String bridgeName) {
+		switch (bridgeName) {
+			case "N":
+			case "SH":
+				return org.eurocarbdb.MolecularFramework.sugar.LinkageType.DEOXY;
+			default:
+				return org.eurocarbdb.MolecularFramework.sugar.LinkageType.H_AT_OH;
+		}
+	}
+
 	private GlycoEdge toSugar(Linkage link) throws Exception {
 
 		GlycoEdge nm_edge = new GlycoEdge();
@@ -659,22 +723,50 @@ public class GlycoCTParser implements GlycanParser {
 			org.eurocarbdb.MolecularFramework.sugar.Linkage nm_link = new org.eurocarbdb.MolecularFramework.sugar.Linkage();
 
 			char[] p_poss = b.getParentPositions();
-			for (int i = 0; i < p_poss.length; i++)
-				nm_link.addParentLinkage(toIntPosition(p_poss[i]));
+			boolean parentIsAttachment = link.getParentResidue() != null
+					&& (link.getParentResidue().isSubstituent()
+							|| "Bridge".equals(link.getParentResidue().getType().getSuperclass()));
+			for (int i = 0; i < p_poss.length; i++) {
+				int p_pos = toIntPosition(p_poss[i]);
+				if (p_pos == -1 && parentIsAttachment) p_pos = 1;
+				nm_link.addParentLinkage(p_pos);
+			}
 
 			// A substituent attaches through its one position, so its side of the bond is 1 by
 			// definition. The bond often records it as unknown, and writing that out as "-1"
 			// produces GlycoCT the validators reject - "for this substituent sulfate linkage pos
 			// must be 1" - which is how the GAG templates failed GlyTouCan's graphic search (#45).
+			// A bridge is the same thing with two attachments, so both of its edges get the same
+			// repair: the child side of the edge into it, and the parent side of the edge out of
+			// it (#27).
 			int c_pos = toIntPosition(b.getChildPosition());
 			if (c_pos == -1 && link.getChildResidue() != null
-					&& link.getChildResidue().isSubstituent())
+					&& (link.getChildResidue().isSubstituent()
+							|| "Bridge".equals(link.getChildResidue().getType().getSuperclass())))
 				c_pos = 1;
 			nm_link.addChildLinkage(c_pos);
 
 			//Append linkage type added by e15d5605 20191223
 			nm_link.setParentLinkageType(link.getParentLinkageType());
 			nm_link.setChildLinkageType(link.getChildLinkageType());
+
+			// A bridge's edges carry no usable linkage types - the model leaves them unvalidated
+			// (#4), and unlike a simple substituent nothing downstream repairs them, because the
+			// typed node skips the namescheme converter. Said here instead: the substituent's own
+			// side is a non-monosaccharide attachment, and the sugar's side follows the atom the
+			// bridge attaches through (#27).
+			Residue childResidue = link.getChildResidue();
+			if (childResidue != null && "Bridge".equals(childResidue.getType().getSuperclass())
+					&& glycoCTNameOfBridge(childResidue.getTypeName()) != null) {
+				nm_link.setParentLinkageType(sugarSideLinkageTypeOfBridge(childResidue.getTypeName()));
+				nm_link.setChildLinkageType(org.eurocarbdb.MolecularFramework.sugar.LinkageType.NONMONOSACCHARID);
+			}
+			Residue parentResidue = link.getParentResidue();
+			if (parentResidue != null && "Bridge".equals(parentResidue.getType().getSuperclass())
+					&& glycoCTNameOfBridge(parentResidue.getTypeName()) != null) {
+				nm_link.setParentLinkageType(org.eurocarbdb.MolecularFramework.sugar.LinkageType.NONMONOSACCHARID);
+				nm_link.setChildLinkageType(sugarSideLinkageTypeOfBridge(parentResidue.getTypeName()));
+			}
 
 			nm_edge.addGlycosidicLinkage(nm_link);
 		}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCTBridgeExportTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCTBridgeExportTest.java
@@ -1,0 +1,102 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a structure with a bridge exports to GlycoCT at all, and correctly (#27).
+ *
+ * <p>Any structure with a phosphate bridge exported to an empty string. The bridge residue went to
+ * the namescheme converter decorated like a sugar - "?-P", which nothing could resolve - and
+ * undecorated it resolved to a substituent whose exchange table only knows the single-attachment
+ * form. The exporter now creates bridges as typed substituent nodes in GlycoCT's own vocabulary,
+ * with both attachments at position 1 and the sugar's side of each bond typed by the atom the
+ * bridge attaches through: oxygen keeps the sugar's OH ({@code o}), nitrogen and sulfur replace it
+ * ({@code d}).</p>
+ */
+public class GlycoCTBridgeExportTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The reported case: a phosphodiester bridge exports as the phosphate substituent. */
+	@Test
+	public void aPhosphateBridgeExportsAsPhosphate() throws Exception {
+		String glycoct = glycoctOfWurcs(
+				"WURCS=2.0/2,2,1/[a2122h-1b_1-5][a2112h-1b_1-5]/1-2/a6-b1*OPO*/3O/3=O");
+
+		assertTrue(glycoct, glycoct.contains("s:phosphate"));
+		assertTrue("the edge into it is not o(6+1)n:\n" + glycoct, glycoct.contains("1o(6+1)2n"));
+		assertTrue("the edge out of it is not n(1+1)o:\n" + glycoct, glycoct.contains("2n(1+1)3o"));
+	}
+
+	/** Every mapped bridge exports non-empty GlycoCT that its own reader accepts back. */
+	@Test
+	public void everyMappedBridgeExportsAndReadsBack() throws Exception {
+		for (String bridge : new String[] {"P", "S", "SH", "N", "Suc", "PyrP"}) {
+			String glycoct = glycoctOfGws(
+					"freeEnd--?b1D-Glc,p--6?1" + bridge + "--1b1D-Gal,p$MONO,Und,0,0,freeEnd");
+
+			assertTrue(bridge + " exported nothing", !glycoct.isBlank());
+			assertTrue(bridge + " still attaches at -1:\n" + glycoct, !glycoct.contains("+-1)"));
+
+			GlycanDocument reader = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+			assertTrue(bridge + "'s own GlycoCT cannot be read back:\n" + glycoct,
+					reader.importFromString(glycoct, "glycoct_condensed"));
+		}
+	}
+
+	/**
+	 * The sugar's side of the bond follows the atom the bridge attaches through.
+	 *
+	 * <p>An oxygen bridge leaves the sugar's OH in place ({@code o}); an amino or thio bridge
+	 * replaces it ({@code d}). Writing {@code o} for an amino bridge would claim an oxygen that is
+	 * not there.</p>
+	 */
+	@Test
+	public void theSugarsSideFollowsTheAttachingAtom() throws Exception {
+		String oxygen = glycoctOfGws("freeEnd--?b1D-Glc,p--6?1P--1b1D-Gal,p$MONO,Und,0,0,freeEnd");
+		String nitrogen = glycoctOfGws("freeEnd--?b1D-Glc,p--6?1N--1b1D-Gal,p$MONO,Und,0,0,freeEnd");
+
+		assertTrue("phosphate is not O-attached:\n" + oxygen, oxygen.contains("1o(6+1)2n"));
+		assertTrue("amino is not N-attached:\n" + nitrogen, nitrogen.contains("1d(6+1)2n"));
+	}
+
+	/**
+	 * A bridge whose two attachments go through different atoms is refused, not guessed.
+	 *
+	 * <p>NS attaches through nitrogen on one side and sulfur-oxygen on the other, and nothing in
+	 * the model records which sugar got which - so it keeps the old failing path (an empty export)
+	 * rather than exporting with an invented linkage type.</p>
+	 */
+	@Test
+	public void anAsymmetricBridgeIsStillRefused() throws Exception {
+		assertEquals("", glycoctOfGws(
+				"freeEnd--?b1D-Glc,p--6?1NS--1b1D-Gal,p$MONO,Und,0,0,freeEnd").strip());
+	}
+
+	private static String glycoctOfWurcs(String wurcs) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS itself would not import", document.importFromString(wurcs, "wurcs2"));
+
+		return document.toString("glycoct_condensed");
+	}
+
+	private static String glycoctOfGws(String gws) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		Glycan structure = Glycan.fromString(gws);
+		assertTrue("the GWS itself would not parse", structure != null);
+		document.addStructure(structure);
+
+		return document.toString("glycoct_condensed");
+	}
+}


### PR DESCRIPTION
Any structure with a phosphate bridge exported to an **empty string**. Diagnosis in [#27's thread](https://github.com/glycoinfo/GlycanBuilder2/issues/27#issuecomment-5227858447); three layers, each found by running into the next:

1. **The node** — a bridge now exports as a typed `Substituent` in GlycoCT's own vocabulary (`P → phosphate`, `S → sulfate`, …) instead of going through the namescheme converter, which mangled it to `?-P` and, un-mangled, only knows the single-attachment form.
2. **The positions** — both bridge edges get #45's repair: attachments are 1, not -1.
3. **The types** — bridge edges are unvalidated in the model (#4), so the exporter states them: substituent side `n`, sugar side by the attaching atom (`o` for oxygen bridges, `d` for amino/thio).

Result for the reported case: `1:1o(6+1)2n` / `2:2n(1+1)3o` around `2s:phosphate`, and every mapped bridge (P, S, SH, N, Suc, PyrP) **round-trips through GB2's own GlycoCT reader**. NS/PEtn/PPEtn attach through two *different* atoms and nothing records which sugar got which side — they keep the old failing path rather than exporting a guessed linkage type.

70 tests pass. Fixes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
