### PR TITLE
Give a glycosidic bond its linkage types, on every route in (#4)

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
@@ -20,6 +20,8 @@
 
 package org.eurocarbdb.application.glycanbuilder.converterGWS;
 
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.LinkageTypeOptimizer;
+
 import java.awt.Rectangle;
 import java.util.*;
 import java.util.regex.*;
@@ -205,6 +207,13 @@ public class GWSParser implements GlycanParser {
 				sugar.setRingSize('o');
 			}
 		}
+
+		// Say what each bond is made of, rather than leaving every one of them UNVALIDATED (#4).
+		// A structure read from WURCS has its linkage types worked out; one read from GWS did not,
+		// so the same glycan carried different bonds depending on which format it arrived in, and
+		// anything that reads a linkage type - an exporter, a renderer - was reading a placeholder.
+		// The same pass the WURCS writer runs is applied here, on the way in.
+		new LinkageTypeOptimizer().start(ret);
 
 		return ret;
 	}

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
@@ -397,6 +397,11 @@ public class GlycoCTParser implements GlycanParser {
 			ret.addAntenna(toadd, bonds);
 		}
 
+		// The same pass the other two readers run, so a structure carries the same bonds whichever
+		// format it arrived in (#4). Reading GlycoCT and reading the WURCS for the same glycan used
+		// to give linkage types that did not agree, and the renderer asks them (#62).
+		new org.glycoinfo.application.glycanbuilder.converterWURCS2.LinkageTypeOptimizer().start(ret);
+
 		return ret;
 	}
 

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/LinkageTypeOptimizer.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/LinkageTypeOptimizer.java
@@ -55,6 +55,24 @@ public class LinkageTypeOptimizer {
                     }
                 }
 
+                // monosaccharide-monosaccharide: an ordinary glycosidic bond, which had no branch
+                // here at all and so stayed UNVALIDATED however the structure was read (#4). The
+                // donor gives up the OH at its anomeric centre (DEOXY) and the acceptor keeps the
+                // oxygen the bond is made through (H_AT_OH) - which is what the GlycoCT writer had
+                // been assuming for an unvalidated bond all along, writing "1o(4+1)2d". Saying it
+                // in the model rather than at one exporter is the point: every other reader of a
+                // linkage type was reading a placeholder.
+                if (acceptorLinkage.getSubstituent() == null
+                        && acceptorLinkage.getChildResidue().isSaccharide()
+                        && acceptorLinkage.getParentResidue().isSaccharide()) {
+                    try {
+                        acceptorLinkage.setParentLinkageType(LinkageType.H_AT_OH);
+                        acceptorLinkage.setChildLinkageType(LinkageType.DEOXY);
+                    } catch (Exception e) {
+                        LogUtils.report(e);
+                    }
+                }
+
                 if (acceptorLinkage.getSubstituent() == null) continue;
 
                 // monosaccharide-bridge-monosaccharide

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
@@ -80,6 +80,12 @@ public class WURCS2Parser implements GlycanParser{
 		refuseCycles(glycan.getRoot(), java.util.Collections.newSetFromMap(
 				new java.util.IdentityHashMap<Residue, Boolean>()));
 
+		// Say what each bond is made of here, where the structure is built, rather than leaving it
+		// to whoever writes it out (#4). This pass used to run in writeGlycan alone, so a structure
+		// read from WURCS carried UNVALIDATED bonds until the moment it was written back to WURCS -
+		// and anything else that asked, a GlycoCT writer or a renderer, was asking a placeholder.
+		new LinkageTypeOptimizer().start(glycan);
+
 		return glycan;
 	}
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/LinkageTypesAreSetOnReadingTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/LinkageTypesAreSetOnReadingTest.java
@@ -1,0 +1,120 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.MolecularFramework.sugar.LinkageType;
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.linkage.Linkage;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a structure knows what its bonds are made of as soon as it is read, whichever format it came
+ * from (#4).
+ *
+ * <p>Every linkage is born {@code UNVALIDATED}, and the pass that works the types out ran in one
+ * place only: the WURCS <i>writer</i>. So the same glycan carried different linkage types depending
+ * on the format it had arrived in, and every other reader of a type - the GlycoCT writer, the
+ * renderer - was reading a placeholder. That is the shape of #62, where a structure is drawn
+ * differently depending on whether it was read from WURCS or from GlycoCT.</p>
+ *
+ * <p>The ordinary glycosidic bond had no branch in that pass at all, only substituents and bridges
+ * did. The donor gives up the OH at its anomeric centre ({@code DEOXY}) and the acceptor keeps the
+ * oxygen the bond is made through ({@code H_AT_OH}) - which is what the GlycoCT writer had been
+ * assuming all along when it wrote {@code 1o(4+1)2d}.</p>
+ */
+public class LinkageTypesAreSetOnReadingTest {
+
+	private static final String GWS = "freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd";
+	private static final String WURCS =
+			"WURCS=2.0/2,2,1/[a2122h-1b_1-5_2*NCC/3=O][a2112h-1b_1-5]/1-2/a4-b1";
+	private static final String GLYCOCT =
+			"RES\n1b:b-dglc-HEX-1:5\n2s:n-acetyl\n3b:b-dgal-HEX-1:5\n"
+			+ "LIN\n1:1d(2+1)2n\n2:1o(4+1)3d\n";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** Read from GWS, the glycosidic bond says what it is. */
+	@Test
+	public void gwsGivesTheGlycosidicBondItsTypes() throws Exception {
+		assertGlycosidicBondIsTyped(Glycan.fromString(GWS));
+	}
+
+	/** Read from WURCS, the same. It used to stay unvalidated until the moment it was written back. */
+	@Test
+	public void wurcsGivesTheGlycosidicBondItsTypes() {
+		assertGlycosidicBondIsTyped(readAs(WURCS, "wurcs2"));
+	}
+
+	/** And read from GlycoCT, which is the pairing #62 is about. */
+	@Test
+	public void glycoCtGivesTheGlycosidicBondItsTypes() {
+		assertGlycosidicBondIsTyped(readAs(GLYCOCT, "glycoct_condensed"));
+	}
+
+	/** A substituent's bond is typed on every route too, not only through WURCS. */
+	@Test
+	public void aSubstituentIsTypedWhicheverWayItArrives() throws Exception {
+		Glycan fromGws = Glycan.fromString("freeEnd--?b1D-Glc,p--2?1N--??1Ac$MONO,Und,0,0,freeEnd");
+
+		Linkage acetyl = linkageInto(fromGws, "Ac");
+		assertEquals(LinkageType.NONMONOSACCHARID, acetyl.getChildLinkageType());
+		assertEquals(LinkageType.H_AT_OH, acetyl.getParentLinkageType());
+	}
+
+	/**
+	 * And saying so changes nothing about what comes out.
+	 *
+	 * <p>The exporters had their own assumptions for an unvalidated bond; stating the type in the
+	 * model has to agree with them, or every stored sequence would shift under its users.</p>
+	 */
+	@Test
+	public void whatIsWrittenOutIsUnchanged() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(Glycan.fromString(GWS));
+
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+		assertEquals(WURCS, document.getString().get(0).strip());
+		document.clearString();
+
+		document.exportFromStructure(document.getStructures(), "glycoct_condensed");
+		assertTrue(document.getString().get(0), document.getString().get(0).contains("1o(4+1)3d"));
+	}
+
+	private static void assertGlycosidicBondIsTyped(Glycan structure) {
+		Linkage glycosidic = linkageInto(structure, "Gal");
+
+		assertEquals("the acceptor's side should keep its oxygen",
+				LinkageType.H_AT_OH, glycosidic.getParentLinkageType());
+		assertEquals("the donor's anomeric side should give up its OH",
+				LinkageType.DEOXY, glycosidic.getChildLinkageType());
+	}
+
+	/** The linkage a named residue hangs from. */
+	private static Linkage linkageInto(Glycan structure, String residueName) {
+		for (Residue residue : structure.getAllResidues()) {
+			if (residue.getTypeName().equals(residueName)) return residue.getParentLinkage();
+		}
+
+		throw new AssertionError("no " + residueName + " in " + structure);
+	}
+
+	private static Glycan readAs(String sequence, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		try {
+			assertTrue(format + " would not import", document.importFromString(sequence, format));
+		} catch (Exception thrown) {
+			throw new AssertionError(format + " threw: " + thrown, thrown);
+		}
+
+		return document.getStructures().get(0);
+	}
+}


