### PR TITLE
Write the configuration where the user may write (#10)

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BuilderWorkspace.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BuilderWorkspace.java
@@ -221,8 +221,14 @@ public class BuilderWorkspace extends BaseDocument implements BaseWorkspace,
 				loaded=false;
 			}else {
 				storeToConfiguration(true);
+				// Write where this user is allowed to write, not where the configuration was looked
+				// for. What is passed in is usually a bundled resource ("/config.xml"), and writing
+				// to it means writing to whatever that path resolves to on disk - the working
+				// directory of whatever launched the application. On Windows that can be
+				// C:\WINDOWS\system32, where the write is denied and the application does not start
+				// (#10).
 				if (config_file != null && create)
-					theConfiguration.save(config_file);
+					theConfiguration.save(getPersistentConfigFile());
 			}
 
 			// initialize dictionaries

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Configuration.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Configuration.java
@@ -66,10 +66,13 @@ public class Configuration implements SAXUtils.SAXWriter {
             fis = new FileInputStream(file);
         }
 
+        // Neither a file nor a bundled resource: there is no configuration to read, which is an
+        // ordinary state on a first run. This used to fall back to "src/main/resources/config.xml",
+        // a path inside the build tree that cannot exist in a distributed jar, so the fallback only
+        // ever threw FileNotFoundException - turning "no configuration yet" into a reported error.
         if (fis == null) {
-            fis = new FileInputStream("src/main/resources/config.xml");
+            return false;
         }
-        //return false;
 
         // open document
         //InputStreamReader fis = new InputStreamReader(file_url.openStream());
@@ -97,7 +100,14 @@ public class Configuration implements SAXUtils.SAXWriter {
     try {
         if( filename==null )
         return false;
-        //File -> inner path -> default path
+
+        // Make the directory the file is asked to live in, so a caller may name a place of its own
+        // (the per-user configuration directory does not exist until something writes there).
+        File parent = new File(filename).getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+
         OutputStream fos = new FileOutputStream(filename);
 
         Document document = XMLUtils.newDocument();

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ConfigurationLocationTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ConfigurationLocationTest.java
@@ -1,0 +1,98 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Configuration;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * That starting up writes the configuration where the user is allowed to write (#10).
+ *
+ * <p>The configuration was saved to the path it had been <i>looked for</i> at, which is normally a
+ * bundled resource - so the write landed wherever that name resolved on disk: the working directory
+ * of whatever launched the application. Started from the Windows start menu that is
+ * {@code C:\WINDOWS\system32}, the write is denied, and the reporter's application did not start at
+ * all: "java.io.FileNotFoundException: C:\WINDOWS\system32\config.xml (Access is denied)".</p>
+ *
+ * <p>{@code user.home} is redirected to a temporary directory for these tests, so they exercise the
+ * real path-choosing code without touching the developer's own configuration.</p>
+ */
+public class ConfigurationLocationTest {
+
+	private String realHome;
+	private Path temporaryHome;
+
+	@Before
+	public void aHomeOfItsOwn() throws Exception {
+		realHome = System.getProperty("user.home");
+		temporaryHome = Files.createTempDirectory("glycanbuilder-home");
+		System.setProperty("user.home", temporaryHome.toString());
+	}
+
+	@After
+	public void putTheHomeBack() {
+		System.setProperty("user.home", realHome);
+	}
+
+	/**
+	 * The name that has to be asked for to reach the failing path: neither a file on disk nor a
+	 * bundled resource, so opening fails and the workspace creates a configuration instead.
+	 */
+	private static final String NOT_THERE = "/no-such-glycanbuilder-config.xml";
+
+	/** Starting up with nothing to read writes into the user's own directory, and starts. */
+	@Test
+	public void theConfigurationIsWrittenUnderTheUsersHome() {
+		new BuilderWorkspace(NOT_THERE, true, new GlycanRendererAWT());
+
+		assertTrue("nothing was written under the user's home",
+				new File(BuilderWorkspace.getPersistentConfigFile()).isFile());
+	}
+
+	/**
+	 * And nothing is written at the name it looked for.
+	 *
+	 * <p>This is the failure itself: the name the configuration is <i>read</i> from is a resource,
+	 * and writing to it means writing to whatever that name resolves to on disk - the root of the
+	 * drive here, {@code C:\WINDOWS\system32} for the reporter, neither of which an ordinary user
+	 * may write to.</p>
+	 */
+	@Test
+	public void nothingIsWrittenWhereTheResourceWasLookedFor() {
+		new BuilderWorkspace(NOT_THERE, true, new GlycanRendererAWT());
+
+		assertFalse("the resource path was written to as if it were a file",
+				new File(NOT_THERE).isFile());
+	}
+
+	/** A configuration directory that does not exist yet is created rather than refused. */
+	@Test
+	public void savingCreatesTheDirectoryItNeeds() {
+		File wanted = temporaryHome.resolve("not/made/yet/config.xml").toFile();
+
+		assertTrue("the save reported failure", new Configuration().save(wanted.getPath()));
+		assertTrue("no file appeared at " + wanted, wanted.isFile());
+	}
+
+	/**
+	 * Asked for a configuration that is neither a file nor a bundled resource, opening says no.
+	 *
+	 * <p>It used to fall back to {@code src/main/resources/config.xml} - a path inside the build
+	 * tree, absent from every distributed jar - so a first run reported a FileNotFoundException
+	 * where it should simply have started with the defaults.</p>
+	 */
+	@Test
+	public void openingSomethingThatIsNotThereIsAnOrderlyNo() {
+		assertFalse(new Configuration().open(
+				temporaryHome.resolve("no-such-config.xml").toString()));
+	}
+}


### PR DESCRIPTION
Closes #10.

A first run saved the configuration to the path it had just tried to read it from — normally the bundled resource `/config.xml` — so the write went to whatever that name resolves to on disk: the working directory of whatever launched the application. Started from the Windows start menu that is `C:\WINDOWS\system32`, the write is denied, and the application does not start at all, which is what the reporter saw:

```
java.io.FileNotFoundException: C:\WINDOWS\system32\config.xml (Access is denied)
	at org.eurocarbdb.application.glycanbuilder.Configuration.save(Configuration.java:89)
	at org.eurocarbdb.application.glycanbuilder.BuilderWorkspace.init(...)
```

It now saves to the per-user location the workspace already knew about (`BuilderWorkspace.getPersistentConfigFile()`, `~/.glycanbuilder/config.xml`), and `Configuration.save` creates the directory it needs.

While there: opening a configuration that is neither a file nor a bundled resource now answers `false` instead of falling back to `src/main/resources/config.xml` — a path inside the build tree, absent from every distributed jar, so the fallback could only ever throw. A first run reported a `FileNotFoundException` where it should simply have started with the defaults.

**Tests** — four, in `ConfigurationLocationTest`. They redirect `user.home` to a temporary directory, so they exercise the real path-choosing code without touching the developer's own configuration.

The first attempt asserted that nothing was left at `config.xml` in the working directory, and failed — on the `config.xml` that has been tracked in the repository root since the first commit, not on anything the test wrote. The assertions now name a resource that genuinely is not there, which is what reaches the failing branch.
