### PR TITLE
Fail in WURCS terms, not in Java's

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -134,7 +134,7 @@ public abstract class BaseDocument {
 			return FileUtils.themeManager.getImageIcon("basedoc",ICON_SIZE.L2);
 		} catch (IOException e) {
 			// TODO Auto-generated catch block
-			e.printStackTrace();
+			LogUtils.report(e);
 		}
 		return null;
     }

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -2049,7 +2049,7 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 			return new GlycoCTParser(false).fromGlycoCT(str,new MassOptions());
 		}
 		catch(Exception e) {
-			e.printStackTrace();
+			LogUtils.report(e);
 			LogUtils.report(e);
 			return null;
 		}
@@ -2080,7 +2080,7 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 			return new GlycoCTCondensedParser(false).fromGlycoCTCondensed(str,new MassOptions());
 		}
 		catch(Exception e) {
-			e.printStackTrace();
+			LogUtils.report(e);
 			LogUtils.report(e);
 			return null;
 		}
@@ -2099,7 +2099,7 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 			return new GlycoCTCondensedParser(tolerate_unknown).fromGlycoCTCondensed(str,new MassOptions());
 		}
 		catch(Exception e) {
-			e.printStackTrace();
+			LogUtils.report(e);
 			LogUtils.report(e);
 			return null;
 		}

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -20,6 +20,7 @@
 
 package org.eurocarbdb.application.glycanbuilder;
 
+import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
 import java.util.*;
 import java.awt.*;
 
@@ -1357,7 +1358,7 @@ public class Residue {
 				link.setParentLinkageType(child.getParentLinkage().getParentLinkageType());
 				link.setChildLinkageType(child.getParentLinkage().getChildLinkageType());
 			} catch (Exception e) {
-				e.printStackTrace();
+				LogUtils.report(e);
 			}
 		}
 		

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/MassUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/MassUtils.java
@@ -112,7 +112,7 @@ public class MassUtils {
 			
 			h2po4_ion = new Molecule("H2PO4-");
 		} catch (Exception e) {
-			e.printStackTrace();
+			LogUtils.report(e);
 			System.exit(-1);
 		}
 	}

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/LinkageTypeOptimizer.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/LinkageTypeOptimizer.java
@@ -1,5 +1,6 @@
 package org.glycoinfo.application.glycanbuilder.converterWURCS2;
 
+import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
 import org.eurocarbdb.MolecularFramework.sugar.LinkageType;
 import org.eurocarbdb.application.glycanbuilder.Glycan;
 import org.eurocarbdb.application.glycanbuilder.Residue;
@@ -21,7 +22,7 @@ public class LinkageTypeOptimizer {
                     acceptorLinkage.setParentLinkageType(lTypeOnChild);
                     acceptorLinkage.setChildLinkageType(LinkageType.NONMONOSACCHARID);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    LogUtils.report(e);
                 }
             }
 
@@ -40,7 +41,7 @@ public class LinkageTypeOptimizer {
                         acceptorLinkage.setParentLinkageType(LinkageType.H_AT_OH);
                         acceptorLinkage.setChildLinkageType(LinkageType.H_AT_OH);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        LogUtils.report(e);
                     }
                 }
 
@@ -50,7 +51,7 @@ public class LinkageTypeOptimizer {
                         acceptorLinkage.setParentLinkageType(LinkageType.H_AT_OH);
                         acceptorLinkage.setChildLinkageType(LinkageType.H_AT_OH);
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        LogUtils.report(e);
                     }
                 }
 

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
@@ -2,6 +2,7 @@ package org.glycoinfo.application.glycanbuilder.converterWURCS2;
 
 import org.eurocarbdb.application.glycanbuilder.Glycan;
 import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.glycoinfo.application.glycanbuilder.util.exchange.WURCSToGlycanException;
 import org.eurocarbdb.application.glycanbuilder.converter.GlycanParser;
 import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
 import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
