### PR TITLE
Release 1.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,48 @@
 ## Change log
+### 1.34.0  (20260810)
+* Gave an antenna one parent when reading WURCS, so it is no longer drawn outside its own
+  picture (#71)
+  * An antenna names the residues it may hang from and is drawn from the bracket; G42735RP names
+    three and the reader, having no way to choose, linked the residue to the first and then made
+    it a child of the bracket as well - two parents at once, which no tree can hold
+  * Everything that walks the structure then met it twice: the renderer laid the sialic acid out
+    under the bracket and translated it a second time along with the other parent's subtree,
+    leaving it outside the box the renderer had reported and cut off by the edge of the image
+  * The writers said it twice too - G42735RP went in as 7,13,12 and came back out of WURCS as
+    8,14,13+, with a NeuAc carrying its N-acetyl twice
+  * Measured on the 107 WURCS strings in the test sources: only G42735RP differs
+* Read an antenna written the other way round by role (#150)
+  * WURCS writes the two sides of a linkage in whichever order puts the residue linking through
+    its anomeric carbon on the donor side; G42735RP says m1-f?|i?|k?, position 1 on a residue
+    whose anomeric carbon is 2, and is parsed the other way round
+  * Read as though the sides meant the usual thing, the antenna's own 1 was taken for the
+    position on each candidate: the structure was drawn as 1-linked to its galactoses and written
+    back as m2-f1|i1|k1, stating a definite position where the sequence said it was unknown
+  * The same reading left a candidate residue with two parents, dropping it from the structure,
+    and could hand LinkageConnector a null acceptor - G00955WX written that way did not import
+  * G42735RP now draws byte for byte the picture its well-formed twin draws
+* Drew a composition whether or not the reducing-end marker is shown (#153)
+  * A composition has no residue privileged as the reducing end, and the renderer laid it out
+    from the residue past that marker - nothing at all - so asking for one without the marker
+    gave a blank 1x1 image, or a NullPointerException from the legend measuring a box that had
+    never been computed
+  * Whether the marker is drawn is a display preference; whether the composition is drawn no
+    longer follows it
+* Moved batik to 1.19 and fop to 2.11, together (#144)
+  * batik 1.9 carries the SSRF and remote-class-loading run fixed later in the 1.x line -
+    CVE-2019-17566, CVE-2020-11987 and the 2022 group including CVE-2022-44729 - and both
+    libraries travel to every consumer
+  * They cannot move apart: fop is built against one batik family and mixing them fails at
+    runtime rather than at build time, so the pair comes from fop-parent's own batik.version
+  * Verified past the test suite: the desktop application starts on the new pair, and
+    glycanbuilder2web builds, runs and exports every format the library offers - PDF, PS, EPS,
+    PNG, JPG, BMP, SVG
+* Declared each plugin once, and each version
+  * maven-deploy-plugin was declared twice and exec-maven-plugin had no version, both of which
+    Maven warned about on every build, the first adding that future versions might no longer
+    accept such a build; jdom was asked for by its pre-relocation coordinates
+  * The effective pom and the resolved dependency list are unchanged - the build simply stopped
+    warning
 ### 1.33.0  (20260810)
 * Wrote the configuration where the user may write, so the application starts on Windows (#10)
   * A first run saved it to the path it had just tried to read it from - normally the bundled

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.33.0</version>
+	<version>1.34.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -144,51 +144,53 @@
 		</plugins>
 	</build>
 
-	<!-- fop 2.2 (the first release past CVE-2017-5661) ships the batik 1.9 family, while the
-	     flamingo ribbon drags in batik-transcoder 1.7 - and a 1.7 transcoder in front of 1.9 jars
-	     fails at runtime with NoClassDefFoundError on the first PDF/PS/EPS export. One batik, the
-	     one fop was built against. TranscoderSmokeTest is what holds this true at runtime. -->
+	<!-- fop ships one batik family, while the flamingo ribbon drags in batik-transcoder 1.7 - and a
+	     1.7 transcoder in front of another family's jars fails at runtime with NoClassDefFoundError
+	     on the first PDF/PS/EPS export. One batik, the one fop was built against: 1.19 for fop 2.11,
+	     which is what fop-parent's batik.version says. TranscoderSmokeTest is what holds this true
+	     at runtime. These pins do not travel - dependencyManagement is not transitive - so a
+	     consumer that puts batik on its own classpath has to move in the same step (#144). -->
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-transcoder</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-swing</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-dom</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-svggen</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-util</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-xml</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-css</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.xmlgraphics</groupId>
 				<artifactId>batik-gui-util</artifactId>
-				<version>1.9</version>
+				<version>1.19</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -212,10 +214,12 @@
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>fop</artifactId>
-			<!-- 2.2 is the first release past CVE-2017-5661 (XXE in the FO/area-tree readers).
-			     Kept at the minimum that clears the advisory rather than the newest, since this is
-			     a security revision and not an upgrade. -->
-			<version>2.2</version>
+			<!-- Past CVE-2017-5661 (XXE in the FO/area-tree readers), and built against batik 1.19,
+			     which clears the SSRF and remote-class-loading run that ended at 1.9 - CVE-2019-17566,
+			     CVE-2020-11987 and the 2022 group including CVE-2022-44729. fop cannot be moved
+			     without batik or the other way round; see the note above dependencyManagement. Both
+			     target Java 8, so no consumer changes JDK for this. -->
+			<version>2.11</version>
 		</dependency>
 		<dependency>
 			<groupId>jdom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,9 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>exec-maven-plugin</artifactId>
+				<!-- The version this build had been resolving to. Without it Maven picks whatever
+				     the machine happens to offer, so two checkouts can run a different plugin. -->
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<goals>
@@ -95,9 +98,18 @@
 			</plugin>
 
 			<plugin>
-				<!-- explicitly define maven-deploy-plugin after other to force exec 
-					order -->
+				<!-- Declared once. It used to be declared twice - once to bind the deploy goal
+				     "after other to force exec order", once to carry the version and the
+				     repository - and Maven warned that a plugin must be declared only once,
+				     saying such a build might not be accepted by later versions. Order within a
+				     phase follows the order the plugins are declared in, which this single
+				     declaration keeps: before site-maven-plugin, whose site goal is bound to the
+				     same phase and publishes what this writes. -->
 				<artifactId>maven-deploy-plugin</artifactId>
+				<version>2.8.2</version>
+				<configuration>
+					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
+				</configuration>
 				<executions>
 					<execution>
 						<id>deploy</id>
@@ -107,14 +119,6 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
-
-			<plugin>
-				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
-				<configuration>
-					<altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo</altDeploymentRepository>
-				</configuration>
 			</plugin>
 
 			<plugin>
@@ -222,7 +226,11 @@
 			<version>2.11</version>
 		</dependency>
 		<dependency>
-			<groupId>jdom</groupId>
+			<!-- org.jdom, not the pre-relocation jdom:jdom this asked for: Maven followed the
+			     relocation to exactly this artifact and said so on every build. Naming it directly
+			     resolves the same jar and spares consumers a coordinate they have to know about
+			     to manage the version. -->
+			<groupId>org.jdom</groupId>
 			<artifactId>jdom</artifactId>
 			<version>1.1</version>
 		</dependency>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
@@ -278,7 +278,12 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 	 */
 	protected boolean laysOutAglycon(Glycan structure, boolean show_redend) {
 		if (structure == null) return show_redend;
-		if (structure.isComposition()) return show_redend;
+		// A composition is laid out from its aglycon whether or not the aglycon is drawn: its
+		// residues all hang from the bracket, and the free end is the only thing the bracket can
+		// be placed against. Asking for the root past the free end gives nothing, and a
+		// composition asked for without the reducing-end marker came out as an empty picture
+		// (#153). Whether the marker is painted is a separate question - see paintsAglycon.
+		if (structure.isComposition()) return true;
 		return GlycanUtils.isShowRedEnd(structure, theGraphicOptions, true);
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/GlycanRendererAWT.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/GlycanRendererAWT.java
@@ -131,7 +131,10 @@ public class GlycanRendererAWT extends AbstractGlycanRenderer {
 	protected void displayLegend(Paintable paintable, Glycan structure, boolean show_redend, BBoxManager bboxManager) {
 		Graphics2D g2d = paintable.getGraphics2D();
 		Rectangle structure_all_bbox = bboxManager.getComplete(structure.getRoot(laysOutAglycon(structure, show_redend)));
-		
+		// nothing was laid out, so there is nowhere to put a legend. Measuring the box that was
+		// never computed threw a NullPointerException out of the middle of painting (#153, #123).
+		if (structure_all_bbox == null) return;
+
 		g2d.setColor(Color.black);
 		g2d.setFont(new Font(theGraphicOptions.MASS_TEXT_FONT_FACE, Font.PLAIN, 10));
 		
@@ -178,6 +181,8 @@ public class GlycanRendererAWT extends AbstractGlycanRenderer {
 		Graphics2D g2d=paintable.getGraphics2D();
 		Rectangle structure_all_bbox = bboxManager.getComplete(structure
 				.getRoot(laysOutAglycon(structure, show_redend)));
+		// as in displayLegend: nothing laid out, nowhere to put the mass (#153, #123)
+		if (structure_all_bbox == null) return;
 
 		g2d.setColor(Color.black);
 		g2d.setFont(new Font(theGraphicOptions.MASS_TEXT_FONT_FACE, Font.PLAIN,

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
@@ -147,7 +147,7 @@ public class GLINToLinkage {
 					if(this.isFacingBetweenAnomer(acceptorGLIN) || !acceptorGLIN.getMAP().equals("") || this.isLinkageWithUnknown(acceptorGLIN))
 						this.analyzeGLINforChild(acceptorGLIN);
 					else if(this.isReverse)
-						this.analyzeGLINforParent(acceptorGLIN);
+						this.analyzeReverseAntennaGLIN(acceptorGLIN);
 					else
 						this.analyzeEndSideCyclic(acceptorGLIN);
 				}
@@ -207,6 +207,41 @@ public class GLINToLinkage {
 
 		// probability annotation
 		this.extractProbabilityAnnotation(_donorGLIN, linkage);
+	}
+
+	/**
+	 * Read the linkage of an antenna written the other way round.
+	 *
+	 * <p>An antenna - a subtree whose attachment point is undetermined - names the residues it
+	 * may hang from, and WURCS writes the two sides in whichever order puts the residue linking
+	 * through its anomeric carbon on the donor side. A sialic acid leaves from C2, so
+	 * {@code l2-a?|...|k?} is written antenna first as a donor and read by
+	 * {@link #analyzeGLINforParent}. G42735RP says {@code m1-f?|i?|k?} instead - position 1 on
+	 * a residue whose anomeric carbon is 2 - and the sequence is then parsed the other way
+	 * round, with the antenna as the acceptor and its candidates as donors. That is the case
+	 * {@link #setGRESs} calls a reverse antenna.</p>
+	 *
+	 * <p>The two sides mean the opposite of what {@link #analyzeGLINforParent} reads them as,
+	 * so it took the antenna's own 1 for the position on each candidate: the structure was
+	 * drawn as 1-linked to the galactoses and written back as {@code m2-f1|i1|k1}, stating a
+	 * definite position where the sequence had said it was unknown. Here the sides are read for
+	 * what they are - the acceptor side names the antenna, the donor side its candidates.</p>
+	 */
+	private void analyzeReverseAntennaGLIN(GLIN _acceptorGLIN) {
+		if(_acceptorGLIN.getDonor().size() < 2) {
+			// not an antenna after all: leave it to the reading that does not swap the sides
+			this.analyzeGLINforParent(_acceptorGLIN);
+			return;
+		}
+
+		char[] antennaPositions = this.makeLinkagePosiiton(_acceptorGLIN.getAcceptorPositions());
+		char[] candidatePositions = this.makeLinkagePosiiton(_acceptorGLIN.getDonorPositions());
+
+		Linkage linkage = new Linkage(null, this.acceptorRES, candidatePositions);
+		linkage.setAnomericCarbon(antennaPositions[0]);
+		this.acceptorLinkages.add(linkage);
+
+		this.extractProbabilityAnnotation(_acceptorGLIN, linkage);
 	}
 
 	/*
@@ -429,6 +464,11 @@ public class GLINToLinkage {
 
 		for(GLIN a_oDGLIN : _gres.getDonorGLINs()) {
 			if(a_oDGLIN.isRepeat()) continue;
+			// A reverse antenna is written with its candidates on the donor side, so this residue
+			// can be here only as one of them - the antenna is not its parent, and taking it for
+			// one leaves the residue with two and drops it from the structure. analyzeDonorGLIN
+			// passes over the same GLINs.
+			if(a_oDGLIN.getDonor().size() > 1) continue;
 			for(GRES a_oAGRES : a_oDGLIN.getAcceptor()) {
 				if(this.acceptorGRESs.contains(a_oAGRES)) continue;
 				if(_gres.getID() - a_oAGRES.getID() > 0) this.acceptorGRESs.add(a_oAGRES);

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
@@ -45,8 +45,14 @@ public class LinkageConnector {
 			donor.setParentLinkage(_glin2linkage.getStartSideRepLinkage());
 		}
 
-		if(_glin2linkage.getDonorGLINs().isEmpty()) {
+		if(_glin2linkage.getDonorGLINs().isEmpty() || this.acceptor == null) {
 			//　start-rep is root node
+			//
+			// Or there is no residue to attach this one to. A residue named among an antenna's
+			// candidates is a donor of that ambiguous linkage, so it can reach here looking as
+			// though it had a parent, while the reading found no acceptor for it - the reducing
+			// end of G00955WX does, if the antenna is written l1-a?|...|k?. It used to walk into
+			// isOutRepeating and fail on a null acceptor, and the sequence would not read at all.
 			this.analyzeBracketNotation (donor, null, _glin2linkage);
 			return;
 		}

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/WURCSSequence2ToGlycan.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/WURCSSequence2ToGlycan.java
@@ -59,6 +59,7 @@ public class WURCSSequence2ToGlycan {
 		// append ambiguous root
 		for(GRES gres : gres2frag.getRootOfFragments()) {
 			Residue fragRoot = this.gres2residue.get(gres);
+			this.detachFromNamedParent(fragRoot);
 			this.glycan.addAntenna(fragRoot, fragRoot.getParentLinkage().getBonds());
 		}
 
@@ -95,6 +96,34 @@ public class WURCSSequence2ToGlycan {
 
 			this.glycan.normalizeCompositionFlags();
 		}
+	}
+
+	/**
+	 * Take an antenna out of the tree it was provisionally linked into, so that the bracket
+	 * is its only parent.
+	 *
+	 * <p>A GRES whose attachment point is undetermined names several possible acceptors -
+	 * {@code m1-f?|i?|k?} in G42735RP. {@link #analyzeGLIN} has no way to choose between
+	 * them and links the residue to the first, then records every candidate with
+	 * {@link Residue#addParentOfFragment}; the same residue then becomes an antenna, a
+	 * child of the bracket. It ends up with two parents at once - a shape no tree can hold
+	 * - and everything that walks the structure meets it twice: the renderer lays it out
+	 * under the bracket and then translates it a second time along with the other parent's
+	 * subtree, which carries it clean out of the picture the renderer has sized, and the
+	 * writers put it in the sequence twice over (#71).</p>
+	 *
+	 * <p>The candidates are already recorded, so the provisional link has nothing left to
+	 * say. The linkage itself is put back on the residue after the parent lets go of it:
+	 * the bracket reads its positions and its linkage types when it adopts the residue.</p>
+	 */
+	private void detachFromNamedParent(Residue _fragRoot) {
+		if (_fragRoot == null) return;
+		Residue parent = _fragRoot.getParent();
+		if (parent == null) return;
+
+		Linkage provisional = _fragRoot.getParentLinkage();
+		parent.removeChild(_fragRoot);
+		_fragRoot.setParentLinkage(provisional);
 	}
 
 	private void analyzeGRES(GRES _gres) throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AmbiguousLinkageKeepsUnknownPositionsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AmbiguousLinkageKeepsUnknownPositionsTest.java
@@ -1,0 +1,125 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an antenna written the other way round still says its position is unknown (#150).
+ *
+ * <p>An antenna names the residues it may hang from, and WURCS writes the two sides in whichever
+ * order puts the residue linking through its anomeric carbon on the donor side. A sialic acid
+ * leaves from C2, so G00955WX is written {@code l2-a?|…|k?} - antenna first, as the donor. G42735RP
+ * says {@code m1-f?|i?|k?} instead, position 1 on a residue whose anomeric carbon is 2, and is
+ * parsed the other way round: the antenna as the acceptor, its candidates as donors.</p>
+ *
+ * <p>Reading it as though the sides meant the usual thing took the antenna's own 1 for the position
+ * on each candidate. The structure came out drawn as 1-linked to the galactoses and written back as
+ * {@code m2-f1|i1|k1} - a definite position where the sequence said it was unknown. The same shape
+ * on G00955WX did not read at all.</p>
+ */
+public class AmbiguousLinkageKeepsUnknownPositionsTest {
+
+	/** G42735RP as registered: the antenna written on the acceptor side, at position 1. */
+	private static final String THE_OTHER_WAY_ROUND =
+			"WURCS=2.0/7,13,12/[a2122h-1x_1-5_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O]"
+			+ "[a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5][a1221m-1a_1-5]"
+			+ "[Aad21122h-2a_2-6_5*NCC/3=O]/1-2-3-4-2-5-4-2-5-2-5-6-7"
+			+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
+			+ "_m1-f?|i?|k?}";
+
+	/** The same structure with the sialic acid's own anomeric carbon, which was always read right. */
+	private static final String THE_USUAL_WAY_ROUND =
+			THE_OTHER_WAY_ROUND.replace("_m1-f?|i?|k?}", "_m2-f?|i?|k?}");
+
+	/** G00955WX, whose antenna is written the usual way round. */
+	private static final String G00955WX =
+			"WURCS=2.0/5,12,11/[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]"
+			+ "[a2112h-1b_1-5][Aad21122h-2a_2-6_5*NCC/3=O]/1-1-2-3-1-4-1-4-3-1-4-5"
+			+ "/a4-b1_b4-c1_c3-d1_c6-i1_d2-e1_d4-g1_e4-f1_g4-h1_i2-j1_j4-k1"
+			+ "_l2-a?|b?|c?|d?|e?|f?|g?|h?|i?|j?|k?}";
+
+	/** And the same, written the other way round - the shape that would not read at all. */
+	private static final String G00955WX_THE_OTHER_WAY_ROUND =
+			G00955WX.replace("_l2-a?", "_l1-a?");
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The position on the residues the antenna may hang from is unknown, and stays unknown. */
+	@Test
+	public void theAntennaDoesNotClaimAPositionOnItsCandidates() throws Exception {
+		Residue antenna = read(THE_OTHER_WAY_ROUND).getBracket().getChildAt(0);
+
+		assertEquals("the antenna's own position was taken for the position on its candidates",
+				"?", antenna.getParentLinkage().getParentPositionsString());
+	}
+
+	/** So it is written back saying what it was given: f, i and k at an unknown position. */
+	@Test
+	public void theUnknownPositionsSurviveTheRoundTrip() throws Exception {
+		String written = writeAs(read(THE_OTHER_WAY_ROUND), "wurcs2");
+
+		assertTrue("a definite position was invented on the candidates: " + written,
+				written.endsWith("_m2-f?|i?|k?}"));
+	}
+
+	/**
+	 * And it is drawn as the same glycan either way round, which is the point.
+	 *
+	 * <p>The two sequences say the same thing about where the sialic acid may go; only the position
+	 * written beside the sialic acid itself differs, and that is not what the picture shows.</p>
+	 */
+	@Test
+	public void bothWaysRoundDrawTheSamePicture() throws Exception {
+		assertEquals("the same antenna is drawn differently depending on how it was written",
+				draw(read(THE_USUAL_WAY_ROUND)), draw(read(THE_OTHER_WAY_ROUND)));
+	}
+
+	/**
+	 * The other way round reads at all, and keeps every residue.
+	 *
+	 * <p>G00955WX written that way used to fail to import - a null acceptor in LinkageConnector -
+	 * and the reading that replaced the crash dropped the last galactose, because the antenna was
+	 * taken for that residue's parent as well.</p>
+	 */
+	@Test
+	public void nothingIsLostWhenTheAntennaIsWrittenTheOtherWayRound() throws Exception {
+		assertEquals("residues went missing when the antenna was written the other way round",
+				read(G00955WX).getAllResidues().size(),
+				read(G00955WX_THE_OTHER_WAY_ROUND).getAllResidues().size());
+	}
+
+	private static String draw(Glycan structure) throws Exception {
+		return SVGUtils.getVectorGraphics(
+				new GlycanRendererAWT(), Collections.singletonList(structure), false, false);
+	}
+
+	private static Glycan read(String sequence) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS would not import", document.importFromString(sequence, "wurcs2"));
+
+		return document.getStructures().get(0);
+	}
+
+	private static String writeAs(Glycan structure, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.exportFromStructure(document.getStructures(), format);
+		assertTrue("nothing came out as " + format, !document.getString().isEmpty());
+
+		return document.getString().get(0);
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionIsDrawnWithoutTheReducingEndTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionIsDrawnWithoutTheReducingEndTest.java
@@ -1,0 +1,99 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.Collections;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a composition is drawn whether or not the reducing-end marker is shown (#153).
+ *
+ * <p>A composition has no residue privileged as the reducing end: its members all hang from the
+ * bracket and the free end is only a marker. The renderer laid it out from the residue past that
+ * marker, which for a composition is nothing at all, so asking for one without the marker gave an
+ * empty picture - a blank 1x1 SVG, or a NullPointerException out of the middle of painting when
+ * the legend went to measure the box that had never been computed.</p>
+ *
+ * <p>Whether the marker is <em>drawn</em> is a display preference. Whether the composition is drawn
+ * should not follow it.</p>
+ */
+public class CompositionIsDrawnWithoutTheReducingEndTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The layout has a size, which is what the picture is cut to. */
+	@Test
+	public void aCompositionIsLaidOutWithoutTheReducingEnd() throws Exception {
+		Rectangle box = layoutOf(composition(), false);
+
+		assertTrue("a composition laid out to nothing: " + box, box.width > 1 && box.height > 1);
+	}
+
+	/** And it draws, where it used to throw. */
+	@Test
+	public void aCompositionIsDrawnWithoutTheReducingEnd() throws Exception {
+		BufferedImage image = new GlycanRendererAWT().getImage(composition(), false, false, false, 1.0);
+
+		assertNotNull("nothing was drawn", image);
+		assertTrue("the image is empty: " + image.getWidth() + "x" + image.getHeight(),
+				image.getWidth() > 1 && image.getHeight() > 1);
+	}
+
+	/**
+	 * The same picture either way, because there is no reducing end for the marker to mark.
+	 *
+	 * <p>The composition's free end is never painted - {@code paint} draws the bracket and leaves
+	 * the core alone - so the flag has nothing to act on here.</p>
+	 */
+	@Test
+	public void aCompositionIsDrawnTheSameEitherWay() throws Exception {
+		assertEquals("a composition is drawn differently depending on the reducing-end marker",
+				draw(composition(), true), draw(composition(), false));
+	}
+
+	/** An ordinary glycan still minds the marker, which is the point of the preference. */
+	@Test
+	public void anOrdinaryGlycanStillMindsTheReducingEnd() throws Exception {
+		Glycan chain = Glycan.fromString("freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd");
+
+		assertNotEquals("the reducing-end marker stopped making any difference",
+				draw(chain, true), draw(chain, false));
+	}
+
+	/** Two hexoses, unlinked and unordered - the smallest thing that is a composition. */
+	private static Glycan composition() throws Exception {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.getCompositionOptions().HEX = 2;
+		Glycan composition =
+				workspace.getCompositionOptions().getCompositionAsGlycan(workspace.getDefaultMassOptions());
+		assertTrue("this was meant to be a composition", composition.isComposition());
+
+		return composition;
+	}
+
+	private static Rectangle layoutOf(Glycan structure, boolean showReducingEnd) throws Exception {
+		return new GlycanRendererAWT().computeBoundingBoxes(Collections.singletonList(structure),
+				false, showReducingEnd, new PositionManager(), new BBoxManager());
+	}
+
+	private static String draw(Glycan structure, boolean showReducingEnd) throws Exception {
+		return SVGUtils.getVectorGraphics(new GlycanRendererAWT(),
+				Collections.singletonList(structure), false, showReducingEnd);
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RenderingLayoutInvariantsTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 /**
  * What has to be true of any layout, whatever it looks like.
  *
- * <p>The drawing issues left open - #58, #71, #29, #88 - all want changes in the middle of the
+ * <p>The drawing issues left open - #58, #29, #88 - all want changes in the middle of the
  * renderer, where a change meant to help one structure can quietly spoil another, and there was no
  * way to tell. Freezing the SVG of a set of structures would tell, but it would also fail on every
  * intentional improvement and say nothing about what went wrong: twelve kilobytes of path data
@@ -33,7 +33,7 @@ import org.junit.Test;
  *
  * <ul>
  *   <li>every residue lies within the bounding box the renderer reports - what is drawn outside it
- *       is clipped out of the image, which is how #71 shows itself;</li>
+ *       is clipped out of the image, which is how #71 showed itself;</li>
  *   <li>no two residues share a top-left corner - two symbols on the same spot are unreadable, and
  *       are a sign that one of them was never placed.</li>
  * </ul>
@@ -120,29 +120,21 @@ public class RenderingLayoutInvariantsTest {
 	}
 
 	/**
-	 * G42735RP, the structure of #71, which puts a residue outside its own picture.
+	 * G42735RP, the structure of #71, which used to put a residue outside its own picture.
 	 *
-	 * <p>The antenna's sialic acid, at linkage position 1, is placed outside the bounding box the
-	 * renderer reports, and so is cut off by the edge of the image: its rectangle runs to x=542 and
-	 * y=199 where the box ends at 512 and 185. It never reaches the list the bracket layout aligns
-	 * and measures, so nothing sizes the picture to include it.</p>
-	 *
-	 * <p>This test states the fault rather than the fix, so that the fault cannot quietly get
-	 * worse. <b>When #71 is fixed this test will fail</b> - that is what it is for. Move the
-	 * structure to a plain {@code assertLaidOutWithin} then, and delete this one.</p>
+	 * <p>The antenna's sialic acid, at linkage position 1, was laid out under the bracket and then
+	 * translated a second time along with the subtree it was also linked into, which left it at
+	 * x=520..542, y=177..199 where the box ended at 512 and 185 - outside the image, and so cut off
+	 * by its edge. It had two parents at once; it has one now, and lands inside the box.</p>
 	 */
 	@Test
-	public void theStructureOfIssue71IsStillDrawnOutsideItsOwnBox() throws Exception {
-		Glycan structure = wurcs(
+	public void theStructureOfIssue71IsLaidOutWithin() throws Exception {
+		assertLaidOutWithin(wurcs(
 				"WURCS=2.0/7,13,12/[a2122h-1x_1-5_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O]"
 				+ "[a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5][a1221m-1a_1-5]"
 				+ "[Aad21122h-2a_2-6_5*NCC/3=O]/1-2-3-4-2-5-4-2-5-2-5-6-7"
 				+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
-				+ "_m1-f?|i?|k?}");
-
-		assertEquals("#71 looks fixed: no residue falls outside the box any more",
-				1, outside(structure));
-		assertEquals("the escape is one residue, drawn once", 0, sharedSpots(structure));
+				+ "_m1-f?|i?|k?}"));
 	}
 
 	/** Everything drawn is inside the box, and no two symbols sit on the same spot. */
@@ -191,10 +183,10 @@ public class RenderingLayoutInvariantsTest {
 		layout.all = all;
 		for (Residue residue : structure.getAllResidues()) {
 			Rectangle rectangle = boxes.getCurrent(residue);
-			// Keyed by identity, because the walk can hand back the same residue twice - an
-			// antenna reachable from both the root and the bracket comes back on both. Counting
-			// those as two residues on one spot would report a drawing fault where there is only
-			// one residue, drawn once.
+			// Keyed by identity, because the walk hands back a residue once per way it can be
+			// reached: an antenna linked into the tree as well as into the bracket comes back on
+			// both. Counting those as two residues on one spot would report a drawing fault where
+			// there is only one residue, drawn once - which is what #71 turned out to be.
 			if (rectangle != null) layout.rectangles.put(residue, rectangle);
 		}
 		assertTrue("nothing was laid out at all", !layout.rectangles.isEmpty());

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsAntennaHasOneParentTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsAntennaHasOneParentTest.java
@@ -1,0 +1,116 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an antenna read from WURCS hangs from the bracket and from nothing else (#71).
+ *
+ * <p>An antenna is a subtree whose attachment point is undetermined: it names the residues it may
+ * hang from, and is drawn from the bracket rather than from any one of them. Reading WURCS linked
+ * it to the first of the named residues as well - there is no way to choose between them, and the
+ * reader chose - so the residue had two parents at once, a shape no tree can hold.</p>
+ *
+ * <p>Everything that walks the structure then met it twice. The renderer laid it out under the
+ * bracket and translated it a second time along with the subtree it was also linked into, which put
+ * it outside the picture the renderer had sized; the writers emitted it twice, so G42735RP came
+ * back out of WURCS with fourteen residues where it went in with thirteen.</p>
+ *
+ * <p>The structure here is G42735RP, the one in the report.</p>
+ */
+public class WurcsAntennaHasOneParentTest {
+
+	/**
+	 * G42735RP: a fucosylated N-glycan whose sialic acid may hang from any of three galactoses.
+	 *
+	 * <p>{@code m1-f?|i?|k?} is the part that matters - residue m, the NeuAc, named against f, i
+	 * and k with the position on each of them unknown.</p>
+	 */
+	private static final String WITH_AN_AMBIGUOUS_ANTENNA =
+			"WURCS=2.0/7,13,12/[a2122h-1x_1-5_2*NCC/3=O][a2122h-1b_1-5_2*NCC/3=O]"
+			+ "[a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5][a1221m-1a_1-5]"
+			+ "[Aad21122h-2a_2-6_5*NCC/3=O]/1-2-3-4-2-5-4-2-5-2-5-6-7"
+			+ "/a4-b1_a6-l1_b4-c1_c3-d1_c6-g1_d2-e1_e4-f1_g2-h1_g6-j1_h4-i1_j4-k1"
+			+ "_m1-f?|i?|k?}";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** The antenna is the bracket's child, and nobody else's. */
+	@Test
+	public void theAntennaHangsFromTheBracketAlone() throws Exception {
+		Glycan structure = read(WITH_AN_AMBIGUOUS_ANTENNA);
+		Residue bracket = structure.getBracket();
+
+		assertEquals("the bracket should carry the one antenna", 1, bracket.getNoChildren());
+		Residue antenna = bracket.getChildAt(0);
+		assertSame("the antenna is linked to a residue as well as to the bracket",
+				bracket, antenna.getParent());
+		assertEquals("the antenna is still a child of a residue in the tree",
+				0, timesReachedFrom(structure.getRoot(), antenna));
+	}
+
+	/** And it still knows which residues it may hang from, which is what says where to draw it. */
+	@Test
+	public void theAntennaKeepsTheParentsItMayHangFrom() throws Exception {
+		Glycan structure = read(WITH_AN_AMBIGUOUS_ANTENNA);
+
+		Residue antenna = structure.getBracket().getChildAt(0);
+		assertEquals("the antenna should name the three residues f, i and k",
+				3, antenna.getParentsOfFragment().size());
+	}
+
+	/** So the walk meets each residue once, and the writers say the structure once. */
+	@Test
+	public void theStructureIsWrittenOutAsOneOfEachResidue() throws Exception {
+		Glycan structure = read(WITH_AN_AMBIGUOUS_ANTENNA);
+
+		// the thirteen residues of the sequence, plus the free end and the bracket
+		assertEquals("a residue is reachable twice, so it will be written twice",
+				15, structure.getAllResidues().size());
+
+		String written = writeAs(structure, "wurcs2");
+		assertTrue("the antenna came out twice: " + written, written.startsWith("WURCS=2.0/7,13,12/"));
+	}
+
+	/** How many times the antenna can be reached by walking down from a residue. */
+	private static int timesReachedFrom(Residue from, Residue antenna) {
+		if (from == null) return 0;
+
+		int found = 0;
+		for (int i = 0; i < from.getNoChildren(); i++) {
+			Residue child = from.getChildAt(i);
+			if (child == antenna) found++;
+			found += timesReachedFrom(child, antenna);
+		}
+
+		return found;
+	}
+
+	private static Glycan read(String sequence) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS would not import", document.importFromString(sequence, "wurcs2"));
+
+		return document.getStructures().get(0);
+	}
+
+	private static String writeAs(Glycan structure, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.exportFromStructure(document.getStructures(), format);
+		assertTrue("nothing came out as " + format, !document.getString().isEmpty());
+
+		return document.getString().get(0);
+	}
+}


### PR DESCRIPTION
Release 1.34.0.

Three drawing and reading faults from the tracker, a security move that had to be made in one
step, and a pom that had stopped warning.

* **#71** — G42735RP was drawn with a residue outside its own picture. An antenna names the
  residues it may hang from and is drawn from the bracket; the WURCS reader, having no way to
  choose between three candidates, linked it to the first *and* made it a child of the bracket.
  With two parents it was met twice by everything that walks the structure: translated a second
  time out of the box the renderer had reported, and written into the sequence twice over.
* **#150** — the same structure claimed a linkage position the sequence had said was unknown.
  `m1-f?|i?|k?` is parsed with the antenna and its candidates on the opposite sides from usual,
  and reading it as though they meant the usual thing carried the antenna's own `1` across to
  each candidate. Read by role now; the same shape on G00955WX used to fail to import at all.
  Option 3 of that issue — what a 1-linked Neu5Ac should be shown as — is still open and is not
  in this release.
* **#153** — a composition was drawn only when the reducing-end marker was shown, and otherwise
  came out blank or threw. Whether the marker is drawn is a display preference; whether the
  composition is drawn no longer follows it.
* **#144** — batik 1.9 (2017) and fop 2.2 both travel to every consumer, and batik 1.9 carries
  the SSRF and remote-class-loading run fixed later in the 1.x line, including CVE-2022-44729.
  They cannot move apart, so batik goes to 1.19 and fop to 2.11 in one step — the pair
  `fop-parent` names.
* The pom warned on every build about a plugin declared twice, a plugin without a version, and a
  relocated dependency coordinate. The effective pom and the resolved dependency list are
  unchanged.

## Verified

* 113 tests pass, `TranscoderSmokeTest` among them — it is what catches a mismatched batik/fop,
  since that failure is a `NoClassDefFoundError` on the first PDF/PS/EPS export
* the **desktop application** starts on the new pair: AWT event loop up, `GlycanBuilder` and
  `GlycanCanvas` live in the heap
* **glycanbuilder2web** builds, starts, draws, computes masses and exports on the new pair; its
  own batik pins moved to match in glyconavi/glycanbuilder2web!81, already on `main`
* 107 WURCS strings from the test sources read, written and drawn before and after: only
  G42735RP differs, and only in the ways above

Closes #71, #144, #153.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
