### PR TITLE
Write the release process down where the next person will look

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,51 @@ java -jar ./target/glycanbuilder2-jar-with-dependencies.jar
 
 Please see [CHANGELOG.md](CHANGELOG.md) for details.
 
+## Releasing
+
+The steps in order. The tag is the one to get right: the installer workflow matches on it, and a tag
+it cannot match is a release with no installers.
+
+**1. Branches.** `master` is never committed to directly and takes pull requests **from `develop`
+only**. Work is done on branches off `develop` and merged into `develop`.
+
+**2. Version.** On `develop`, in one commit, immediately before opening the pull request to `master`:
+raise the version in `pom.xml` and add the `CHANGELOG.md` entry together. **A branch merged into
+`develop` does not raise the version** — leave `pom.xml` alone there, or two branches in flight both
+claim the same number.
+
+**3. Merge** `develop` into `master` by pull request.
+
+**4. Tag** that merge commit `vMAJOR.MINOR.PATCH` — e.g. `v1.27.0`. The leading `v` and all three
+parts are required, because the GitHub Actions workflow reads them. GitHub or local, either is fine.
+
+**5. Deploy**, locally, from `master` at the versioned commit:
+
+```
+mvn deploy
+```
+
+This needs a GitHub PAT. Afterwards check the version is listed under
+[MavenRepository](https://github.com/glycoinfo/MavenRepository/tree/master/org/eurocarbdb/glycanbuilder/glycanbuilder2).
+
+**6. Installers.** Run [Release GlycanBuilder2](https://github.com/glycoinfo/GlycanBuilder2/actions/workflows/release.yml)
+from "Run workflow", giving it the tag from step 4.
+
+**7. Windows (manual).** The MSIX has to be submitted to the Microsoft Store by hand:
+
+1. Download the `glycanbuilder2-installer-windows` artifact from that workflow run and unzip it to
+   get `GlycanBuilder2.msix`.
+2. Sign in to Microsoft Partner Center with the project's store account. This needs two-factor
+   authentication, so it also needs whoever holds the authenticator — plan for that, since it is the
+   usual reason this step waits.
+3. Apps and games → **GlycanBuilder** → product update → **Packages**.
+4. Drag `GlycanBuilder2.msix` in and Save. The previous version's package is removed automatically.
+5. **Submit for certification**, then wait: the Store page updates itself once certification passes.
+
+**8. Release label.** The workflow leaves the release as a Pre-Release. On the
+[releases page](https://github.com/glycoinfo/GlycanBuilder2/releases), Edit it, choose **Latest**
+under "Release label", and Update release.
+
 ## Publications
 
 * [Shinichiro Tsuchiya, Nobuyuki P. Aoki, Daisuke Shinmachi, Masaaki Matsubara, Issaku Yamada, Kiyoko F. Aoki-Kinoshita, Hisashi Narimatsu,


### PR DESCRIPTION
The release steps existed only in one person's head. The README had a Release Notes section pointing
at the changelog, and nothing about making a release.

Now written down in order: which branch takes what, when the version is raised, the tag, the deploy,
the installer workflow, the Microsoft Store submission, and the Pre-Release → Latest flip.

**The tag is the part worth being exact about.** `vMAJOR.MINOR.PATCH` — the `v` and all three parts —
because the GitHub Actions workflow matches on it. A tag it cannot match is a release with no
installers.

Two things are stated that are easy to get wrong and were not recorded anywhere:

* **A branch merged into `develop` does not raise the version.** It is raised on `develop` in one
  commit, with the CHANGELOG entry, immediately before the pull request to `master` — otherwise two
  branches in flight both claim the same number.
* **The Windows MSIX is manual.** Nothing automates it, the account is not the one a developer signs
  in with day to day, and its two-factor sign-in needs whoever holds the authenticator to be
  available. It is the step most likely to stall, so it is written out rather than left as folklore.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
