### PR TITLE
Give an antenna one parent when reading WURCS (#71)

### DIFF
--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/WURCSSequence2ToGlycan.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/WURCSSequence2ToGlycan.java
@@ -59,6 +59,7 @@ public class WURCSSequence2ToGlycan {
 		// append ambiguous root
 		for(GRES gres : gres2frag.getRootOfFragments()) {
 			Residue fragRoot = this.gres2residue.get(gres);
+			this.detachFromNamedParent(fragRoot);
 			this.glycan.addAntenna(fragRoot, fragRoot.getParentLinkage().getBonds());
 		}
 
@@ -95,6 +96,34 @@ public class WURCSSequence2ToGlycan {
 
 			this.glycan.normalizeCompositionFlags();
 		}
+	}
+
+	/**
+	 * Take an antenna out of the tree it was provisionally linked into, so that the bracket
+	 * is its only parent.
+	 *
+	 * <p>A GRES whose attachment point is undetermined names several possible acceptors -
+	 * {@code m1-f?|i?|k?} in G42735RP. {@link #analyzeGLIN} has no way to choose between
+	 * them and links the residue to the first, then records every candidate with
+	 * {@link Residue#addParentOfFragment}; the same residue then becomes an antenna, a
+	 * child of the bracket. It ends up with two parents at once - a shape no tree can hold
+	 * - and everything that walks the structure meets it twice: the renderer lays it out
+	 * under the bracket and then translates it a second time along with the other parent's
+	 * subtree, which carries it clean out of the picture the renderer has sized, and the
+	 * writers put it in the sequence twice over (#71).</p>
+	 *
+	 * <p>The candidates are already recorded, so the provisional link has nothing left to
+	 * say. The linkage itself is put back on the residue after the parent lets go of it:
+	 * the bracket reads its positions and its linkage types when it adopts the residue.</p>
+	 */
+	private void detachFromNamedParent(Residue _fragRoot) {
+		if (_fragRoot == null) return;
+		Residue parent = _fragRoot.getParent();
+		if (parent == null) return;
+
+		Linkage provisional = _fragRoot.getParentLinkage();
+		parent.removeChild(_fragRoot);
+		_fragRoot.setParentLinkage(provisional);
 	}
 
 	private void analyzeGRES(GRES _gres) throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 /**
  * What has to be true of any layout, whatever it looks like.
  *
- * <p>The drawing issues left open - #58, #71, #29, #88 - all want changes in the middle of the
+ * <p>The drawing issues left open - #58, #29, #88 - all want changes in the middle of the
  * renderer, where a change meant to help one structure can quietly spoil another, and there was no
  * way to tell. Freezing the SVG of a set of structures would tell, but it would also fail on every
  * intentional improvement and say nothing about what went wrong: twelve kilobytes of path data
@@ -33,7 +33,7 @@ import org.junit.Test;
  *
  * <ul>
  *   <li>every residue lies within the bounding box the renderer reports - what is drawn outside it
- *       is clipped out of the image, which is how #71 shows itself;</li>
+ *       is clipped out of the image, which is how #71 showed itself;</li>
  *   <li>no two residues share a top-left corner - two symbols on the same spot are unreadable, and
  *       are a sign that one of them was never placed.</li>
  * </ul>
@@ -120,29 +120,21 @@ public class RenderingLayoutInvariantsTest {
 	}
 
 	/**
-	 * G42735RP, the structure of #71, which puts a residue outside its own picture.
+	 * G42735RP, the structure of #71, which used to put a residue outside its own picture.
 	 *
-	 * <p>The antenna's sialic acid, at linkage position 1, is placed outside the bounding box the
-	 * renderer reports, and so is cut off by the edge of the image: its rectangle runs to x=542 and
-	 * y=199 where the box ends at 512 and 185. It never reaches the list the bracket layout aligns
-	 * and measures, so nothing sizes the picture to include it.</p>
-	 *
-	 * <p>This test states the fault rather than the fix, so that the fault cannot quietly get
-	 * worse. <b>When #71 is fixed this test will fail</b> - that is what it is for. Move the
-	 * structure to a plain {@code assertLaidOutWithin} then, and delete this one.</p>
+	 * <p>The antenna's sialic acid, at linkage position 1, was laid out under the bracket and then
+	 * translated a second time along with the subtree it was also linked into, which left it at
+	 * x=520..542, y=177..199 where the box ended at 512 and 185 - outside the image, and so cut off
+	 * by its edge. It had two parents at once; it has one now, and lands inside the box.</p>
 	 */
 	@Test
-	public void theStructureOfIssue71IsStillDrawnOutsideItsOwnBox() throws Exception {
-		Glycan structure = wurcs(
+	public void theStructureOfIssue71IsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(wurcs(
 				"WURCS=2.0/7,13,12/[a2122h-1x_1-5_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O]"
 				+ "[a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5][a1221m-1a_1-5]"
 				+ "[Aad21122h-2a_2-6_5*NCC/3=O]/1-2-3-4-2-5-4-2-5-2-5-6-7"
 				+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
-				+ "_m1-f?|i?|k?}");
-
-		assertEquals("#71 looks fixed: no residue falls outside the box any more",
-				1, outside(structure));
-		assertEquals("the escape is one residue, drawn once", 0, sharedSpots(structure));
+				+ "_m1-f?|i?|k?}"));
 	}
 
 	/** Everything drawn is inside the box, and no two symbols sit on the same spot. */
@@ -191,10 +183,10 @@ public class RenderingLayoutInvariantsTest {
 		layout.all = all;
 		for (Residue residue : structure.getAllResidues()) {
 			Rectangle rectangle = boxes.getCurrent(residue);
-			// Keyed by identity, because the walk can hand back the same residue twice - an
-			// antenna reachable from both the root and the bracket comes back on both. Counting
-			// those as two residues on one spot would report a drawing fault where there is only
-			// one residue, drawn once.
+			// Keyed by identity, because the walk hands back a residue once per way it can be
+			// reached: an antenna linked into the tree as well as into the bracket comes back on
+			// both. Counting those as two residues on one spot would report a drawing fault where
+			// there is only one residue, drawn once - which is what #71 turned out to be.
 			if (rectangle != null) layout.rectangles.put(residue, rectangle);
 		}
 		assertTrue("nothing was laid out at all", !layout.rectangles.isEmpty());

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsAntennaHasOneParentTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsAntennaHasOneParentTest.java
@@ -1,0 +1,116 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an antenna read from WURCS hangs from the bracket and from nothing else (#71).
+ *
+ * <p>An antenna is a subtree whose attachment point is undetermined: it names the residues it may
+ * hang from, and is drawn from the bracket rather than from any one of them. Reading WURCS linked
+ * it to the first of the named residues as well - there is no way to choose between them, and the
+ * reader chose - so the residue had two parents at once, a shape no tree can hold.</p>
+ *
+ * <p>Everything that walks the structure then met it twice. The renderer laid it out under the
+ * bracket and translated it a second time along with the subtree it was also linked into, which put
+ * it outside the picture the renderer had sized; the writers emitted it twice, so G42735RP came
+ * back out of WURCS with fourteen residues where it went in with thirteen.</p>
+ *
+ * <p>The structure here is G42735RP, the one in the report.</p>
+ */
+public class WurcsAntennaHasOneParentTest {
+
+	/**
+	 * G42735RP: a fucosylated N-glycan whose sialic acid may hang from any of three galactoses.
+	 *
+	 * <p>{@code m1-f?|i?|k?} is the part that matters - residue m, the NeuAc, named against f, i
+	 * and k with the position on each of them unknown.</p>
+	 */
+	private static final String WITH_AN_AMBIGUOUS_ANTENNA =
+			"WURCS=2.0/7,13,12/[a2122h-1x_1-5_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O]"
+			+ "[a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5][a1221m-1a_1-5]"
+			+ "[Aad21122h-2a_2-6_5*NCC/3=O]/1-2-3-4-2-5-4-2-5-2-5-6-7"
+			+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
+			+ "_m1-f?|i?|k?}";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The antenna is the bracket's child, and nobody else's. */
+	@Test
+	public void theAntennaHangsFromTheBracketAlone() throws Exception {
+		Glycan structure = read(WITH_AN_AMBIGUOUS_ANTENNA);
+		Residue bracket = structure.getBracket();
+
+		assertEquals("the bracket should carry the one antenna", 1, bracket.getNoChildren());
+		Residue antenna = bracket.getChildAt(0);
+		assertSame("the antenna is linked to a residue as well as to the bracket",
+				bracket, antenna.getParent());
+		assertEquals("the antenna is still a child of a residue in the tree",
+				0, timesReachedFrom(structure.getRoot(), antenna));
+	}
+
+	/** And it still knows which residues it may hang from, which is what says where to draw it. */
+	@Test
+	public void theAntennaKeepsTheParentsItMayHangFrom() throws Exception {
+		Glycan structure = read(WITH_AN_AMBIGUOUS_ANTENNA);
+
+		Residue antenna = structure.getBracket().getChildAt(0);
+		assertEquals("the antenna should name the three residues f, i and k",
+				3, antenna.getParentsOfFragment().size());
+	}
+
+	/** So the walk meets each residue once, and the writers say the structure once. */
+	@Test
+	public void theStructureIsWrittenOutAsOneOfEachResidue() throws Exception {
+		Glycan structure = read(WITH_AN_AMBIGUOUS_ANTENNA);
+
+		// the thirteen residues of the sequence, plus the free end and the bracket
+		assertEquals("a residue is reachable twice, so it will be written twice",
+				15, structure.getAllResidues().size());
+
+		String written = writeAs(structure, "wurcs2");
+		assertTrue("the antenna came out twice: " + written, written.startsWith("WURCS=2.0/7,13,12/"));
+	}
+
+	/** How many times the antenna can be reached by walking down from a residue. */
+	private static int timesReachedFrom(Residue from, Residue antenna) {
+		if (from == null) return 0;
+
+		int found = 0;
+		for (int i = 0; i < from.getNoChildren(); i++) {
+			Residue child = from.getChildAt(i);
+			if (child == antenna) found++;
+			found += timesReachedFrom(child, antenna);
+		}
+
+		return found;
+	}
+
+	private static Glycan read(String sequence) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS would not import", document.importFromString(sequence, "wurcs2"));
+
+		return document.getStructures().get(0);
+	}
+
+	private static String writeAs(Glycan structure, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.exportFromStructure(document.getStructures(), format);
+		assertTrue("nothing came out as " + format, !document.getString().isEmpty());
+
+		return document.getString().get(0);
+	}
+}


### PR DESCRIPTION
Fixes #71.

An antenna - a subtree whose attachment point is undetermined - names the residues it may hang
from and is drawn from the bracket, not from any one of them. G42735RP names three,
`m1-f?|i?|k?`, and the reader, having no way to choose, linked the residue to the first and then
handed the same residue to `addAntenna`, which made it a child of the bracket as well. A
`Residue` carries one parent linkage but a parent keeps its own list of children, so the Gal went
on listing the NeuAc while the NeuAc's parent read `#bracket`: two parents at once, a shape no
tree can hold.

Everything that walks the structure then met it twice. `BBoxManager` translates by walking
children and the renderer translates the root subtree and the bracket subtree in turn, so the
NeuAc - laid out under the bracket - was moved a second time and came to rest at x=520..542,
y=177..199, outside the box the renderer reported (30..512, 30..185) and cut off by the edge of
the image, which is what the report shows. The writers said it twice too: G42735RP went in as
`7,13,12` and came back out of WURCS as `8,14,13+`, with a NeuAc carrying its N-acetyl twice.

The candidates are recorded by `addParentOfFragment` before this, so the provisional link has
nothing left to say; the antenna is taken out of that subtree before it joins the bracket,
keeping its linkage so the bracket can read the positions and linkage types. This is the shape
the GlycoCT reader already builds (#62). **Nothing in the renderer changed.**

## Measured

On the 107 WURCS strings in the test sources, read and written and drawn before and after: only
G42735RP differs. Its SVG goes from 35008 to 32732 bytes and its round trip from `8,14,13+` back
to `7,13,12`. 105 tests pass.

The characterisation test that held the fault in place is now a plain `assertLaidOutWithin`, and
`WurcsAntennaHasOneParentTest` states what the reader has to produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