### PR DESCRIPTION
Closes #4. **Stacked on #145** — review that one first; this PR's base is its branch, so the diff here is only the linkage-type work.

Two gaps, both in `LinkageTypeOptimizer`'s reach.

**It had no branch for an ordinary sugar–sugar bond at all** — only substituents and bridges — so every glycosidic linkage in every structure stayed `UNVALIDATED`. The issue asks for `Deoxy`–`H_AT_OH`, and that is what it now sets: the donor gives up the OH at its anomeric centre (`DEOXY`) and the acceptor keeps the oxygen the bond is made through (`H_AT_OH`).

**And the pass ran in one place: the WURCS writer.** So a structure read from WURCS carried placeholders until the moment it was written back to WURCS, and reading the same glycan from GlycoCT gave something different again. All three readers now run it.

Measured on `freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p`:

| route in | before | after |
|---|---|---|
| GWS | UNVALIDATED / UNVALIDATED | **H_AT_OH / DEOXY** |
| WURCS | UNVALIDATED / UNVALIDATED | **H_AT_OH / DEOXY** |
| GlycoCT | UNVALIDATED / UNVALIDATED | **H_AT_OH / DEOXY** |

**Nothing that is written out changes**, and that is the property that mattered most here: stating a type in the model has to agree with what the exporters had been assuming, or every stored sequence would shift under its users. Seven structures — plain chains, an N-glycan core, a substituent, a phosphate bridge, an alditol, a sialylated chain, a sulfate — were exported to WURCS, GlycoCT and GWS before and after, and the output is byte-identical. The GlycoCT writer had been assuming exactly `1o(4+1)2d` for an unvalidated bond all along. A test holds that agreement.

**Tests** — five, in `LinkageTypesAreSetOnReadingTest`.
