### PR TITLE
Version 1.34.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,26 @@
 ## Change log
+### 1.34.1  (20260812)
+* Stopped weighing a marker that is not a residue, so a composition read from WURCS weighs what
+  the composition dialog says it does
+  * `WURCSSequence2ToGlycan` hangs a synthetic "no glycosidic linkages" marker off a composition's
+    bracket to record that no linkages are known. The renderers have always skipped it -
+    `AbstractGlycanRenderer` tests for that description in four places - but `computeMass` had not
+    been told about it, and counted it twice
+  * Once among the bracket's members, where N members imply N-1 glycosidic bonds: six were assumed
+    where there are five, and one water too many came off. Measured, `childrenLinkages.size()` is 6
+    for Hex3HexNAc2
+  * Once as an ordinary residue, where it collected `(noSubstitutions - no_bonds) *
+    substitutionMass` for its single bond to the bracket - nothing underivatized, a whole methyl or
+    acetyl group otherwise, which is why the shortfall grew with derivatization
+  * Hex3HexNAc2 read **892.3172** where the composition dialog reads **910.3278**, the Man3GlcNAc2
+    figure. The two routes now agree to 1e-6 underivatized, permethylated, peracetylated and
+    per-deuteromethylated
+  * The arithmetic the 1.33.0 composition fix intended is unchanged: sum the members, take off N-1
+    waters for the bonds they imply. Only the counting is corrected
+  * Found while writing a mass-spectrometry example against glycanbuilder2web's MCP interface,
+    where WURCS is the only way a caller can express a composition (#160)
+* Wrote the release process down in the README, where the next person will look (#159)
+
 ### 1.34.0  (20260810)
 * Gave an antenna one parent when reading WURCS, so it is no longer drawn outside its own
   picture (#71)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,51 @@ java -jar ./target/glycanbuilder2-jar-with-dependencies.jar
 
 Please see [CHANGELOG.md](CHANGELOG.md) for details.
 
+## Releasing
+
+The steps in order. The tag is the one to get right: the installer workflow matches on it, and a tag
+it cannot match is a release with no installers.
+
+**1. Branches.** `master` is never committed to directly and takes pull requests **from `develop`
+only**. Work is done on branches off `develop` and merged into `develop`.
+
+**2. Version.** On `develop`, in one commit, immediately before opening the pull request to `master`:
+raise the version in `pom.xml` and add the `CHANGELOG.md` entry together. **A branch merged into
+`develop` does not raise the version** — leave `pom.xml` alone there, or two branches in flight both
+claim the same number.
+
+**3. Merge** `develop` into `master` by pull request.
+
+**4. Tag** that merge commit `vMAJOR.MINOR.PATCH` — e.g. `v1.27.0`. The leading `v` and all three
+parts are required, because the GitHub Actions workflow reads them. GitHub or local, either is fine.
+
+**5. Deploy**, locally, from `master` at the versioned commit:
+
+```
+mvn deploy
+```
+
+This needs a GitHub PAT. Afterwards check the version is listed under
+[MavenRepository](https://github.com/glycoinfo/MavenRepository/tree/master/org/eurocarbdb/glycanbuilder/glycanbuilder2).
+
+**6. Installers.** Run [Release GlycanBuilder2](https://github.com/glycoinfo/GlycanBuilder2/actions/workflows/release.yml)
+from "Run workflow", giving it the tag from step 4.
+
+**7. Windows (manual).** The MSIX has to be submitted to the Microsoft Store by hand:
+
+1. Download the `glycanbuilder2-installer-windows` artifact from that workflow run and unzip it to
+   get `GlycanBuilder2.msix`.
+2. Sign in to Microsoft Partner Center with the project's store account. This needs two-factor
+   authentication, so it also needs whoever holds the authenticator — plan for that, since it is the
+   usual reason this step waits.
+3. Apps and games → **GlycanBuilder** → product update → **Packages**.
+4. Drag `GlycanBuilder2.msix` in and Save. The previous version's package is removed automatically.
+5. **Submit for certification**, then wait: the Store page updates itself once certification passes.
+
+**8. Release label.** The workflow leaves the release as a Pre-Release. On the
+[releases page](https://github.com/glycoinfo/GlycanBuilder2/releases), Edit it, choose **Latest**
+under "Release label", and Update release.
+
 ## Publications
 
 * [Shinichiro Tsuchiya, Nobuyuki P. Aoki, Daisuke Shinmachi, Masaaki Matsubara, Issaku Yamada, Kiyoko F. Aoki-Kinoshita, Hisashi Narimatsu,

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.34.0</version>
+	<version>1.34.1</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -1430,8 +1430,28 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 		}
 	}
 	
+	/**
+	   Whether a residue is the marker the WURCS importer attaches to a
+	   composition to say that no linkages are known, rather than a member of
+	   the composition itself. It carries no mass and must not be counted among
+	   the members: N members imply N-1 glycosidic bonds, and the marker is not
+	   one of them.
+	 */
+	private static boolean isCompositionMarker(Residue residue) {
+		return residue != null && residue.getType() != null
+				&& "no glycosidic linkages".equals(residue.getType().getDescription());
+	}
+
 	private double computeMass(Residue node, double multipler) {
 		if( node==null || node.getTypeName().equals("Sugar"))
+			return 0.;
+
+		// The "no glycosidic linkages" marker is a label the WURCS importer hangs off a
+		// composition to say that no linkages are known - not a residue of the glycan. It weighs
+		// nothing, but left to fall through it collects a derivatization adjustment for the one
+		// bond it has to the bracket, which is why every derivatized composition read one
+		// methyl/acetyl group light. The renderers skip it by the same test.
+		if( isCompositionMarker(node) )
 			return 0.;
 
 		// a composition has no distinguished reducing end of its own: the root
@@ -1493,7 +1513,15 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 				// data model contributes no mass of its own for a composition
 				// (see the top of this method), whatever its actual residue
 				// type happens to be, so there is nothing else to account for.
-				int no_members = node.getChildrenLinkages().size();
+				// The WURCS importer hangs a synthetic "no glycosidic linkages" marker off the
+				// bracket alongside the real members (see WURCSSequence2ToGlycan). It weighs
+				// nothing itself, but counting it as a member subtracts one water too many - so
+				// every composition imported from WURCS came out 18.0106 light, at any size. The
+				// renderers already skip it by the same test; the mass had not been told about it.
+				int no_members = 0;
+				for( int i=0; i<node.getNoChildren(); i++ )
+					if( !isCompositionMarker(node.getChildAt(i)) )
+						no_members++;
 				if( no_members>0 )
 					mass -= (no_members-1)*MassUtils.water.getMass();
 			}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionFromWurcsWeighsTheSameAsFromGwsTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionFromWurcsWeighsTheSameAsFromGwsTest.java
@@ -1,0 +1,85 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.CompositionOptions;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.Test;
+
+/**
+ * One composition weighs one thing, however it was written.
+ *
+ * <p>Hex3HexNAc2 built through {@link CompositionOptions} - the route the composition dialog takes -
+ * and the same composition imported from WURCS must agree. They did not: the WURCS one came out
+ * <b>18.0106 light</b> underivatized, and a further methyl or acetyl group light on top of that once
+ * derivatized.
+ *
+ * <p>The cause was a residue that is not a residue. {@code WURCSSequence2ToGlycan} hangs a synthetic
+ * <em>"no glycosidic linkages"</em> marker off a composition's bracket to record that no linkages
+ * are known. The renderers have always skipped it; the mass calculation had not been told about it,
+ * so it was counted twice over - once among the members, where N members imply N-1 glycosidic bonds
+ * and so subtracted one water too many, and once as an ordinary residue, where it collected a
+ * derivatization adjustment for its single bond to the bracket.
+ *
+ * <p>The numbers below are the composition dialog's, which were already right and are what a user
+ * sees on the canvas.
+ */
+public class CompositionFromWurcsWeighsTheSameAsFromGwsTest {
+
+	/** Hex3HexNAc2 - the N-glycan core's composition. */
+	private static final String AS_WURCS = "WURCS=2.0/2,5,0/[u2122h_2*NCC/3=O][u1122h]/1-1-2-2-2/";
+
+	/** Underivatized, this is the Man3GlcNAc2 figure. */
+	@Test
+	public void underivatized() throws Exception {
+		assertEquals(910.3278, massFromWurcs(MassOptions.NO_DERIVATIZATION), 1e-3);
+		assertEquals(massFromTheCompositionDialog(MassOptions.NO_DERIVATIZATION),
+				massFromWurcs(MassOptions.NO_DERIVATIZATION), 1e-6);
+	}
+
+	/** And derivatized, where the marker was costing a group of its own. */
+	@Test
+	public void derivatized() throws Exception {
+		for (String derivatization : new String[] { MassOptions.PERMETHYLATED,
+				MassOptions.PERACETYLATED, MassOptions.PERDMETHYLATED }) {
+			assertEquals(derivatization,
+					massFromTheCompositionDialog(derivatization), massFromWurcs(derivatization), 1e-6);
+		}
+	}
+
+	private static double massFromWurcs(String derivatization) throws Exception {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.setAutoSave(false);
+		GlycanDocument document = workspace.getStructures();
+		document.importFromString(AS_WURCS, "wurcs2");
+
+		List<Glycan> structures = document.getStructures();
+		Glycan composition = structures.get(0);
+		composition.setMassOptions(massOptions(derivatization));
+
+		return composition.computeMass();
+	}
+
+	private static double massFromTheCompositionDialog(String derivatization) throws Exception {
+		CompositionOptions counted = new CompositionOptions();
+		counted.HEX = 3;
+		counted.HEXNAC = 2;
+
+		return counted.getCompositionAsGlycan(massOptions(derivatization)).computeMass();
+	}
+
+	private static MassOptions massOptions(String derivatization) {
+		MassOptions options = new MassOptions();
+		options.DERIVATIZATION = derivatization;
+		options.ION_CLOUD = new IonCloud();
+
+		return options;
+	}
+}


### PR DESCRIPTION
A composition read from WURCS now weighs what the composition dialog says it does.

## Stopped weighing a marker that is not a residue ([#160](https://github.com/glycoinfo/GlycanBuilder2/pull/160))

`WURCSSequence2ToGlycan` hangs a synthetic **"no glycosidic linkages"** marker off a composition's bracket to record that no linkages are known. The renderers have always skipped it — `AbstractGlycanRenderer` tests for that description in four places — but `computeMass` had not been told about it, and counted it **twice**:

1. **Among the bracket's members**, where N members imply N−1 glycosidic bonds: six were assumed where there are five, and one water too many came off. Measured, `childrenLinkages.size()` is 6 for Hex3HexNAc2.
2. **As an ordinary residue**, where it collected `(noSubstitutions - no_bonds) * substitutionMass` for its single bond to the bracket — nothing underivatized, a whole methyl or acetyl group otherwise, which is why the shortfall grew with derivatization.

| derivatization | composition dialog | from WURCS, before | from WURCS, after |
|---|---|---|---|
| none | 910.327780 | 892.317215 | **910.327780** |
| permethylated | 1190.640781 | 1158.614567 | **1190.640781** |
| peracetylated | 1666.517944 | 1606.496815 | **1666.517944** |
| per-deuteromethylated | 1251.017386 | 1215.972341 | **1251.017386** |

The arithmetic the 1.33.0 composition fix intended is unchanged — sum the members, take off N−1 waters for the bonds they imply. Only the counting is corrected.

Found while writing a mass-spectrometry example against glycanbuilder2web's MCP interface, where WURCS is the only way a caller can express a composition.

## Also

The release process is written down in the README ([#159](https://github.com/glycoinfo/GlycanBuilder2/pull/159)).

## Checks

`mvn clean verify`: **115 tests, 0 failures**, `glycanbuilder2-1.34.1.jar` builds. The regression test fails on the old code with `expected:<910.3278> but was:<892.317215352>` — verified by reverting the fix.

The 534 tests of glycanbuilder2web also pass built against this.

After merge: tag the merge commit `v1.34.1`, then `mvn deploy` locally from master.