### PR TITLE
Refuse a cyclic structure graph with a sentence, not a StackOverflowError

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
@@ -250,6 +250,19 @@ public class GWSParser implements GlycanParser {
 	}
 
 	static public String writeSubtree(Residue r, boolean ordered, BBoxManager bboxManager ) {
+		return writeSubtree(r, ordered, bboxManager,
+				java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<Residue, Boolean>()));
+	}
+
+	static private String writeSubtree(Residue r, boolean ordered, BBoxManager bboxManager,
+			java.util.Set<Residue> visited) {
+		// The walk below assumes a tree. Hand it a cyclic graph - which a faulty import can build -
+		// and it used to descend forever, dying as a StackOverflowError far from the cause (#125).
+		// GWS has no spelling for a residue that is its own ancestor, so this says so instead.
+		if (!visited.add(r))
+			throw new IllegalArgumentException("the structure contains a cycle"
+					+ " (a residue reachable from itself), which GWS cannot write");
+
 		//------------
 		// write typ
 		String str = writeResidueType(r);    
@@ -275,7 +288,8 @@ public class GWSParser implements GlycanParser {
 
 		ArrayList<String> str_children = new ArrayList();
 		for( Linkage l : r.getChildrenLinkages() )
-			str_children.add(writeSubtree(l,ordered, bboxManager));
+			str_children.add("--" + toStringLinkage(l)
+					+ writeSubtree(l.getChildResidue(), ordered, bboxManager, visited));
 
 		if( ordered ) 
 			Collections.sort(str_children);    

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
@@ -1,6 +1,7 @@
 package org.glycoinfo.application.glycanbuilder.converterWURCS2;
 
 import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
 import org.eurocarbdb.application.glycanbuilder.converter.GlycanParser;
 import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
 import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
@@ -52,7 +53,35 @@ public class WURCS2Parser implements GlycanParser{
 
 		WURCSSequence2ToGlycan seq22glycan = new WURCSSequence2ToGlycan();
 		seq22glycan.start(new WURCSFactory(graph), mass_opt);
-		return seq22glycan.getGlycan();
+		Glycan glycan = seq22glycan.getGlycan();
+
+		// A WURCS with two connections between the same pair of residues - a bridge plus a direct
+		// bond, as in G11127BT - comes out of the conversion as a genuine cycle in what every
+		// walker downstream assumes is a tree. The first of them to touch it then descends
+		// forever, and the report is a StackOverflowError far from the cause (#125). Refusing here
+		// with a sentence keeps the document untouched and gives the caller something it can
+		// actually catch; drawing such structures needs a representation for the second
+		// connection, which is its own piece of work.
+		refuseCycles(glycan.getRoot(), java.util.Collections.newSetFromMap(
+				new java.util.IdentityHashMap<Residue, Boolean>()));
+
+		return glycan;
+	}
+
+	/**
+	 * Walks the residue tree and throws where it finds itself again.
+	 * @param residue Residue to walk from.
+	 * @param visited Every residue already walked, by identity.
+	 * @throws Exception If the tree has a cycle in it.
+	 */
+	private static void refuseCycles(Residue residue, java.util.Set<Residue> visited) throws Exception {
+		if (residue == null) return;
+		if (!visited.add(residue))
+			throw new Exception("this WURCS makes two connections between the same residues"
+					+ " (a ring through a bridge), which cannot be represented yet");
+
+		for (org.eurocarbdb.application.glycanbuilder.linkage.Linkage linkage : residue.getChildrenLinkages())
+			refuseCycles(linkage.getChildResidue(), visited);
 	}
 
 	/**

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CyclicGraphRefusalTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CyclicGraphRefusalTest.java
@@ -1,0 +1,100 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.converterGWS.GWSParser;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a structure graph with a cycle in it is refused with a sentence, not a StackOverflowError
+ * (#125).
+ *
+ * <p>A WURCS with two connections between the same pair of residues - a bridge plus a direct bond,
+ * as in G11127BT - came out of the importer as a genuine cycle in what every walker downstream
+ * assumes is a tree. The first walker to touch it descended forever, and the report was a
+ * StackOverflowError far from the cause, which nothing can usefully catch. The importer now walks
+ * what it built and refuses a cycle before the document sees it, and the GWS writer carries its own
+ * guard for any cyclic graph that arrives another way.</p>
+ */
+public class CyclicGraphRefusalTest {
+
+	/** The two-connection WURCS from #125, minus the repeat that hides it. */
+	private static final String TWO_CONNECTIONS =
+			"WURCS=2.0/2,2,2/[u2122h][a2211m-1x_1-5]/1-2/a3-b2*OCCCCO*/6=O/3=O_a?-b1";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The cyclic WURCS is refused cleanly, and the document is left exactly as it was. */
+	@Test
+	public void theCyclicWurcsIsRefusedAndTheDocumentUntouched() {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		boolean imported;
+		try {
+			imported = document.importFromString(TWO_CONNECTIONS, "wurcs2");
+		} catch (Exception refused) {
+			imported = false;
+		}
+
+		assertFalse("the cycle was imported", imported);
+		assertEquals("something was left in the document", 0, document.getStructures().size());
+	}
+
+	/** The GWS writer refuses a cyclic graph with a sentence rather than dying in it. */
+	@Test
+	public void theGwsWriterRefusesACycleWithASentence() throws Exception {
+		Residue one = ResidueDictionary.newResidue("Glc");
+		Residue other = ResidueDictionary.newResidue("Gal");
+		one.addChild(other, '4');
+		other.addChild(one, '6');
+
+		try {
+			GWSParser.writeSubtree(one, false);
+			fail("a cyclic graph was written");
+		} catch (IllegalArgumentException refused) {
+			assertTrue(refused.getMessage(), refused.getMessage().contains("cycle"));
+		}
+	}
+
+	/** A bridge with one connection is not a cycle, and still imports and writes. */
+	@Test
+	public void aSingleConnectionBridgeStillGoesThrough() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		assertTrue(document.importFromString(
+				"WURCS=2.0/2,2,1/[a2122h-1b_1-5][a2112h-1b_1-5]/1-2/a6-b1*OPO*/3O/3=O", "wurcs2"));
+		assertTrue("its GWS came out empty", !document.toString("GWS").isBlank());
+	}
+
+	/** A repeat closes its ring through markers, not a raw cycle, and still imports and writes. */
+	@Test
+	public void aRepeatStillGoesThrough() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		assertTrue(document.importFromString(
+				"WURCS=2.0/2,3,3/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5]/1-1-2/a4-b1_b4-c1_c4-c?~n",
+				"wurcs2"));
+		assertTrue(!document.toString("GWS").isBlank());
+	}
+
+	/** And an ordinary chain is untouched by either guard. */
+	@Test
+	public void anOrdinaryChainIsUntouched() throws Exception {
+		Glycan chain = Glycan.fromString("freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p$MONO,Und,0,0,freeEnd");
+
+		assertTrue(chain.toString().contains("GlcNAc"));
+	}
+}


### PR DESCRIPTION
The G11127BT family — two connections between the same pair of residues (a bridge plus a direct bond) — came out of the WURCS importer as a genuine **cycle** in what every walker downstream assumes is a tree. `GWSParser.writeSubtree`, whose serialization runs on every document change, descended forever; the report was a StackOverflowError far from the cause, which nothing can usefully catch.

Two guards, one at each end:
* the **importer** walks the tree it just built and refuses a cycle before the document sees it — `importFromString` returns false, document untouched;
* the **GWS writer** carries its own visited check for any cyclic graph arriving another way, and refuses with a sentence naming the problem.

Non-regression pinned: a single-connection bridge and a `~n` repeat (which closes its ring through markers, not a raw cycle) both still import and write.

This is the crash half of #125; drawing such structures needs a representation for the second connection, which stays open there. 75 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
