### PR TITLE
Move batik and fop to 1.19 / 2.11 together (#144)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,51 +144,53 @@
 		</plugins>
 	</build>
 
-	<!-- fop 2.2 (the first release past CVE-2017-5661) ships the batik 1.9 family, while the
-	     flamingo ribbon drags in batik-transcoder 1.7 - and a 1.7 transcoder in front of 1.9 jars
-	     fails at runtime with NoClassDefFoundError on the first PDF/PS/EPS export. One batik, the
-	     one fop was built against. TranscoderSmokeTest is what holds this true at runtime. -->
+	<!-- fop ships one batik family, while the flamingo ribbon drags in batik-transcoder 1.7 - and a
+	     1.7 transcoder in front of another family's jars fails at runtime with NoClassDefFoundError
+	     on the first PDF/PS/EPS export. One batik, the one fop was built against: 1.19 for fop 2.11,
+	     which is what fop-parent's batik.version says. TranscoderSmokeTest is what holds this true
+	     at runtime. These pins do not travel - dependencyManagement is not transitive - so a
+	     consumer that puts batik on its own classpath has to move in the same step (#144). -->
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-transcoder</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-swing</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-dom</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-svggen</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-util</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-xml</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-css</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-gui-util</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -212,10 +214,12 @@
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>fop</artifactId>
-			<!-- 2.2 is the first release past CVE-2017-5661 (XXE in the FO/area-tree readers).
-			     Kept at the minimum that clears the advisory rather than the newest, since this is
-			     a security revision and not an upgrade. -->
-			<version>2.2</version>
+			<!-- Past CVE-2017-5661 (XXE in the FO/area-tree readers), and built against batik 1.19,
+			     which clears the SSRF and remote-class-loading run that ended at 1.9 - CVE-2019-17566,
+			     CVE-2020-11987 and the 2022 group including CVE-2022-44729. fop cannot be moved
+			     without batik or the other way round; see the note above dependencyManagement. Both
+			     target Java 8, so no consumer changes JDK for this. -->
+			<version>2.11</version>
 		</dependency>
 		<dependency>
 			<groupId>jdom</groupId>


### PR DESCRIPTION
Fixes #144 (the batik/fop half; the log4j-core note at the end of that issue is separate and not
touched here). Off `develop`, independent of anything else in flight.

batik was pinned at 1.9 (2017) and fop at 2.2, and both travel to every consumer as compile
dependencies. Batik 1.9 carries the SSRF and remote-class-loading run fixed later in the 1.x line -
CVE-2019-17566, CVE-2020-11987, and the 2022 group including **CVE-2022-44729, the alert Dependabot
has open against this repository**.

They have to move together: fop is built against one batik family, and mixing families fails at
runtime rather than at build time. `fop-parent` names the family it was built against, so the pairs
are not a guess:

| fop | batik |
|---|---|
| 2.9 | 1.17 |
| 2.10 | 1.18 |
| **2.11** | **1.19** |

Both target Java 8 (`maven.compiler.release`), so nothing downstream changes JDK for this.

## Measured

**Here:** 113 tests pass, `TranscoderSmokeTest` among them - it is what catches a mixed pair, since
the failure is a `NoClassDefFoundError` on the first PDF/PS/EPS export rather than a compile error.

**Against glycanbuilder2web**, with its own eleven batik pins and two direct batik dependencies
moved to match: one batik family across all 19 artifacts, fop 2.11, dependency convergence passes,
the WAR builds. The app starts, draws an N-glycan core, computes its mass, and exports; every format
the library offers comes out with the right magic bytes - PDF `%PDF-1`, PS and EPS `%!PS-A`, PNG,
JPG, BMP, SVG - with no server-side exception.

## For consumers

`dependencyManagement` is not transitive, so these pins do not travel. A consumer that pins batik
itself - as glycanbuilder2web does, because the flamingo ribbon drags in a 1.7 transcoder - has to
move in the same step, or it will hold the old family in front of the new fop and fail on the first
export.

Dependabot PR #143 should be closed with this: it bumps `batik-transcoder` alone, which is exactly
the mix that breaks, and it targets `master` rather than `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
