### PR TITLE
Stop weighing a marker that is not a residue

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -1430,8 +1430,28 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 		}
 	}
 	
+	/**
+	   Whether a residue is the marker the WURCS importer attaches to a
+	   composition to say that no linkages are known, rather than a member of
+	   the composition itself. It carries no mass and must not be counted among
+	   the members: N members imply N-1 glycosidic bonds, and the marker is not
+	   one of them.
+	 */
+	private static boolean isCompositionMarker(Residue residue) {
+		return residue != null && residue.getType() != null
+				&& "no glycosidic linkages".equals(residue.getType().getDescription());
+	}
+
 	private double computeMass(Residue node, double multipler) {
 		if( node==null || node.getTypeName().equals("Sugar"))
+			return 0.;
+
+		// The "no glycosidic linkages" marker is a label the WURCS importer hangs off a
+		// composition to say that no linkages are known - not a residue of the glycan. It weighs
+		// nothing, but left to fall through it collects a derivatization adjustment for the one
+		// bond it has to the bracket, which is why every derivatized composition read one
+		// methyl/acetyl group light. The renderers skip it by the same test.
+		if( isCompositionMarker(node) )
 			return 0.;
 
 		// a composition has no distinguished reducing end of its own: the root
@@ -1493,7 +1513,15 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 				// data model contributes no mass of its own for a composition
 				// (see the top of this method), whatever its actual residue
 				// type happens to be, so there is nothing else to account for.
-				int no_members = node.getChildrenLinkages().size();
+				// The WURCS importer hangs a synthetic "no glycosidic linkages" marker off the
+				// bracket alongside the real members (see WURCSSequence2ToGlycan). It weighs
+				// nothing itself, but counting it as a member subtracts one water too many - so
+				// every composition imported from WURCS came out 18.0106 light, at any size. The
+				// renderers already skip it by the same test; the mass had not been told about it.
+				int no_members = 0;
+				for( int i=0; i<node.getNoChildren(); i++ )
+					if( !isCompositionMarker(node.getChildAt(i)) )
+						no_members++;
 				if( no_members>0 )
 					mass -= (no_members-1)*MassUtils.water.getMass();
 			}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionFromWurcsWeighsTheSameAsFromGwsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionFromWurcsWeighsTheSameAsFromGwsTest.java
@@ -1,0 +1,85 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.CompositionOptions;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.Test;
+
+/**
+ * One composition weighs one thing, however it was written.
+ *
+ * <p>Hex3HexNAc2 built through {@link CompositionOptions} - the route the composition dialog takes -
+ * and the same composition imported from WURCS must agree. They did not: the WURCS one came out
+ * <b>18.0106 light</b> underivatized, and a further methyl or acetyl group light on top of that once
+ * derivatized.
+ *
+ * <p>The cause was a residue that is not a residue. {@code WURCSSequence2ToGlycan} hangs a synthetic
+ * <em>"no glycosidic linkages"</em> marker off a composition's bracket to record that no linkages
+ * are known. The renderers have always skipped it; the mass calculation had not been told about it,
+ * so it was counted twice over - once among the members, where N members imply N-1 glycosidic bonds
+ * and so subtracted one water too many, and once as an ordinary residue, where it collected a
+ * derivatization adjustment for its single bond to the bracket.
+ *
+ * <p>The numbers below are the composition dialog's, which were already right and are what a user
+ * sees on the canvas.
+ */
+public class CompositionFromWurcsWeighsTheSameAsFromGwsTest {
+
+	/** Hex3HexNAc2 - the N-glycan core's composition. */
+	private static final String AS_WURCS = "WURCS=2.0/2,5,0/[u2122h_2*NCC/3=O][u1122h]/1-1-2-2-2/";
+
+	/** Underivatized, this is the Man3GlcNAc2 figure. */
+	@Test
+	public void underivatized() throws Exception {
+		assertEquals(910.3278, massFromWurcs(MassOptions.NO_DERIVATIZATION), 1e-3);
+		assertEquals(massFromTheCompositionDialog(MassOptions.NO_DERIVATIZATION),
+				massFromWurcs(MassOptions.NO_DERIVATIZATION), 1e-6);
+	}
+
+	/** And derivatized, where the marker was costing a group of its own. */
+	@Test
+	public void derivatized() throws Exception {
+		for (String derivatization : new String[] { MassOptions.PERMETHYLATED,
+				MassOptions.PERACETYLATED, MassOptions.PERDMETHYLATED }) {
+			assertEquals(derivatization,
+					massFromTheCompositionDialog(derivatization), massFromWurcs(derivatization), 1e-6);
+		}
+	}
+
+	private static double massFromWurcs(String derivatization) throws Exception {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.setAutoSave(false);
+		GlycanDocument document = workspace.getStructures();
+		document.importFromString(AS_WURCS, "wurcs2");
+
+		List<Glycan> structures = document.getStructures();
+		Glycan composition = structures.get(0);
+		composition.setMassOptions(massOptions(derivatization));
+
+		return composition.computeMass();
+	}
+
+	private static double massFromTheCompositionDialog(String derivatization) throws Exception {
+		CompositionOptions counted = new CompositionOptions();
+		counted.HEX = 3;
+		counted.HEXNAC = 2;
+
+		return counted.getCompositionAsGlycan(massOptions(derivatization)).computeMass();
+	}
+
+	private static MassOptions massOptions(String derivatization) {
+		MassOptions options = new MassOptions();
+		options.DERIVATIZATION = derivatization;
+		options.ION_CLOUD = new IonCloud();
+
+		return options;
+	}
+}


