### PR TITLE
Declare each plugin once, and each version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,9 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+				<!-- The version this build had been resolving to. Without it Maven picks whatever
+				     the machine happens to offer, so two checkouts can run a different plugin. -->
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -95,9 +98,18 @@
 			</plugin>
 
 			<plugin>
-				<!-- explicitly define maven-deploy-plugin after other to force exec 
-					order -->
+				<!-- Declared once. It used to be declared twice - once to bind the deploy goal
+				     "after other to force exec order", once to carry the version and the
+				     repository - and Maven warned that a plugin must be declared only once,
+				     saying such a build might not be accepted by later versions. Order within a
+				     phase follows the order the plugins are declared in, which this single
+				     declaration keeps: before site-maven-plugin, whose site goal is bound to the
+				     same phase and publishes what this writes. -->
 				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
+				<configuration>
+					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+				</configuration>
 				<executions>
 					<execution>
 						<id>deploy</id>
@@ -107,14 +119,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-
-			<plugin>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
-				<configuration>
-					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-				</configuration>
 			</plugin>
 
 			<plugin>
@@ -222,7 +226,11 @@
 			<version>2.11</version>
 		</dependency>
 		<dependency>
-			<groupId>jdom</groupId>
+			<!-- org.jdom, not the pre-relocation jdom:jdom this asked for: Maven followed the
+			     relocation to exactly this artifact and said so on every build. Naming it directly
+			     resolves the same jar and spares consumers a coordinate they have to know about
+			     to manage the version. -->
+			<groupId>org.jdom</groupId>
 			<artifactId>jdom</artifactId>
 			<version>1.1</version>
 		</dependency>


### PR DESCRIPTION
Three things the build said about this pom on every run, none of them about the code:

```
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate
          declaration of plugin org.apache.maven.plugins:maven-deploy-plugin @ line 112
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:exec-maven-plugin is missing @ line 72
[WARNING] The artifact jdom:jdom:jar:1.1 has been relocated to org.jdom:jdom:jar:1.1
```

* **maven-deploy-plugin was declared twice** — once to bind its goal "after other to force exec
  order", once to carry the version and the repository. Maven's warning adds that future versions
  might no longer accept such a build. Now one declaration, in the same position in the plugin list,
  so goal order within the `deploy` phase is unchanged: still before site-maven-plugin, whose `site`
  goal publishes what deploy writes.
* **exec-maven-plugin had no version**, so the build ran whichever plugin the machine happened to
  offer. Pinned at 3.1.0 — the version it was resolving to here.
* **jdom was asked for as `jdom:jdom`**, the coordinates it had before moving to `org.jdom`. Named
  directly now: the same jar, and one less coordinate a consumer has to know about to manage the
  version — glycanbuilder2web currently pins `org.jdom:jdom` to settle exactly this.

## Nothing about the build changed

* effective pom, before vs after the first two changes: **byte-identical** (`mvn help:effective-pom`)
* resolved dependency list, before vs after the jdom change: **identical**, 69 artifacts
* 113 tests pass; `-P make-fat-jar package` builds both jars
* a plain `mvn validate` now prints no warnings at all

## Left alone deliberately

The `deploy` phase runs `deploy:deploy` **twice** — once as the lifecycle's `default-deploy`, once
as the explicit execution kept above. That is what it did before this change as well, so this PR
does not alter it; dropping the explicit execution touches the release path and is worth deciding on
its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
