### PR TITLE
Keep an antenna's parents when reading GlycoCT (#62)

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
@@ -363,10 +363,13 @@ public class GlycoCTParser implements GlycanParser {
 		if (sugar.getRootNodes().size() == 0)
 			return new Glycan(null, false, default_mass_opt);
 
-		// parse from the root
+		// parse from the root, keeping which residue each node became: the undetermined subtrees
+		// below name the nodes they may hang from, and without the map there is no way back from
+		// one of those names to the residue it is (#62).
 		GlycoNode gn_root = sugar.getRootNodes().iterator().next();
+		HashMap<GlycoNode, Residue> residueOfNode = new HashMap<GlycoNode, Residue>();
 		Residue root = fromSugar(gn_root, converter, tolerate_unknown_residues,
-				null);
+				residueOfNode);
 
 		if (root != null && !root.isReducingEnd()) {
 			if (root.isAlditol()) {
@@ -395,6 +398,18 @@ public class GlycoCTParser implements GlycanParser {
 					tolerate_unknown_residues, null);
 			Vector<Bond> bonds = fromSugar(antenna.getConnection());
 			ret.addAntenna(toadd, bonds);
+
+			// Carry over which residues this antenna may hang from. GlycoCT states them (the UND
+			// section's ParentIDs) and this dropped them, so an antenna read from GlycoCT knew of
+			// no parents while the same glycan read from WURCS did - and the renderer asks exactly
+			// that when it decides whether to draw a link towards the bracket, so one sequence was
+			// drawn with the link and the other without (#62).
+			for (GlycoNode parentNode : antenna.getParents()) {
+				Residue parentResidue = residueOfNode.get(parentNode);
+				if (parentResidue != null) {
+					toadd.addParentOfFragment(parentResidue);
+				}
+			}
 		}
 
 		// The same pass the other two readers run, so a structure carries the same bonds whichever

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCtKeepsAntennaParentsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCtKeepsAntennaParentsTest.java
@@ -1,0 +1,105 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a glycan is drawn the same whether it was read from WURCS or from GlycoCT (#62).
+ *
+ * <p>An antenna - a subtree whose attachment point is undetermined - names the residues it may hang
+ * from. WURCS carries them, GlycoCT states them in its UND section's ParentIDs, and reading GlycoCT
+ * dropped them: the antenna arrived knowing of no parents at all. The renderer asks exactly that
+ * ({@code getParentsOfFragment().isEmpty()}) when it decides whether to draw a link towards the
+ * bracket, so the same glycan came out with the link from one sequence and without it from the
+ * other.</p>
+ *
+ * <p>The structure here is G00955WX, the one in the report, reduced to what shows the fault: a
+ * bracketed antenna over a small core.</p>
+ */
+public class GlycoCtKeepsAntennaParentsTest {
+
+	/**
+	 * G00955WX itself: a biantennary N-glycan with a sialic acid whose attachment is undetermined,
+	 * so it is drawn from the bracket and may hang from any of the eleven residues before it.
+	 *
+	 * <p>A smaller structure was tried first and would not do: with one Fuc over a short core the
+	 * WURCS side names no parents either, so the two routes agree by both being empty and the test
+	 * proves nothing. The assertion that the WURCS side has parents is there to keep it honest.</p>
+	 */
+	private static final String WITH_AN_ANTENNA =
+			"WURCS=2.0/5,12,11/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]"
+			+ "[a2112h-1b_1-5][Aad21122h-2a_2-6_5*NCC/3=O]/1-1-2-3-1-4-1-4-3-1-4-5"
+			+ "/a4-b1_b4-c1_c3-d1_c6-i1_d2-e1_d4-g1_e4-f1_g4-h1_i2-j1_j4-k1"
+			+ "_l2-a?|b?|c?|d?|e?|f?|g?|h?|i?|j?|k?}";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The antenna knows what it may hang from after a trip through GlycoCT. */
+	@Test
+	public void theAntennaKeepsItsParentsThroughGlycoCt() throws Exception {
+		Glycan fromWurcs = read(WITH_AN_ANTENNA, "wurcs2");
+
+		Glycan fromGlycoCt = read(writeAs(fromWurcs, "glycoct_condensed"), "glycoct_condensed");
+
+		assertEquals("the antenna lost its parents on the way through GlycoCT",
+				parentsOfFragmentCount(fromWurcs), parentsOfFragmentCount(fromGlycoCt));
+		assertTrue("the WURCS side has no antenna parents, so this proves nothing",
+				parentsOfFragmentCount(fromWurcs) > 0);
+	}
+
+	/** And so it is drawn the same, which is what the report is about. */
+	@Test
+	public void bothRoutesDrawTheSamePicture() throws Exception {
+		Glycan fromWurcs = read(WITH_AN_ANTENNA, "wurcs2");
+		Glycan fromGlycoCt = read(writeAs(fromWurcs, "glycoct_condensed"), "glycoct_condensed");
+
+		assertEquals("the two routes draw different pictures", draw(fromWurcs), draw(fromGlycoCt));
+	}
+
+	/** How many residues in the structure name a parent they may hang from. */
+	private static int parentsOfFragmentCount(Glycan structure) {
+		int named = 0;
+		for (Residue residue : structure.getAllResidues()) {
+			if (!residue.getParentsOfFragment().isEmpty()) named++;
+		}
+
+		return named;
+	}
+
+	private static String draw(Glycan structure) throws Exception {
+		List<Glycan> one = Collections.singletonList(structure);
+
+		return SVGUtils.getVectorGraphics(new GlycanRendererAWT(), one, false, false);
+	}
+
+	private static Glycan read(String sequence, String format) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(format + " would not import", document.importFromString(sequence, format));
+
+		return document.getStructures().get(0);
+	}
+
+	private static String writeAs(Glycan structure, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.exportFromStructure(document.getStructures(), format);
+		assertTrue("nothing came out as " + format, !document.getString().isEmpty());
+
+		return document.getString().get(0);
+	}
+}


### PR DESCRIPTION
Closes #62. **Stacked on #146** — its branch is this PR's base, so the diff here is only the antenna work.

An antenna — a subtree whose attachment point is undetermined — names the residues it may hang from. WURCS carries them; GlycoCT states them in the `UND` section's `ParentIDs`, and reading GlycoCT dropped them, so the antenna arrived knowing of no parents at all.

The renderer asks exactly that — `getParentsOfFragment().isEmpty()`, the line @edwardsnj pointed at — when it decides whether to draw a link towards the bracket. So G00955WX came out **with** the link when read from WURCS and **without** it when read from GlycoCT: the same glycan, drawn two ways depending on which sequence it arrived as.

The parser already threads a node-to-residue map through for its own use; the antenna loop now uses it to turn each named parent node back into the residue it became.

Measured on G00955WX:

| | parents named | SVG |
|---|---|---|
| from WURCS | 11 | 29947 bytes |
| from GlycoCT, before | **0** | 29930 bytes |
| from GlycoCT, after | **11** | **29947 bytes — identical** |

**Tests** — two, in `GlycoCtKeepsAntennaParentsTest`.

A smaller structure was tried first and would not do: with one Fuc over a short core the WURCS side names no parents either, so the two routes agree by both being empty and the test proves nothing. The assertion that the WURCS side has parents is there to keep it honest, and it is what caught that.

Worth noting for the rest of #62's family: this does **not** fix #58 or #71. Both were re-rendered before and after and the images are byte-identical, so their causes are elsewhere — see #147 for what is now known about #71.