@@ -51,9 +52,23 @@ public class WURCS2Parser implements GlycanParser{
 		// whatever spelling the MAPs arrived in, hand the conversion the one it recognises
 		this.rewriteMAPs(graph, false);
 
-		WURCSSequence2ToGlycan seq22glycan = new WURCSSequence2ToGlycan();
-		seq22glycan.start(new WURCSFactory(graph), mass_opt);
-		Glycan glycan = seq22glycan.getGlycan();
+		Glycan glycan;
+		try {
+			WURCSSequence2ToGlycan seq22glycan = new WURCSSequence2ToGlycan();
+			seq22glycan.start(new WURCSFactory(graph), mass_opt);
+			glycan = seq22glycan.getGlycan();
+		} catch (RuntimeException undescribed) {
+			// The conversion's own failures come out as raw NullPointerExceptions and
+			// StringIndexOutOfBounds - "String index out of range: 8" for a substituent placed at
+			// position 9 of a hexose, say - which name nothing and read as crashes rather than as
+			// answers (#123). This is the one door every WURCS enters through, so the translation
+			// happens here: what kind of failure, on which sequence, with the original underneath
+			// for whoever needs the trace.
+			throw new WURCSToGlycanException("could not convert this WURCS to a structure ("
+					+ undescribed.getClass().getSimpleName()
+					+ (undescribed.getMessage() != null ? ": " + undescribed.getMessage() : "")
+					+ "): " + shortenedForError(str), undescribed);
+		}
 
 		// A WURCS with two connections between the same pair of residues - a bridge plus a direct
 		// bond, as in G11127BT - comes out of the conversion as a genuine cycle in what every
@@ -66,6 +81,17 @@ public class WURCS2Parser implements GlycanParser{
 				new java.util.IdentityHashMap<Residue, Boolean>()));
 
 		return glycan;
+	}
+
+	/**
+	 * The sequence, cut to fit an error message.
+	 * @param sequence The WURCS being read.
+	 * @return Returns at most eighty characters of it.
+	 */
+	private static String shortenedForError(String sequence) {
+		String flat = sequence.strip();
+
+		return flat.length() > 80 ? flat.substring(0, 80) + "..." : flat;
 	}
 
 	/**

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/canvas/CompositionUtility.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/canvas/CompositionUtility.java
@@ -1,5 +1,6 @@
 package org.glycoinfo.application.glycanbuilder.util.canvas;
 
+import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
 import java.util.LinkedList;
 
 import javax.swing.JOptionPane;
@@ -86,7 +87,7 @@ public class CompositionUtility {
 				if(a_sSuperClass.equals("Substituent")) a_aResidues.add(a_oRES);
 			} catch (Exception e) {
 				// TODO 自動生成された catch ブロック
-				e.printStackTrace();
+				LogUtils.report(e);
 			}
 		}
 			

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/WURCSToGlycanException.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/WURCSToGlycanException.java
@@ -9,6 +9,10 @@ public class WURCSToGlycanException extends WURCSException{
 	 */
 	private static final long serialVersionUID = 1L;
 
+	public WURCSToGlycanException(String a_strMessage, Throwable a_oCause) {
+		super(a_strMessage, a_oCause);
+	}
+
 	public WURCSToGlycanException(String a_strMessage) {
 		super(a_strMessage);
 		// TODO 自動生成されたコンストラクター・スタブ

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
@@ -1,5 +1,6 @@
 package org.glycoinfo.application.glycanbuilder.util.exchange.importer;
 
+import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
 import org.eurocarbdb.application.glycanbuilder.Residue;
 import org.eurocarbdb.application.glycanbuilder.linkage.Linkage;
 import org.glycoinfo.WURCSFramework.util.WURCSDataConverter;
@@ -200,7 +201,7 @@ public class GLINToLinkage {
 				linkage = new Linkage(null, a_oSUB, a_caPositions);
 				this.acceptorLinkages.add(linkage);
 			} catch (Exception e) {
-				e.printStackTrace();
+				LogUtils.report(e);
 			}
 		}
 
@@ -242,7 +243,7 @@ public class GLINToLinkage {
 				Linkage linkage = new Linkage(this.acceptorRES, bridge, a_caPositions);
 				this.acceptorLinkages.add(linkage);
 			} catch (Exception e) {
-				e.printStackTrace();
+				LogUtils.report(e);
 			}
 		}
 
@@ -284,7 +285,7 @@ public class GLINToLinkage {
 				Linkage linkage = new Linkage(this.acceptorRES, bridge, a_caPositions);
 				this.acceptorLinkages.add(linkage);
 			} catch (Exception e) {
-				e.printStackTrace();
+				LogUtils.report(e);
 			}
 		}
 
