### PR TITLE
Draw a composition whether or not the reducing end is marked (#153)

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
@@ -278,7 +278,12 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 	 */
 	protected boolean laysOutAglycon(Glycan structure, boolean show_redend) {
 		if (structure == null) return show_redend;
-		if (structure.isComposition()) return show_redend;
+		// A composition is laid out from its aglycon whether or not the aglycon is drawn: its
+		// residues all hang from the bracket, and the free end is the only thing the bracket can
+		// be placed against. Asking for the root past the free end gives nothing, and a
+		// composition asked for without the reducing-end marker came out as an empty picture
+		// (#153). Whether the marker is painted is a separate question - see paintsAglycon.
+		if (structure.isComposition()) return true;
 		return GlycanUtils.isShowRedEnd(structure, theGraphicOptions, true);
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/GlycanRendererAWT.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/GlycanRendererAWT.java
@@ -131,7 +131,10 @@ public class GlycanRendererAWT extends AbstractGlycanRenderer {
 	protected void displayLegend(Paintable paintable, Glycan structure, boolean show_redend, BBoxManager bboxManager) {
 		Graphics2D g2d = paintable.getGraphics2D();
 		Rectangle structure_all_bbox = bboxManager.getComplete(structure.getRoot(laysOutAglycon(structure, show_redend)));
-		
+		// nothing was laid out, so there is nowhere to put a legend. Measuring the box that was
+		// never computed threw a NullPointerException out of the middle of painting (#153, #123).
+		if (structure_all_bbox == null) return;
+
 		g2d.setColor(Color.black);
 		g2d.setFont(new Font(theGraphicOptions.MASS_TEXT_FONT_FACE, Font.PLAIN, 10));
 		
@@ -178,6 +181,8 @@ public class GlycanRendererAWT extends AbstractGlycanRenderer {
 		Graphics2D g2d=paintable.getGraphics2D();
 		Rectangle structure_all_bbox = bboxManager.getComplete(structure
 				.getRoot(laysOutAglycon(structure, show_redend)));
+		// as in displayLegend: nothing laid out, nowhere to put the mass (#153, #123)
+		if (structure_all_bbox == null) return;
 
 		g2d.setColor(Color.black);
 		g2d.setFont(new Font(theGraphicOptions.MASS_TEXT_FONT_FACE, Font.PLAIN,

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionIsDrawnWithoutTheReducingEndTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionIsDrawnWithoutTheReducingEndTest.java
@@ -1,0 +1,99 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.Collections;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a composition is drawn whether or not the reducing-end marker is shown (#153).
+ *
+ * <p>A composition has no residue privileged as the reducing end: its members all hang from the
+ * bracket and the free end is only a marker. The renderer laid it out from the residue past that
+ * marker, which for a composition is nothing at all, so asking for one without the marker gave an
+ * empty picture - a blank 1x1 SVG, or a NullPointerException out of the middle of painting when
+ * the legend went to measure the box that had never been computed.</p>
+ *
+ * <p>Whether the marker is <em>drawn</em> is a display preference. Whether the composition is drawn
+ * should not follow it.</p>
+ */
+public class CompositionIsDrawnWithoutTheReducingEndTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The layout has a size, which is what the picture is cut to. */
+	@Test
+	public void aCompositionIsLaidOutWithoutTheReducingEnd() throws Exception {
+		Rectangle box = layoutOf(composition(), false);
+
+		assertTrue("a composition laid out to nothing: " + box, box.width > 1 && box.height > 1);
+	}
+
+	/** And it draws, where it used to throw. */
+	@Test
+	public void aCompositionIsDrawnWithoutTheReducingEnd() throws Exception {
+		BufferedImage image = new GlycanRendererAWT().getImage(composition(), false, false, false, 1.0);
+
+		assertNotNull("nothing was drawn", image);
+		assertTrue("the image is empty: " + image.getWidth() + "x" + image.getHeight(),
+				image.getWidth() > 1 && image.getHeight() > 1);
+	}
+
+	/**
+	 * The same picture either way, because there is no reducing end for the marker to mark.
+	 *
+	 * <p>The composition's free end is never painted - {@code paint} draws the bracket and leaves
+	 * the core alone - so the flag has nothing to act on here.</p>
+	 */
+	@Test
+	public void aCompositionIsDrawnTheSameEitherWay() throws Exception {
+		assertEquals("a composition is drawn differently depending on the reducing-end marker",
+				draw(composition(), true), draw(composition(), false));
+	}
+
+	/** An ordinary glycan still minds the marker, which is the point of the preference. */
+	@Test
+	public void anOrdinaryGlycanStillMindsTheReducingEnd() throws Exception {
+		Glycan chain = Glycan.fromString("freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd");
+
+		assertNotEquals("the reducing-end marker stopped making any difference",
+				draw(chain, true), draw(chain, false));
+	}
+
+	/** Two hexoses, unlinked and unordered - the smallest thing that is a composition. */
+	private static Glycan composition() throws Exception {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.getCompositionOptions().HEX = 2;
+		Glycan composition =
+				workspace.getCompositionOptions().getCompositionAsGlycan(workspace.getDefaultMassOptions());
+		assertTrue("this was meant to be a composition", composition.isComposition());
+
+		return composition;
+	}
+
+	private static Rectangle layoutOf(Glycan structure, boolean showReducingEnd) throws Exception {
+		return new GlycanRendererAWT().computeBoundingBoxes(Collections.singletonList(structure),
+				false, showReducingEnd, new PositionManager(), new BBoxManager());
+	}
+
+	private static String draw(Glycan structure, boolean showReducingEnd) throws Exception {
+		return SVGUtils.getVectorGraphics(new GlycanRendererAWT(),
+				Collections.singletonList(structure), false, showReducingEnd);
+	}
+}


### PR DESCRIPTION
Fixes #153. Off `develop`, independent of #151 and #152.

A composition has no residue privileged as the reducing end: its members all hang from the bracket
and the free end is a marker for "nothing is attached here". The renderer laid it out from the
residue past that marker - nothing at all, for a composition - so asking for one without the marker
gave an empty picture: a blank 1×1 SVG, or a `NullPointerException` from `displayLegend` when it
went to measure a box that had never been computed.

`laysOutAglycon` now says yes for a composition however the marker is set. The distinction it
exists for is already there: `paintsAglycon`, which is `laysOutAglycon && show_redend`, still
decides whether the free end is *painted*, and `paint()` draws only the bracket for a composition
anyway - so a composition comes out the same either way, as it should.

`displayLegend` and `displayMass` return instead of measuring a box that was never computed.
Nothing reaches them with an empty layout now, but they were one dereference away from a stack
trace out of the middle of painting - the sort of thing #123 is about.

## Measured

| | `show_redend = false` | `show_redend = true` |
|---|---|---|
| composition (Hex2), before | blank 1×1 SVG; `getImage` threw NPE | 144×82 |
| composition (Hex2), after | 144×82, byte for byte the same picture | 144×82 |
| ordinary glycan, before and after | drawn, and still different from ↓ | drawn |

The compositions of #17 - G00771KP and G49174JP - draw. 106 tests pass, four of them new in
`CompositionIsDrawnWithoutTheReducingEndTest`; without the fix three of those four fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
