### PR TITLE
Read an antenna written the other way round by role (#150)

### DIFF
--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
@@ -147,7 +147,7 @@ public class GLINToLinkage {
 					if(this.isFacingBetweenAnomer(acceptorGLIN) || !acceptorGLIN.getMAP().equals("") || this.isLinkageWithUnknown(acceptorGLIN))
 						this.analyzeGLINforChild(acceptorGLIN);
 					else if(this.isReverse)
-						this.analyzeGLINforParent(acceptorGLIN);
+						this.analyzeReverseAntennaGLIN(acceptorGLIN);
 					else
 						this.analyzeEndSideCyclic(acceptorGLIN);
 				}
@@ -207,6 +207,41 @@ public class GLINToLinkage {
 
 		// probability annotation
 		this.extractProbabilityAnnotation(_donorGLIN, linkage);
+	}
+
+	/**
+	 * Read the linkage of an antenna written the other way round.
+	 *
+	 * <p>An antenna - a subtree whose attachment point is undetermined - names the residues it
+	 * may hang from, and WURCS writes the two sides in whichever order puts the residue linking
+	 * through its anomeric carbon on the donor side. A sialic acid leaves from C2, so
+	 * {@code l2-a?|...|k?} is written antenna first as a donor and read by
+	 * {@link #analyzeGLINforParent}. G42735RP says {@code m1-f?|i?|k?} instead - position 1 on
+	 * a residue whose anomeric carbon is 2 - and the sequence is then parsed the other way
+	 * round, with the antenna as the acceptor and its candidates as donors. That is the case
+	 * {@link #setGRESs} calls a reverse antenna.</p>
+	 *
+	 * <p>The two sides mean the opposite of what {@link #analyzeGLINforParent} reads them as,
+	 * so it took the antenna's own 1 for the position on each candidate: the structure was
+	 * drawn as 1-linked to the galactoses and written back as {@code m2-f1|i1|k1}, stating a
+	 * definite position where the sequence had said it was unknown. Here the sides are read for
+	 * what they are - the acceptor side names the antenna, the donor side its candidates.</p>
+	 */
+	private void analyzeReverseAntennaGLIN(GLIN _acceptorGLIN) {
+		if(_acceptorGLIN.getDonor().size() < 2) {
+			// not an antenna after all: leave it to the reading that does not swap the sides
+			this.analyzeGLINforParent(_acceptorGLIN);
+			return;
+		}
+
+		char[] antennaPositions = this.makeLinkagePosiiton(_acceptorGLIN.getAcceptorPositions());
+		char[] candidatePositions = this.makeLinkagePosiiton(_acceptorGLIN.getDonorPositions());
+
+		Linkage linkage = new Linkage(null, this.acceptorRES, candidatePositions);
+		linkage.setAnomericCarbon(antennaPositions[0]);
+		this.acceptorLinkages.add(linkage);
+
+		this.extractProbabilityAnnotation(_acceptorGLIN, linkage);
 	}
 
 	/*
@@ -429,6 +464,11 @@ public class GLINToLinkage {
 
 		for(GLIN a_oDGLIN : _gres.getDonorGLINs()) {
 			if(a_oDGLIN.isRepeat()) continue;
+			// A reverse antenna is written with its candidates on the donor side, so this residue
+			// can be here only as one of them - the antenna is not its parent, and taking it for
+			// one leaves the residue with two and drops it from the structure. analyzeDonorGLIN
+			// passes over the same GLINs.
+			if(a_oDGLIN.getDonor().size() > 1) continue;
 			for(GRES a_oAGRES : a_oDGLIN.getAcceptor()) {
 				if(this.acceptorGRESs.contains(a_oAGRES)) continue;
 				if(_gres.getID() - a_oAGRES.getID() > 0) this.acceptorGRESs.add(a_oAGRES);

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
@@ -45,8 +45,14 @@ public class LinkageConnector {
 			donor.setParentLinkage(_glin2linkage.getStartSideRepLinkage());
 		}
 
-		if(_glin2linkage.getDonorGLINs().isEmpty()) {
+		if(_glin2linkage.getDonorGLINs().isEmpty() || this.acceptor == null) {
 			//　start-rep is root node
+			//
+			// Or there is no residue to attach this one to. A residue named among an antenna's
+			// candidates is a donor of that ambiguous linkage, so it can reach here looking as
+			// though it had a parent, while the reading found no acceptor for it - the reducing
+			// end of G00955WX does, if the antenna is written l1-a?|...|k?. It used to walk into
+			// isOutRepeating and fail on a null acceptor, and the sequence would not read at all.
 			this.analyzeBracketNotation (donor, null, _glin2linkage);
 			return;
 		}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AmbiguousLinkageKeepsUnknownPositionsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AmbiguousLinkageKeepsUnknownPositionsTest.java
@@ -1,0 +1,125 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an antenna written the other way round still says its position is unknown (#150).
+ *
+ * <p>An antenna names the residues it may hang from, and WURCS writes the two sides in whichever
+ * order puts the residue linking through its anomeric carbon on the donor side. A sialic acid
+ * leaves from C2, so G00955WX is written {@code l2-a?|…|k?} - antenna first, as the donor. G42735RP
+ * says {@code m1-f?|i?|k?} instead, position 1 on a residue whose anomeric carbon is 2, and is
+ * parsed the other way round: the antenna as the acceptor, its candidates as donors.</p>
+ *
+ * <p>Reading it as though the sides meant the usual thing took the antenna's own 1 for the position
+ * on each candidate. The structure came out drawn as 1-linked to the galactoses and written back as
+ * {@code m2-f1|i1|k1} - a definite position where the sequence said it was unknown. The same shape
+ * on G00955WX did not read at all.</p>
+ */
+public class AmbiguousLinkageKeepsUnknownPositionsTest {
+
+	/** G42735RP as registered: the antenna written on the acceptor side, at position 1. */
+	private static final String THE_OTHER_WAY_ROUND =
+			"WURCS=2.0/7,13,12/[a2122h-1x_1-5_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O]"
+			+ "[a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5][a1221m-1a_1-5]"
+			+ "[Aad21122h-2a_2-6_5*NCC/3=O]/1-2-3-4-2-5-4-2-5-2-5-6-7"
+			+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
+			+ "_m1-f?|i?|k?}";
+
+	/** The same structure with the sialic acid's own anomeric carbon, which was always read right. */
+	private static final String THE_USUAL_WAY_ROUND =
+			THE_OTHER_WAY_ROUND.replace("_m1-f?|i?|k?}", "_m2-f?|i?|k?}");
+
+	/** G00955WX, whose antenna is written the usual way round. */
+	private static final String G00955WX =
+			"WURCS=2.0/5,12,11/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]"
+			+ "[a2112h-1b_1-5][Aad21122h-2a_2-6_5*NCC/3=O]/1-1-2-3-1-4-1-4-3-1-4-5"
+			+ "/a4-b1_b4-c1_c3-d1_c6-i1_d2-e1_d4-g1_e4-f1_g4-h1_i2-j1_j4-k1"
+			+ "_l2-a?|b?|c?|d?|e?|f?|g?|h?|i?|j?|k?}";
+
+	/** And the same, written the other way round - the shape that would not read at all. */
+	private static final String G00955WX_THE_OTHER_WAY_ROUND =
+			G00955WX.replace("_l2-a?", "_l1-a?");
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The position on the residues the antenna may hang from is unknown, and stays unknown. */
+	@Test
+	public void theAntennaDoesNotClaimAPositionOnItsCandidates() throws Exception {
+		Residue antenna = read(THE_OTHER_WAY_ROUND).getBracket().getChildAt(0);
+
+		assertEquals("the antenna's own position was taken for the position on its candidates",
+				"?", antenna.getParentLinkage().getParentPositionsString());
+	}
+
+	/** So it is written back saying what it was given: f, i and k at an unknown position. */
+	@Test
+	public void theUnknownPositionsSurviveTheRoundTrip() throws Exception {
+		String written = writeAs(read(THE_OTHER_WAY_ROUND), "wurcs2");
+
+		assertTrue("a definite position was invented on the candidates: " + written,
+				written.endsWith("_m2-f?|i?|k?}"));
+	}
+
+	/**
+	 * And it is drawn as the same glycan either way round, which is the point.
+	 *
+	 * <p>The two sequences say the same thing about where the sialic acid may go; only the position
+	 * written beside the sialic acid itself differs, and that is not what the picture shows.</p>
+	 */
+	@Test
+	public void bothWaysRoundDrawTheSamePicture() throws Exception {
+		assertEquals("the same antenna is drawn differently depending on how it was written",
+				draw(read(THE_USUAL_WAY_ROUND)), draw(read(THE_OTHER_WAY_ROUND)));
+	}
+
+	/**
+	 * The other way round reads at all, and keeps every residue.
+	 *
+	 * <p>G00955WX written that way used to fail to import - a null acceptor in LinkageConnector -
+	 * and the reading that replaced the crash dropped the last galactose, because the antenna was
+	 * taken for that residue's parent as well.</p>
+	 */
+	@Test
+	public void nothingIsLostWhenTheAntennaIsWrittenTheOtherWayRound() throws Exception {
+		assertEquals("residues went missing when the antenna was written the other way round",
+				read(G00955WX).getAllResidues().size(),
+				read(G00955WX_THE_OTHER_WAY_ROUND).getAllResidues().size());
+	}
+
+	private static String draw(Glycan structure) throws Exception {
+		return SVGUtils.getVectorGraphics(
+				new GlycanRendererAWT(), Collections.singletonList(structure), false, false);
+	}
+
+	private static Glycan read(String sequence) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS would not import", document.importFromString(sequence, "wurcs2"));
+
+		return document.getStructures().get(0);
+	}
+
+	private static String writeAs(Glycan structure, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.exportFromStructure(document.getStructures(), format);
+		assertTrue("nothing came out as " + format, !document.getString().isEmpty());
+
+		return document.getString().get(0);
+	}
+}