@@ -343,7 +344,7 @@ public class GLINToLinkage {
 				this.endSideRepLinkage = new Linkage(null, a_oSUB, a_cdPositions);
 				this.endSideRepLinkage.setAnomericCarbon(a_cdPositions[0]);
 			} catch (Exception e) {
-				e.printStackTrace();
+				LogUtils.report(e);
 			}
 		}
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsErrorTranslationTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsErrorTranslationTest.java
@@ -1,0 +1,96 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.glycoinfo.application.glycanbuilder.util.exchange.WURCSToGlycanException;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a WURCS the conversion cannot handle fails in WURCS terms, not in Java's (#123).
+ *
+ * <p>The conversion's own failures came out as raw NullPointerExceptions and
+ * StringIndexOutOfBounds - "String index out of range: 8" for a substituent placed at position 9
+ * of a hexose - which name nothing, and read as crashes rather than as answers about the sequence.
+ * Every WURCS enters through one door, {@code WURCS2Parser.readGlycan}, so the translation lives
+ * there: what kind of failure, on which sequence, with the original chained underneath for whoever
+ * needs the trace.</p>
+ */
+public class WurcsErrorTranslationTest {
+
+	/** A substituent at position 9 of a six-carbon sugar, which the conversion indexes past. */
+	private static final String POSITION_PAST_THE_SUGAR =
+			"WURCS=2.0/1,1,0/[axxxxh-1x_1-5_2*NCC/3=O_9*OSO/3=O/3=O]/1/";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The failure names the failure, the sequence, and carries the original underneath. */
+	@Test
+	public void aConversionFailureSpeaksWurcs() throws Exception {
+		try {
+			new WURCS2Parser().readGlycan(POSITION_PAST_THE_SUGAR, new MassOptions());
+			fail("it converted");
+		} catch (StringIndexOutOfBoundsException raw) {
+			fail("still a raw StringIndexOutOfBoundsException");
+		} catch (WURCSToGlycanException translated) {
+			assertTrue(translated.getMessage(),
+					translated.getMessage().contains("could not convert this WURCS"));
+			assertTrue("does not say what kind of failure it was",
+					translated.getMessage().contains("StringIndexOutOfBounds"));
+			assertTrue("does not name the sequence",
+					translated.getMessage().contains("WURCS=2.0/1,1,0/[axxxxh"));
+			assertTrue("the original trace was lost",
+					translated.getCause() instanceof StringIndexOutOfBoundsException);
+		}
+	}
+
+	/** Through the document it is an orderly false, and the document is left as it was. */
+	@Test
+	public void throughTheDocumentItIsAnOrderlyNo() {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		boolean imported;
+		try {
+			imported = document.importFromString(POSITION_PAST_THE_SUGAR, "wurcs2");
+		} catch (Exception refused) {
+			imported = false;
+		}
+
+		assertTrue("it imported an unconvertible WURCS", !imported);
+		assertEquals(0, document.getStructures().size());
+	}
+
+	/**
+	 * A failure that already speaks - "this substituent could not support: *XYZQW" - is passed
+	 * through untouched, not wrapped into noise.
+	 */
+	@Test
+	public void aFailureThatAlreadySpeaksIsNotRewrapped() throws Exception {
+		try {
+			new WURCS2Parser().readGlycan(
+					"WURCS=2.0/1,1,0/[a2122h-1b_1-5_2*XYZQW]/1/", new MassOptions());
+			fail("it converted");
+		} catch (WURCSToGlycanException wrapped) {
+			fail("a descriptive checked failure was rewrapped: " + wrapped.getMessage());
+		} catch (Exception descriptive) {
+			assertTrue(descriptive.getMessage(), descriptive.getMessage().contains("*XYZQW"));
+		}
+	}
+
+	/** And an ordinary WURCS converts exactly as before. */
+	@Test
+	public void anOrdinaryWurcsStillConverts() throws Exception {
+		assertTrue(new WURCS2Parser().readGlycan(
+				"WURCS=2.0/1,2,1/[a2122h-1b_1-5_2*NCC/3=O]/1-1/a4-b1", new MassOptions()) != null);
+	}
+}


### PR DESCRIPTION
Toward #123, as its own layer under whatever finer per-site messages arrive later.

Conversion failures came out as raw `NullPointerException`s and `StringIndexOutOfBounds` — "String index out of range: 8" for a substituent placed at position 9 of a hexose — naming nothing about the sequence. Every WURCS enters through one door, `WURCS2Parser.readGlycan`, so the translation lives there: a runtime failure becomes a `WURCSToGlycanException` that says **what kind of failure, on which sequence**, with the original chained underneath. Failures that already speak (`this substituent could not support: *XYZQW`) pass through untouched, pinned by test.

Also: fourteen `printStackTrace` calls in the conversion/model classes now go through `LogUtils.report`, so they answer to logging configuration; the Swing classes keep theirs for now.

82 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
