### PR TITLE
Write a composition's GWS so it can be read back

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -1430,18 +1430,6 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 		}
 	}
 	
-	/**
-	   Whether a residue is the marker the WURCS importer attaches to a
-	   composition to say that no linkages are known, rather than a member of
-	   the composition itself. It carries no mass and must not be counted among
-	   the members: N members imply N-1 glycosidic bonds, and the marker is not
-	   one of them.
-	 */
-	private static boolean isCompositionMarker(Residue residue) {
-		return residue != null && residue.getType() != null
-				&& "no glycosidic linkages".equals(residue.getType().getDescription());
-	}
-
 	private double computeMass(Residue node, double multipler) {
 		if( node==null || node.getTypeName().equals("Sugar"))
 			return 0.;
@@ -1451,7 +1439,7 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 		// nothing, but left to fall through it collects a derivatization adjustment for the one
 		// bond it has to the bracket, which is why every derivatized composition read one
 		// methyl/acetyl group light. The renderers skip it by the same test.
-		if( isCompositionMarker(node) )
+		if( node.isCompositionMarker() )
 			return 0.;
 
 		// a composition has no distinguished reducing end of its own: the root
@@ -1520,7 +1508,7 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 				// renderers already skip it by the same test; the mass had not been told about it.
 				int no_members = 0;
 				for( int i=0; i<node.getNoChildren(); i++ )
-					if( !isCompositionMarker(node.getChildAt(i)) )
+					if( !node.getChildAt(i).isCompositionMarker() )
 						no_members++;
 				if( no_members>0 )
 					mass -= (no_members-1)*MassUtils.water.getMass();

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -589,6 +589,31 @@ public class Residue {
 		return type.isBracket();
 	}
 
+	/**
+       The description the WURCS importer gives the marker it hangs off a
+       composition to record that no linkages are known.
+       @see #isCompositionMarker
+	 */
+	public static final String NO_GLYCOSIDIC_LINKAGES = "no glycosidic linkages";
+
+	/**
+       Return <code>true</code> if this residue is the label a composition
+       carries to say that no linkages among its members are known, rather
+       than a member of the composition itself.
+       <p>
+       {@code WURCSSequence2ToGlycan} attaches it when reading a composition.
+       It is not a residue of the glycan: it weighs nothing, it is not one of
+       the N members whose N-1 implicit bonds a composition's mass accounts
+       for, it is not drawn, and no notation has a spelling for it. Everything
+       that walks a structure has to leave it out, and each place that forgot
+       has been a fault of its own - the mass read one water and one
+       derivatization group light, and the GWS written for a composition could
+       not be read back.
+	 */
+	public boolean isCompositionMarker() {
+		return type != null && NO_GLYCOSIDIC_LINKAGES.equals(type.getDescription());
+	}
+
 	/*
        Return <code>true</code> if this residue is contained in a
        terminal structure linked to a bracket residue.

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGWS/GWSParser.java
@@ -295,16 +295,25 @@ public class GWSParser implements GlycanParser {
 		//-----------------
 		// write children
 
+		// A composition carries a marker saying that no linkages among its members are known. It
+		// is a label, not a residue, and GWS has no spelling for it: written out like a child it
+		// became "--?no glycosidic linkages", where the parser reads everything after "--?" as a
+		// linkage, meets a sentence and stops - so a composition's own GWS could not be read back
+		// (#162). It is left out here, as it is left out of the drawing and of the mass.
 		ArrayList<String> str_children = new ArrayList();
-		for( Linkage l : r.getChildrenLinkages() )
+		for( Linkage l : r.getChildrenLinkages() ) {
+			if( l.getChildResidue()!=null && l.getChildResidue().isCompositionMarker() )
+				continue;
 			str_children.add("--" + toStringLinkage(l)
 					+ writeSubtree(l.getChildResidue(), ordered, bboxManager, visited));
+		}
 
 		if( ordered ) 
 			Collections.sort(str_children);    
 
-		// add parenthesis    
-		for( int i=0; i<r.getChildrenLinkages().size()-1; i++ ) 
+		// add parenthesis - one fewer than the children actually written, which is not necessarily
+		// how many the residue has
+		for( int i=0; i<str_children.size()-1; i++ ) 
 			str += "(";       
 
 		// write children

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
@@ -499,7 +499,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 	private void addLegendMargin (Rectangle _bbox, Glycan _glycan) {
 		for (Residue res : _glycan.getAllResidues()) {
 			if (!res.getType().getSuperclass().equals("Assigned")) continue;
-			if (res.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (res.isCompositionMarker()) continue;
 			_bbox.height = _bbox.height + theGraphicOptions.MASS_TEXT_SPACE;
 		}
 	}
@@ -549,7 +549,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 			Residue child = link.getChildResidue();
 			Residue matching_child = (child.getCleavedResidue() != null) ? child.getCleavedResidue() : child;
 
-			if (child.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (child.isCompositionMarker()) continue;
 
 			ResiduePlacement default_placement = theResiduePlacementDictionary.getPlacement(current, link, matching_child, sticky);
 			onBorder.put(child, default_placement.isOnBorder());
@@ -572,7 +572,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		for (Iterator<Linkage> i = current.iterator(); i.hasNext();) {
 			Residue child = i.next().getChildResidue();
 
-			if (child.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (child.isCompositionMarker()) continue;
 
 			ResiduePlacement child_placement = bookManager.getPlacement(child);
 			ResAngle child_pos = bookManager.getPosition(child);
@@ -1261,7 +1261,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		TreeMap<String, Pair<Residue, Integer>> unique_antennae = new TreeMap<String, Pair<Residue, Integer>>();
 		for (int i = 0; i < bracket.getNoChildren(); i++) {
 			Residue child = bracket.getChildAt(i); // avoid concurrent
-			if (child.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (child.isCompositionMarker()) continue;
 			// modification of
 			// iterator!!
 			String child_str = (COLLAPSE_MULTIPLE_ANTENNAE) ? GWSParser.writeSubtree(child, false) : ("" + (id++));
@@ -1351,7 +1351,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		TreeMap<String, Pair<Residue, Integer>> unique_antennae = new TreeMap<>();
 		for (int i = 0; i < bracket.getNoChildren(); i++) {
 			Residue child = bracket.getChildAt(i); // avoid concurrent
-			if (child.getType().getDescription().equals("no glycosidic linkages")) {
+			if (child.isCompositionMarker()) {
 				isNoGlycosidicLinkages = true;
 				continue;
 			}
@@ -1445,7 +1445,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		TreeMap<String, Pair<Residue, Integer>> unique_antennae = new TreeMap<String, Pair<Residue, Integer>>();
 		for (int i = 0; i < bracket.getNoChildren(); i++) {
 			Residue child = bracket.getChildAt(i); // avoid concurrent
-			if (child.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (child.isCompositionMarker()) continue;
 			// modification of
 			// iterator!!
 			String child_str = (COLLAPSE_MULTIPLE_ANTENNAE) ? GWSParser.writeSubtree(child, false) : ("" + (id++));
@@ -1536,7 +1536,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		TreeMap<String, Pair<Residue, Integer>> unique_antennae = new TreeMap<String, Pair<Residue, Integer>>();
 		for (int i = 0; i < bracket.getNoChildren(); i++) {
 			Residue child = bracket.getChildAt(i); // avoid concurrent
-			if (child.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (child.isCompositionMarker()) continue;
 			// modification of
 			// iterator!!
 			String child_str = (COLLAPSE_MULTIPLE_ANTENNAE) ? GWSParser.writeSubtree(child, false) : ("" + (id++));
@@ -1635,7 +1635,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		for (Linkage link : bracket.getChildrenLinkages()) {
 			Residue child = link.getChildResidue();
 
-			if (child.getType().getDescription().equals("no glycosidic linkages")) continue;
+			if (child.isCompositionMarker()) continue;
 
 			int quantity = bboxManager.getLinkedResidues(child).size() + 1;
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionGwsCanBeReadBackTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CompositionGwsCanBeReadBackTest.java
@@ -1,0 +1,62 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.Test;
+
+/**
+ * A composition read from WURCS can be written to GWS and read back.
+ *
+ * <p>It could not. The marker a composition carries to say that no linkages are known was written
+ * out like a child - {@code --?no glycosidic linkages} - and the parser, reading everything after
+ * {@code --?} as a linkage, met a sentence and stopped: <em>invalid format for linkage: " glycosidic
+ * linkages"</em>. So a composition could not be moved between the two formats the application itself
+ * uses.
+ */
+public class CompositionGwsCanBeReadBackTest {
+
+	/** Hex3HexNAc2 - the N-glycan core's composition. */
+	private static final String AS_WURCS = "WURCS=2.0/2,5,0/[u2122h_2*NCC/3=O][u1122h]/1-1-2-2-2/";
+
+	@Test
+	public void aCompositionSurvivesTheRoundTrip() throws Exception {
+		Glycan composition = fromWurcs();
+		String gws = composition.toString();
+
+		assertFalse("the marker is written into the GWS: " + gws,
+				gws.contains(Residue.NO_GLYCOSIDIC_LINKAGES));
+
+		Glycan readBack = Glycan.fromString(gws);
+		assertNotNull("the GWS a composition writes cannot be read back: " + gws, readBack);
+	}
+
+	/** And weighs the same on the way back, which is what the round trip is for. */
+	@Test
+	public void andWeighsTheSameOnTheWayBack() throws Exception {
+		Glycan composition = fromWurcs();
+
+		Glycan readBack = Glycan.fromString(composition.toString());
+
+		assertEquals(composition.computeMass(), readBack.computeMass(), 1e-6);
+		assertEquals(910.3278, readBack.computeMass(), 1e-3);
+	}
+
+	private static Glycan fromWurcs() throws Exception {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.setAutoSave(false);
+		GlycanDocument document = workspace.getStructures();
+		document.importFromString(AS_WURCS, "wurcs2");
+
+		List<Glycan> structures = document.getStructures();
+		return structures.get(0);
+	}
+}


### PR DESCRIPTION
Closes #162.

## What was wrong

A composition imported from WURCS wrote GWS the GWS parser could not read. The marker a composition carries to say that no linkages are known was written out like a child:

```
freeEnd}(((((--?D-GlcNAc)--?D-GlcNAc)--?D-Man)--?D-Man)--?D-Man)--?no glycosidic linkages$MONO,Und,0,0,freeEnd
```

The parser reads everything after `--?` as a linkage, meets a sentence and stops — *invalid format for linkage: " glycosidic linkages"*. A composition could not be moved between the two formats the application itself uses.

## The fix

The marker is left out of what is written, as it is left out of the drawing and — since 1.34.1 — of the mass. **The parenthesis count now follows the children actually written**, rather than how many the residue has, which stops being the same number once one is skipped.

## And a predicate to stop this recurring

`Residue#isCompositionMarker()`, with the description it matches as `Residue.NO_GLYCOSIDIC_LINKAGES`.

Three places had grown their own copy of that string comparison — the renderers in eight places, the mass calculation, and now the writer — and **each place that had not grown one was a fault**: the mass read a water and a derivatization group light ([1.34.1](https://github.com/glycoinfo/GlycanBuilder2/pull/160)), and this. All of them now ask the residue.

## Checks

| | |
|---|---|
| the GWS no longer contains the marker | ✅ |
| it parses back | ✅ |
| it weighs the same on the way back | ✅ 910.3278 for Hex3HexNAc2 |
| the test fails on the old writer | ✅ verified by reverting |
| library tests | **117, 0 failures** |
| glycanbuilder2web tests against this | **534, 0 failures** |