### PR TITLE
Release 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,35 @@
 ## Change log
+### 1.33.0  (20260810)
+* Wrote the configuration where the user may write, so the application starts on Windows (#10)
+  * A first run saved it to the path it had just tried to read it from - normally the bundled
+    resource "/config.xml" - so the write went to whatever that name resolves to on disk: the
+    working directory of whatever launched the application, which from the Windows start menu is
+    C:\WINDOWS\system32, where it is denied and nothing starts
+  * It saves to the per-user location the workspace already knew about, creating the directory
+  * Opening a configuration that is neither a file nor a resource now answers no, instead of
+    falling back to src/main/resources/config.xml - a build-tree path absent from every
+    distributed jar, so the fallback could only ever throw on a first run
+* Gave a glycosidic bond its linkage types, on every route in (#4)
+  * The pass that works them out had no branch for an ordinary sugar-sugar bond at all, only for
+    substituents and bridges, so every glycosidic linkage stayed UNVALIDATED: the donor gives up
+    the OH at its anomeric centre (DEOXY), the acceptor keeps the oxygen (H_AT_OH)
+  * And it ran in one place, the WURCS writer, so a structure carried placeholders until the
+    moment it was written back - all three readers run it now, and GWS, WURCS and GlycoCT agree
+  * Nothing written out changes: seven structures were exported to all three formats before and
+    after, byte-identical, which is what stating a type in the model had to agree with
+* Kept an antenna's parents when reading GlycoCT, so a glycan is drawn the same whichever
+  sequence it arrived as (#62)
+  * GlycoCT states them in the UND section's ParentIDs and the reader dropped them, so an antenna
+    knew of no parents; the renderer asks exactly that when it decides whether to draw a link
+    towards the bracket, and G00955WX came out with the link from WURCS and without it from
+    GlycoCT
+  * Measured on G00955WX: eleven parents on both routes now, and the two SVGs identical
+* Said what has to be true of any layout, before changing one (groundwork for #58 and #71)
+  * Every residue lies within the bounding box the renderer reports, and no two share a spot -
+    properties that hold whatever the layout looks like, so an improvement passes them and a
+    mistake does not, where a frozen SVG would fail on both
+  * Nine structures hold them; G42735RP of #71 does not, and its test says so, failing the day
+    #71 is fixed
 ### 1.32.0  (20260809)
 * Wrote structures with bridges to GlycoCT, which had exported as an empty string
   * The bridge went to the namescheme converter decorated like a sugar - "?-P", which nothing

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.32.0</version>
+	<version>1.33.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BuilderWorkspace.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BuilderWorkspace.java
@@ -221,8 +221,14 @@ public class BuilderWorkspace extends BaseDocument implements BaseWorkspace,
 				loaded=false;
 			}else {
 				storeToConfiguration(true);
+				// Write where this user is allowed to write, not where the configuration was looked
+				// for. What is passed in is usually a bundled resource ("/config.xml"), and writing
+				// to it means writing to whatever that path resolves to on disk - the working
+				// directory of whatever launched the application. On Windows that can be
+				// C:\WINDOWS\system32, where the write is denied and the application does not start
+				// (#10).
 				if (config_file != null && create)
-					theConfiguration.save(config_file);
+					theConfiguration.save(getPersistentConfigFile());
 			}
 
 			// initialize dictionaries

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Configuration.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Configuration.java
@@ -66,10 +66,13 @@ public class Configuration implements SAXUtils.SAXWriter {
             fis = new FileInputStream(file);
         }
 
+        // Neither a file nor a bundled resource: there is no configuration to read, which is an
+        // ordinary state on a first run. This used to fall back to "src/main/resources/config.xml",
+        // a path inside the build tree that cannot exist in a distributed jar, so the fallback only
+        // ever threw FileNotFoundException - turning "no configuration yet" into a reported error.
         if (fis == null) {
-            fis = new FileInputStream("src/main/resources/config.xml");
+            return false;
         }
-        //return false;
 
         // open document
         //InputStreamReader fis = new InputStreamReader(file_url.openStream());
@@ -97,7 +100,14 @@ public class Configuration implements SAXUtils.SAXWriter {
     try {
         if( filename==null )
         return false;
-        //File -> inner path -> default path
+
+        // Make the directory the file is asked to live in, so a caller may name a place of its own
+        // (the per-user configuration directory does not exist until something writes there).
+        File parent = new File(filename).getParentFile();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+
         OutputStream fos = new FileOutputStream(filename);
 
         Document document = XMLUtils.newDocument();

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
@@ -20,6 +20,8 @@
 
 package org.eurocarbdb.application.glycanbuilder.converterGWS;
 
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.LinkageTypeOptimizer;
+
 import java.awt.Rectangle;
 import java.util.*;
 import java.util.regex.*;
@@ -205,6 +207,13 @@ public class GWSParser implements GlycanParser {
 				sugar.setRingSize('o');
 			}
 		}
+
+		// Say what each bond is made of, rather than leaving every one of them UNVALIDATED (#4).
+		// A structure read from WURCS has its linkage types worked out; one read from GWS did not,
+		// so the same glycan carried different bonds depending on which format it arrived in, and
+		// anything that reads a linkage type - an exporter, a renderer - was reading a placeholder.
+		// The same pass the WURCS writer runs is applied here, on the way in.
+		new LinkageTypeOptimizer().start(ret);
 
 		return ret;
 	}

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
@@ -397,6 +397,11 @@ public class GlycoCTParser implements GlycanParser {
 			ret.addAntenna(toadd, bonds);
 		}
 
+		// The same pass the other two readers run, so a structure carries the same bonds whichever
+		// format it arrived in (#4). Reading GlycoCT and reading the WURCS for the same glycan used
+		// to give linkage types that did not agree, and the renderer asks them (#62).
+		new org.glycoinfo.application.glycanbuilder.converterWURCS2.LinkageTypeOptimizer().start(ret);
+
 		return ret;
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
@@ -363,10 +363,13 @@ public class GlycoCTParser implements GlycanParser {
 		if (sugar.getRootNodes().size() == 0)
 			return new Glycan(null, false, default_mass_opt);
 
-		// parse from the root
+		// parse from the root, keeping which residue each node became: the undetermined subtrees
+		// below name the nodes they may hang from, and without the map there is no way back from
+		// one of those names to the residue it is (#62).
 		GlycoNode gn_root = sugar.getRootNodes().iterator().next();
+		HashMap<GlycoNode, Residue> residueOfNode = new HashMap<GlycoNode, Residue>();
 		Residue root = fromSugar(gn_root, converter, tolerate_unknown_residues,
-				null);
+				residueOfNode);
 
 		if (root != null && !root.isReducingEnd()) {
 			if (root.isAlditol()) {
@@ -395,6 +398,18 @@ public class GlycoCTParser implements GlycanParser {
 					tolerate_unknown_residues, null);
 			Vector<Bond> bonds = fromSugar(antenna.getConnection());
 			ret.addAntenna(toadd, bonds);
+
+			// Carry over which residues this antenna may hang from. GlycoCT states them (the UND
+			// section's ParentIDs) and this dropped them, so an antenna read from GlycoCT knew of
+			// no parents while the same glycan read from WURCS did - and the renderer asks exactly
+			// that when it decides whether to draw a link towards the bracket, so one sequence was
+			// drawn with the link and the other without (#62).
+			for (GlycoNode parentNode : antenna.getParents()) {
+				Residue parentResidue = residueOfNode.get(parentNode);
+				if (parentResidue != null) {
+					toadd.addParentOfFragment(parentResidue);
+				}
+			}
 		}
 
 		// The same pass the other two readers run, so a structure carries the same bonds whichever

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/LinkageTypeOptimizer.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/LinkageTypeOptimizer.java
@@ -55,6 +55,24 @@ public class LinkageTypeOptimizer {
                     }
                 }
 
+                // monosaccharide-monosaccharide: an ordinary glycosidic bond, which had no branch
+                // here at all and so stayed UNVALIDATED however the structure was read (#4). The
+                // donor gives up the OH at its anomeric centre (DEOXY) and the acceptor keeps the
+                // oxygen the bond is made through (H_AT_OH) - which is what the GlycoCT writer had
+                // been assuming for an unvalidated bond all along, writing "1o(4+1)2d". Saying it
+                // in the model rather than at one exporter is the point: every other reader of a
+                // linkage type was reading a placeholder.
+                if (acceptorLinkage.getSubstituent() == null
+                        && acceptorLinkage.getChildResidue().isSaccharide()
+                        && acceptorLinkage.getParentResidue().isSaccharide()) {
+                    try {
+                        acceptorLinkage.setParentLinkageType(LinkageType.H_AT_OH);
+                        acceptorLinkage.setChildLinkageType(LinkageType.DEOXY);
+                    } catch (Exception e) {
+                        LogUtils.report(e);
+                    }
+                }
+
                 if (acceptorLinkage.getSubstituent() == null) continue;
 
                 // monosaccharide-bridge-monosaccharide

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
@@ -80,6 +80,12 @@ public class WURCS2Parser implements GlycanParser{
 		refuseCycles(glycan.getRoot(), java.util.Collections.newSetFromMap(
 				new java.util.IdentityHashMap<Residue, Boolean>()));
 
+		// Say what each bond is made of here, where the structure is built, rather than leaving it
+		// to whoever writes it out (#4). This pass used to run in writeGlycan alone, so a structure
+		// read from WURCS carried UNVALIDATED bonds until the moment it was written back to WURCS -
+		// and anything else that asked, a GlycoCT writer or a renderer, was asking a placeholder.
+		new LinkageTypeOptimizer().start(glycan);
+
 		return glycan;
 	}
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ConfigurationLocationTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ConfigurationLocationTest.java
@@ -1,0 +1,98 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Configuration;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * That starting up writes the configuration where the user is allowed to write (#10).
+ *
+ * <p>The configuration was saved to the path it had been <i>looked for</i> at, which is normally a
+ * bundled resource - so the write landed wherever that name resolved on disk: the working directory
+ * of whatever launched the application. Started from the Windows start menu that is
+ * {@code C:\WINDOWS\system32}, the write is denied, and the reporter's application did not start at
+ * all: "java.io.FileNotFoundException: C:\WINDOWS\system32\config.xml (Access is denied)".</p>
+ *
+ * <p>{@code user.home} is redirected to a temporary directory for these tests, so they exercise the
+ * real path-choosing code without touching the developer's own configuration.</p>
+ */
+public class ConfigurationLocationTest {
+
+	private String realHome;
+	private Path temporaryHome;
+
+	@Before
+	public void aHomeOfItsOwn() throws Exception {
+		realHome = System.getProperty("user.home");
+		temporaryHome = Files.createTempDirectory("glycanbuilder-home");
+		System.setProperty("user.home", temporaryHome.toString());
+	}
+
+	@After
+	public void putTheHomeBack() {
+		System.setProperty("user.home", realHome);
+	}
+
+	/**
+	 * The name that has to be asked for to reach the failing path: neither a file on disk nor a
+	 * bundled resource, so opening fails and the workspace creates a configuration instead.
+	 */
+	private static final String NOT_THERE = "/no-such-glycanbuilder-config.xml";
+
+	/** Starting up with nothing to read writes into the user's own directory, and starts. */
+	@Test
+	public void theConfigurationIsWrittenUnderTheUsersHome() {
+		new BuilderWorkspace(NOT_THERE, true, new GlycanRendererAWT());
+
+		assertTrue("nothing was written under the user's home",
+				new File(BuilderWorkspace.getPersistentConfigFile()).isFile());
+	}
+
+	/**
+	 * And nothing is written at the name it looked for.
+	 *
+	 * <p>This is the failure itself: the name the configuration is <i>read</i> from is a resource,
+	 * and writing to it means writing to whatever that name resolves to on disk - the root of the
+	 * drive here, {@code C:\WINDOWS\system32} for the reporter, neither of which an ordinary user
+	 * may write to.</p>
+	 */
+	@Test
+	public void nothingIsWrittenWhereTheResourceWasLookedFor() {
+		new BuilderWorkspace(NOT_THERE, true, new GlycanRendererAWT());
+
+		assertFalse("the resource path was written to as if it were a file",
+				new File(NOT_THERE).isFile());
+	}
+
+	/** A configuration directory that does not exist yet is created rather than refused. */
+	@Test
+	public void savingCreatesTheDirectoryItNeeds() {
+		File wanted = temporaryHome.resolve("not/made/yet/config.xml").toFile();
+
+		assertTrue("the save reported failure", new Configuration().save(wanted.getPath()));
+		assertTrue("no file appeared at " + wanted, wanted.isFile());
+	}
+
+	/**
+	 * Asked for a configuration that is neither a file nor a bundled resource, opening says no.
+	 *
+	 * <p>It used to fall back to {@code src/main/resources/config.xml} - a path inside the build
+	 * tree, absent from every distributed jar - so a first run reported a FileNotFoundException
+	 * where it should simply have started with the defaults.</p>
+	 */
+	@Test
+	public void openingSomethingThatIsNotThereIsAnOrderlyNo() {
+		assertFalse(new Configuration().open(
+				temporaryHome.resolve("no-such-config.xml").toString()));
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCtKeepsAntennaParentsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/GlycoCtKeepsAntennaParentsTest.java
@@ -1,0 +1,105 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a glycan is drawn the same whether it was read from WURCS or from GlycoCT (#62).
+ *
+ * <p>An antenna - a subtree whose attachment point is undetermined - names the residues it may hang
+ * from. WURCS carries them, GlycoCT states them in its UND section's ParentIDs, and reading GlycoCT
+ * dropped them: the antenna arrived knowing of no parents at all. The renderer asks exactly that
+ * ({@code getParentsOfFragment().isEmpty()}) when it decides whether to draw a link towards the
+ * bracket, so the same glycan came out with the link from one sequence and without it from the
+ * other.</p>
+ *
+ * <p>The structure here is G00955WX, the one in the report, reduced to what shows the fault: a
+ * bracketed antenna over a small core.</p>
+ */
+public class GlycoCtKeepsAntennaParentsTest {
+
+	/**
+	 * G00955WX itself: a biantennary N-glycan with a sialic acid whose attachment is undetermined,
+	 * so it is drawn from the bracket and may hang from any of the eleven residues before it.
+	 *
+	 * <p>A smaller structure was tried first and would not do: with one Fuc over a short core the
+	 * WURCS side names no parents either, so the two routes agree by both being empty and the test
+	 * proves nothing. The assertion that the WURCS side has parents is there to keep it honest.</p>
+	 */
+	private static final String WITH_AN_ANTENNA =
+			"WURCS=2.0/5,12,11/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]"
+			+ "[a2112h-1b_1-5][Aad21122h-2a_2-6_5*NCC/3=O]/1-1-2-3-1-4-1-4-3-1-4-5"
+			+ "/a4-b1_b4-c1_c3-d1_c6-i1_d2-e1_d4-g1_e4-f1_g4-h1_i2-j1_j4-k1"
+			+ "_l2-a?|b?|c?|d?|e?|f?|g?|h?|i?|j?|k?}";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The antenna knows what it may hang from after a trip through GlycoCT. */
+	@Test
+	public void theAntennaKeepsItsParentsThroughGlycoCt() throws Exception {
+		Glycan fromWurcs = read(WITH_AN_ANTENNA, "wurcs2");
+
+		Glycan fromGlycoCt = read(writeAs(fromWurcs, "glycoct_condensed"), "glycoct_condensed");
+
+		assertEquals("the antenna lost its parents on the way through GlycoCT",
+				parentsOfFragmentCount(fromWurcs), parentsOfFragmentCount(fromGlycoCt));
+		assertTrue("the WURCS side has no antenna parents, so this proves nothing",
+				parentsOfFragmentCount(fromWurcs) > 0);
+	}
+
+	/** And so it is drawn the same, which is what the report is about. */
+	@Test
+	public void bothRoutesDrawTheSamePicture() throws Exception {
+		Glycan fromWurcs = read(WITH_AN_ANTENNA, "wurcs2");
+		Glycan fromGlycoCt = read(writeAs(fromWurcs, "glycoct_condensed"), "glycoct_condensed");
+
+		assertEquals("the two routes draw different pictures", draw(fromWurcs), draw(fromGlycoCt));
+	}
+
+	/** How many residues in the structure name a parent they may hang from. */
+	private static int parentsOfFragmentCount(Glycan structure) {
+		int named = 0;
+		for (Residue residue : structure.getAllResidues()) {
+			if (!residue.getParentsOfFragment().isEmpty()) named++;
+		}
+
+		return named;
+	}
+
+	private static String draw(Glycan structure) throws Exception {
+		List<Glycan> one = Collections.singletonList(structure);
+
+		return SVGUtils.getVectorGraphics(new GlycanRendererAWT(), one, false, false);
+	}
+
+	private static Glycan read(String sequence, String format) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(format + " would not import", document.importFromString(sequence, format));
+
+		return document.getStructures().get(0);
+	}
+
+	private static String writeAs(Glycan structure, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.exportFromStructure(document.getStructures(), format);
+		assertTrue("nothing came out as " + format, !document.getString().isEmpty());
+
+		return document.getString().get(0);
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/LinkageTypesAreSetOnReadingTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/LinkageTypesAreSetOnReadingTest.java
@@ -1,0 +1,120 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.MolecularFramework.sugar.LinkageType;
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.linkage.Linkage;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a structure knows what its bonds are made of as soon as it is read, whichever format it came
+ * from (#4).
+ *
+ * <p>Every linkage is born {@code UNVALIDATED}, and the pass that works the types out ran in one
+ * place only: the WURCS <i>writer</i>. So the same glycan carried different linkage types depending
+ * on the format it had arrived in, and every other reader of a type - the GlycoCT writer, the
+ * renderer - was reading a placeholder. That is the shape of #62, where a structure is drawn
+ * differently depending on whether it was read from WURCS or from GlycoCT.</p>
+ *
+ * <p>The ordinary glycosidic bond had no branch in that pass at all, only substituents and bridges
+ * did. The donor gives up the OH at its anomeric centre ({@code DEOXY}) and the acceptor keeps the
+ * oxygen the bond is made through ({@code H_AT_OH}) - which is what the GlycoCT writer had been
+ * assuming all along when it wrote {@code 1o(4+1)2d}.</p>
+ */
+public class LinkageTypesAreSetOnReadingTest {
+
+	private static final String GWS = "freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd";
+	private static final String WURCS =
+			"WURCS=2.0/2,2,1/[a2122h-1b_1-5_2*NCC/3=O][a2112h-1b_1-5]/1-2/a4-b1";
+	private static final String GLYCOCT =
+			"RES\n1b:b-dglc-HEX-1:5\n2s:n-acetyl\n3b:b-dgal-HEX-1:5\n"
+			+ "LIN\n1:1d(2+1)2n\n2:1o(4+1)3d\n";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** Read from GWS, the glycosidic bond says what it is. */
+	@Test
+	public void gwsGivesTheGlycosidicBondItsTypes() throws Exception {
+		assertGlycosidicBondIsTyped(Glycan.fromString(GWS));
+	}
+
+	/** Read from WURCS, the same. It used to stay unvalidated until the moment it was written back. */
+	@Test
+	public void wurcsGivesTheGlycosidicBondItsTypes() {
+		assertGlycosidicBondIsTyped(readAs(WURCS, "wurcs2"));
+	}
+
+	/** And read from GlycoCT, which is the pairing #62 is about. */
+	@Test
+	public void glycoCtGivesTheGlycosidicBondItsTypes() {
+		assertGlycosidicBondIsTyped(readAs(GLYCOCT, "glycoct_condensed"));
+	}
+
+	/** A substituent's bond is typed on every route too, not only through WURCS. */
+	@Test
+	public void aSubstituentIsTypedWhicheverWayItArrives() throws Exception {
+		Glycan fromGws = Glycan.fromString("freeEnd--?b1D-Glc,p--2?1N--??1Ac$MONO,Und,0,0,freeEnd");
+
+		Linkage acetyl = linkageInto(fromGws, "Ac");
+		assertEquals(LinkageType.NONMONOSACCHARID, acetyl.getChildLinkageType());
+		assertEquals(LinkageType.H_AT_OH, acetyl.getParentLinkageType());
+	}
+
+	/**
+	 * And saying so changes nothing about what comes out.
+	 *
+	 * <p>The exporters had their own assumptions for an unvalidated bond; stating the type in the
+	 * model has to agree with them, or every stored sequence would shift under its users.</p>
+	 */
+	@Test
+	public void whatIsWrittenOutIsUnchanged() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(Glycan.fromString(GWS));
+
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+		assertEquals(WURCS, document.getString().get(0).strip());
+		document.clearString();
+
+		document.exportFromStructure(document.getStructures(), "glycoct_condensed");
+		assertTrue(document.getString().get(0), document.getString().get(0).contains("1o(4+1)3d"));
+	}
+
+	private static void assertGlycosidicBondIsTyped(Glycan structure) {
+		Linkage glycosidic = linkageInto(structure, "Gal");
+
+		assertEquals("the acceptor's side should keep its oxygen",
+				LinkageType.H_AT_OH, glycosidic.getParentLinkageType());
+		assertEquals("the donor's anomeric side should give up its OH",
+				LinkageType.DEOXY, glycosidic.getChildLinkageType());
+	}
+
+	/** The linkage a named residue hangs from. */
+	private static Linkage linkageInto(Glycan structure, String residueName) {
+		for (Residue residue : structure.getAllResidues()) {
+			if (residue.getTypeName().equals(residueName)) return residue.getParentLinkage();
+		}
+
+		throw new AssertionError("no " + residueName + " in " + structure);
+	}
+
+	private static Glycan readAs(String sequence, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		try {
+			assertTrue(format + " would not import", document.importFromString(sequence, format));
+		} catch (Exception thrown) {
+			throw new AssertionError(format + " threw: " + thrown, thrown);
+		}
+
+		return document.getStructures().get(0);
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
@@ -1,0 +1,217 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * What has to be true of any layout, whatever it looks like.
+ *
+ * <p>The drawing issues left open - #58, #71, #29, #88 - all want changes in the middle of the
+ * renderer, where a change meant to help one structure can quietly spoil another, and there was no
+ * way to tell. Freezing the SVG of a set of structures would tell, but it would also fail on every
+ * intentional improvement and say nothing about what went wrong: twelve kilobytes of path data
+ * differing in the fourth decimal.</p>
+ *
+ * <p>These are the properties instead. They hold for a well-formed layout regardless of where it
+ * puts things, so an improvement passes them and a mistake does not:</p>
+ *
+ * <ul>
+ *   <li>every residue lies within the bounding box the renderer reports - what is drawn outside it
+ *       is clipped out of the image, which is how #71 shows itself;</li>
+ *   <li>no two residues share a top-left corner - two symbols on the same spot are unreadable, and
+ *       are a sign that one of them was never placed.</li>
+ * </ul>
+ */
+public class RenderingLayoutInvariantsTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A plain chain. */
+	@Test
+	public void aChainIsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(gws("freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd"));
+	}
+
+	/** A branch. */
+	@Test
+	public void anNGlycanCoreIsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(gws("freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p--4b1D-Man,p"
+				+ "(--3a1D-Man,p)--6a1D-Man,p$MONO,Und,0,0,freeEnd"));
+	}
+
+	/** A substituent, which is drawn beside its sugar rather than as a symbol of its own. */
+	@Test
+	public void aSubstituentIsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(gws("freeEnd--?b1D-Glc,p--2?1N--??1Ac$MONO,Und,0,0,freeEnd"));
+	}
+
+	/** A bridge, which sits in the middle of a linkage. */
+	@Test
+	public void aBridgeIsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(gws("freeEnd--?b1D-Glc,p--6?1P--1b1D-Gal,p$MONO,Und,0,0,freeEnd"));
+	}
+
+	/** A reduced structure. */
+	@Test
+	public void anAlditolIsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(gws("redEnd--?b1D-Glc,o$MONO,Und,0,0,redEnd"));
+	}
+
+	/** A bracket with antennae - the shape #71 is about, in a structure that gets it right. */
+	@Test
+	public void aBracketWithAntennaeIsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(wurcs(
+				"WURCS=2.0/5,12,11/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]"
+				+ "[a2112h-1b_1-5][Aad21122h-2a_2-6_5*NCC/3=O]/1-1-2-3-1-4-1-4-3-1-4-5"
+				+ "/a4-b1_b4-c1_c3-d1_c6-i1_d2-e1_d4-g1_e4-f1_g4-h1_i2-j1_j4-k1"
+				+ "_l2-a?|b?|c?|d?|e?|f?|g?|h?|i?|j?|k?}"));
+	}
+
+	/**
+	 * A repeating unit - G03246MZ, which #57 was about.
+	 *
+	 * <p>A repeat was tried by hand first and would not do: the sequence read without complaint and
+	 * laid nothing out at all, so the test passed on an empty picture. This is a structure from the
+	 * tracker, which is what makes it worth having.</p>
+	 */
+	@Test
+	public void aRepeatIsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(wurcs(
+				"WURCS=2.0/7,15,15/[h2122h_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5]"
+				+ "[a1122h-1a_1-5][a2112h-1b_1-5][Aad21122h-2a_2-6_5*NCC/3=O][a1221m-1a_1-5]"
+				+ "/1-2-3-4-2-5-6-2-5-6-4-2-5-6-7"
+				+ "/a4-b1_a6-o1_b4-c1_c3-d1_c6-k1_d2-e1_d4-h1_e4-f1_f3-g2_h4-i1_i3-j2"
+				+ "_k2-l1_l4-m1_m3-n2_l1-m3~n"));
+	}
+
+	/**
+	 * G07957FT, which #58 says is drawn with badly positioned links.
+	 *
+	 * <p>Its links do cross, and these properties do not speak to that - crossing lines are a
+	 * matter of where things are put, not of whether they are inside the picture. It is here so
+	 * that a change made for #58 has to keep the rest true.</p>
+	 */
+	@Test
+	public void theStructureOfIssue58IsAtLeastLaidOutWithin() throws Exception {
+		assertLaidOutWithin(wurcs(
+				"WURCS=2.0/7,9,8/[a2122h-1x_1-5_2*N][Aad1122h-2x_2-6][axxxxxh-1x_1-5]"
+				+ "[a2122h-1x_1-5][a2112h-1x_1-5][axxxxxh-1x_1-5_6*OP^XOCCN/3O/3=O]"
+				+ "[a2122h-1x_1-5_2*NCC/3=O]/1-2-3-4-5-5-6-7-2"
+				+ "/a?-b2_b?-c1_b?-i2_c?-d1_c?-g1_d?-e1_e?-f1_g?-h1"));
+	}
+
+	/**
+	 * G42735RP, the structure of #71, which breaks both properties today.
+	 *
+	 * <p>Two residues - an antenna's sialic acid, at linkage position 1 - are placed on the same
+	 * spot, outside the bounding box the renderer reports, and so are cut off by the edge of the
+	 * image. They never reach the list the bracket layout aligns and measures, so nothing sizes the
+	 * picture to include them.</p>
+	 *
+	 * <p>This test states the fault rather than the fix, so that the fault cannot quietly get
+	 * worse. <b>When #71 is fixed this test will fail</b> - that is what it is for. Move the
+	 * structure to a plain {@code assertLaidOutWithin} then, and delete this one.</p>
+	 */
+	@Test
+	public void theStructureOfIssue71IsStillDrawnOutsideItsOwnBox() throws Exception {
+		Glycan structure = wurcs(
+				"WURCS=2.0/7,13,12/[a2122h-1x_1-5_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O]"
+				+ "[a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5][a1221m-1a_1-5]"
+				+ "[Aad21122h-2a_2-6_5*NCC/3=O]/1-2-3-4-2-5-4-2-5-2-5-6-7"
+				+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
+				+ "_m1-f?|i?|k?}");
+
+		assertEquals("#71 looks fixed: no residue falls outside the box any more", 2, outside(structure));
+		assertEquals("#71 looks fixed: no two residues share a spot any more", 1, sharedSpots(structure));
+	}
+
+	/** Everything drawn is inside the box, and no two symbols sit on the same spot. */
+	private static void assertLaidOutWithin(Glycan structure) throws Exception {
+		assertEquals("residues fall outside the bounding box, and are clipped from the image",
+				0, outside(structure));
+		assertEquals("two residues are drawn on the same spot", 0, sharedSpots(structure));
+	}
+
+	/** How many residues lie outside the bounding box the renderer reports for the structure. */
+	private static int outside(Glycan structure) throws Exception {
+		Layout layout = layoutOf(structure);
+
+		int escaped = 0;
+		for (Rectangle each : layout.rectangles.values()) {
+			if (!layout.all.contains(each)) escaped++;
+		}
+
+		return escaped;
+	}
+
+	/** How many spots carry more than one residue. */
+	private static int sharedSpots(Glycan structure) throws Exception {
+		Layout layout = layoutOf(structure);
+
+		Map<String, Integer> perSpot = new HashMap<String, Integer>();
+		int shared = 0;
+		for (Rectangle each : layout.rectangles.values()) {
+			String spot = each.x + "," + each.y;
+			Integer now = perSpot.merge(spot, 1, Integer::sum);
+			if (now == 2) shared++;
+		}
+
+		return shared;
+	}
+
+	/** Where the renderer puts each residue, and the box it says it used. */
+	private static Layout layoutOf(Glycan structure) throws Exception {
+		GlycanRendererAWT renderer = new GlycanRendererAWT();
+		PositionManager positions = new PositionManager();
+		BBoxManager boxes = new BBoxManager();
+		Rectangle all = renderer.computeBoundingBoxes(
+				Collections.singletonList(structure), true, false, positions, boxes);
+
+		Layout layout = new Layout();
+		layout.all = all;
+		int at = 0;
+		for (Residue residue : structure.getAllResidues()) {
+			Rectangle rectangle = boxes.getCurrent(residue);
+			// Keyed by order rather than by residue: the same residue can appear twice in the walk,
+			// and both appearances are drawn.
+			if (rectangle != null) layout.rectangles.put(at++, rectangle);
+		}
+		assertTrue("nothing was laid out at all", !layout.rectangles.isEmpty());
+
+		return layout;
+	}
+
+	private static final class Layout {
+		private Rectangle all;
+		private final Map<Integer, Rectangle> rectangles = new HashMap<Integer, Rectangle>();
+	}
+
+	private static Glycan gws(String sequence) throws Exception {
+		return Glycan.fromString(sequence);
+	}
+
+	private static Glycan wurcs(String sequence) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS would not import", document.importFromString(sequence, "wurcs2"));
+
+		return document.getStructures().get(0);
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import java.awt.Rectangle;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 
 import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
@@ -119,12 +120,12 @@ public class RenderingLayoutInvariantsTest {
 	}
 
 	/**
-	 * G42735RP, the structure of #71, which breaks both properties today.
+	 * G42735RP, the structure of #71, which puts a residue outside its own picture.
 	 *
-	 * <p>Two residues - an antenna's sialic acid, at linkage position 1 - are placed on the same
-	 * spot, outside the bounding box the renderer reports, and so are cut off by the edge of the
-	 * image. They never reach the list the bracket layout aligns and measures, so nothing sizes the
-	 * picture to include them.</p>
+	 * <p>The antenna's sialic acid, at linkage position 1, is placed outside the bounding box the
+	 * renderer reports, and so is cut off by the edge of the image: its rectangle runs to x=542 and
+	 * y=199 where the box ends at 512 and 185. It never reaches the list the bracket layout aligns
+	 * and measures, so nothing sizes the picture to include it.</p>
 	 *
 	 * <p>This test states the fault rather than the fix, so that the fault cannot quietly get
 	 * worse. <b>When #71 is fixed this test will fail</b> - that is what it is for. Move the
@@ -139,8 +140,9 @@ public class RenderingLayoutInvariantsTest {
 				+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
 				+ "_m1-f?|i?|k?}");
 
-		assertEquals("#71 looks fixed: no residue falls outside the box any more", 2, outside(structure));
-		assertEquals("#71 looks fixed: no two residues share a spot any more", 1, sharedSpots(structure));
+		assertEquals("#71 looks fixed: no residue falls outside the box any more",
+				1, outside(structure));
+		assertEquals("the escape is one residue, drawn once", 0, sharedSpots(structure));
 	}
 
 	/** Everything drawn is inside the box, and no two symbols sit on the same spot. */
@@ -187,12 +189,13 @@ public class RenderingLayoutInvariantsTest {
 
 		Layout layout = new Layout();
 		layout.all = all;
-		int at = 0;
 		for (Residue residue : structure.getAllResidues()) {
 			Rectangle rectangle = boxes.getCurrent(residue);
-			// Keyed by order rather than by residue: the same residue can appear twice in the walk,
-			// and both appearances are drawn.
-			if (rectangle != null) layout.rectangles.put(at++, rectangle);
+			// Keyed by identity, because the walk can hand back the same residue twice - an
+			// antenna reachable from both the root and the bracket comes back on both. Counting
+			// those as two residues on one spot would report a drawing fault where there is only
+			// one residue, drawn once.
+			if (rectangle != null) layout.rectangles.put(residue, rectangle);
 		}
 		assertTrue("nothing was laid out at all", !layout.rectangles.isEmpty());
 
@@ -201,7 +204,7 @@ public class RenderingLayoutInvariantsTest {
 
 	private static final class Layout {
 		private Rectangle all;
-		private final Map<Integer, Rectangle> rectangles = new HashMap<Integer, Rectangle>();
+		private final Map<Residue, Rectangle> rectangles = new IdentityHashMap<Residue, Rectangle>();
 	}
 
 	private static Glycan gws(String sequence) throws Exception {


### PR DESCRIPTION
Release 1.33.0.

Three fixes from the tracker, and the groundwork the remaining drawing issues need.

* **#10** — the application did not start on Windows. A first run saved the configuration to the path it had just tried to read it from, so the write went to the working directory of whatever launched it: `C:\WINDOWS\system32` from the start menu, where it is denied. It saves to the per-user location now.
* **#4** — every glycosidic bond was `UNVALIDATED`. The pass that works linkage types out had no branch for an ordinary sugar–sugar bond, and ran only in the WURCS writer; all three readers run it now, and nothing written out changes (seven structures, three formats, byte-identical before and after).
* **#62** — a glycan was drawn differently depending on whether it was read from WURCS or GlycoCT, because the GlycoCT reader dropped the residues an antenna may hang from. Eleven parents on both routes now, and the two SVGs identical.
* **Groundwork for #58/#71** — properties every layout must satisfy, so a change in the middle of the renderer can be made without silently spoiling another structure. G42735RP of #71 breaks them, and its test says so.

102 tests, from 86.

Closes #10. Closes #4. Closes #62.

Not in this release, and worth knowing:

* **#17, #57, #67** do not reproduce on 1.32.0 — measured, including a render of #57's G03246MZ before and after, which is identical. They look fixed by earlier work and want confirmation from their reporters before closing.
* **#58 and #71** still reproduce and are untouched by this release: both were re-rendered before and after and the images are byte-identical, so their causes lie elsewhere in the layout. What is known about #71 is written up in the PR that added the invariants.