### PR DESCRIPTION
A composition imported from WURCS weighed **18.0106 less** than the same composition built through `CompositionOptions`, and a further methyl or acetyl group less once derivatized. Hex3HexNAc2 read **892.3172** where the composition dialog reads **910.3278**, the Man3GlcNAc2 figure.

## The cause

A residue that is not a residue. `WURCSSequence2ToGlycan` hangs a synthetic **"no glycosidic linkages"** marker off a composition's bracket to record that no linkages are known. The renderers have always skipped it — `AbstractGlycanRenderer` tests for that description in four places. `computeMass` had not been told about it, and counted it **twice**:

1. **Among the bracket's members.** N members imply N−1 glycosidic bonds, so six members were assumed where there are five, and one water too many came off. Measured: `childrenLinkages.size()` is 6 for Hex3HexNAc2 — five sugars and the marker.
2. **As an ordinary residue**, where it collected `(noSubstitutions - no_bonds) * substitutionMass` for its single bond to the bracket. Nothing underivatized; one whole group otherwise — which is why the shortfall grew under permethylation and peracetylation.

It now returns before either, and is left out of the member count. **The arithmetic the 2026-08-04 composition fix intended is unchanged**: sum the members, take off N−1 waters for the bonds they imply.

## Measured, before and after

| derivatization | via CompositionOptions | via WURCS, before | via WURCS, after |
|---|---|---|---|
| none | 910.327780 | 892.317215 | **910.327780** |
| permethylated | 1190.640781 | 1158.614567 | **1190.640781** |
| peracetylated | 1666.517944 | 1606.496815 | **1666.517944** |
| per-deuteromethylated | 1251.017386 | 1215.972341 | **1251.017386** |

The two routes now agree to 1e-6 in every case.

## Checks

A test holds both routes against each other and fails on the old code with `expected:<910.3278> but was:<892.317215352>` — verified by reverting the fix and running it.

**113 library tests pass.** So do the **534** of glycanbuilder2web, built against this.

## Why it surfaced

Writing a mass-spectrometry example for glycanbuilder2web's MCP interface: a composition is what MS data often is, and WURCS is the only way an MCP caller can express one. Tracked there as [glycanbuilder2web#30](https://gitlab.com/glyconavi/glycanbuilder2web/-/issues/30), which also notes two things this does **not** fix — the GWS a composition writes cannot be read back (`--?no glycosidic linkages` is written where a linkage belongs), and no MCP tool builds a composition at all.