### PR DESCRIPTION
Stacked on #151 (`fix/antenna-escapes-bounding-box`) - review that one first, and this diff alone
once it lands. Addresses options 1 and 2 of #150; option 3 is a question for @edwardsnj and is
left open.

An antenna names the residues it may hang from, and WURCS writes the two sides in whichever order
puts the residue linking through its anomeric carbon on the donor side. A sialic acid leaves from
C2, so G00955WX is written `l2-a?|…|k?` - antenna first, as the donor. G42735RP says
`m1-f?|i?|k?` instead, position 1 on a residue whose anomeric carbon is 2, and WURCS then parses
it the other way round: the antenna as the acceptor, its candidates as donors. `setGRESs` already
recognises this and calls it a reverse antenna.

Read as though the sides meant the usual thing, the antenna's own 1 was taken for the position on
each candidate. The sides are now read for what they are - the acceptor side names the antenna,
the donor side its candidates - and an unknown position stays unknown.

Two more things followed from the same reading. A residue named among an antenna's candidates is
a donor of that ambiguous linkage, so it looked as though the antenna were its parent, which left
it with two parents and dropped it from the structure; and the reducing end could reach
`LinkageConnector` with nothing to attach to and fail on a null acceptor, so G00955WX written that
way would not import at all. `setGRESs` now passes over ambiguous linkages, as `analyzeDonorGLIN`
already did, and `LinkageConnector` says there is nothing to attach rather than following a null
pointer - one of the null pointers #123 is about.

|  | before | after |
|---|---|---|
| G42735RP, antenna's parent position | `1` | `?` |
| G42735RP, round trip | `_m2-f1\|i1\|k1}` | `_m2-f?\|i?\|k?}` |
| G42735RP, drawn | `α 1` | `α ?` |
| G00955WX written `l1-a?\|…\|k?` | does not import | imports, keeps all 12 residues |

## Measured

On the 107 WURCS strings in the test sources, read and written and drawn before and after: only
G42735RP differs, and it now draws byte for byte the picture its well-formed twin `m2-f?|i?|k?`
draws. 109 tests pass, four of them new in `AmbiguousLinkageKeepsUnknownPositionsTest`.

## Still open

What the sequence says about the sialic acid's own position is not kept: it is written back as
`m2-`, its anomeric carbon, not the `m1-` it was given. That normalisation is what makes the
picture right, but the round trip is not byte-identical for G42735RP and would not be until
GlycanBuilder can hold a Neu5Ac linked through C1. Asked on #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
