### PR TITLE
Take the derivatization off a composition's implicit bonds too

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -1512,6 +1512,22 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 						no_members++;
 				if( no_members>0 )
 					mass -= (no_members-1)*MassUtils.water.getMass();
+
+				// A glycosidic bond also consumes a hydroxyl that would otherwise carry a
+				// derivatization group, and the members - each attached to the bracket rather than
+				// to one another - are derivatized as though they were free. Underivatized this
+				// costs nothing, which is why it went unseen; permethylated, a composition read
+				// higher than the same glycan written with its linkages, and permethylation is the
+				// ordinary preparation in MS glycomics.
+				//
+				// Measured against the linked structure of the same residues, for N = 2..7 and for
+				// branched as well as straight chains (mass does not depend on topology): the
+				// excess is N-2 groups, one fewer than the N-1 bonds whose water is taken off
+				// above. The remaining one is already accounted for in the walk - the root of a
+				// composition returns before it can add its own adjustment (see the top of this
+				// method) - so taking off N-1 here would overshoot by exactly that one.
+				if( no_members>1 )
+					mass -= (no_members-2)*substitutionMass();
 			}
 		}
 		else if( node.isCleavage() && !node.isRingFragment() ) {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/DerivatizedCompositionWeighsTheSameTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/DerivatizedCompositionWeighsTheSameTest.java
@@ -1,0 +1,101 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.massutil.CompositionOptions;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * A derivatized composition weighs what the same glycan written with its linkages weighs.
+ *
+ * <p>It did not. Underivatized the two agreed (1.34.1), but derivatized the composition gained one
+ * group per implicit glycosidic bond less one: permethylated Hex3HexNAc2 read 1190.6408 against
+ * 1148.5938, which is 3 x CH2. A glycosidic bond consumes a hydroxyl that would otherwise be
+ * derivatized, and the members - attached to the bracket rather than to one another - were
+ * derivatized as though they were free.
+ *
+ * <p>The linked figures are checkable without this code: permethylated Man3GlcNAc2 as [M+Na]+ is
+ * 1171.58 in the literature, and the permethylated Hex residue increment is 204.0998. The second is
+ * the sharper test, and is asserted below - adding one Hex to a glycan must add exactly one
+ * permethylated Hex residue, whichever way the glycan is written.
+ */
+public class DerivatizedCompositionWeighsTheSameTest {
+
+	/** Published permethylated residue increments. */
+	private static final double PERMETHYLATED_HEX = 204.0998;
+
+	/**
+	 * The residue dictionary and its mass tables are filled in when a workspace is built. Without
+	 * one every residue type weighs zero, and the sums come out negative.
+	 */
+	@BeforeClass
+	public static void loadTheResidueMasses() {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+		workspace.setAutoSave(false);
+	}
+
+	@Test
+	public void underEveryDerivatization() throws Exception {
+		for (String derivatization : new String[] { MassOptions.NO_DERIVATIZATION,
+				MassOptions.PERMETHYLATED, MassOptions.HEAVYPERMETHYLATION,
+				MassOptions.PERDMETHYLATED, MassOptions.PERACETYLATED, MassOptions.PERDACETYLATED }) {
+			assertEquals(derivatization,
+					linkedMan3GlcNAc2(derivatization), composition(3, 2, derivatization), 1e-6);
+		}
+	}
+
+	/** Permethylated Man3GlcNAc2, the figure a table of permethylated masses gives. */
+	@Test
+	public void andAgreesWithThePublishedFigure() throws Exception {
+		assertEquals(1148.5938, composition(3, 2, MassOptions.PERMETHYLATED), 1e-3);
+	}
+
+	/**
+	 * One more Hex adds one permethylated Hex residue, and nothing else.
+	 *
+	 * <p>The test that does not depend on remembering a total: whatever the absolute masses are, the
+	 * step between consecutive sizes is the residue increment. It was 218.1154 - one CH2 too many
+	 * every time.
+	 */
+	@Test
+	public void andOneMoreHexAddsOneHexResidue() throws Exception {
+		for (int hexoses = 1; hexoses < 6; hexoses++) {
+			assertEquals("Hex" + hexoses + " -> Hex" + (hexoses + 1),
+					PERMETHYLATED_HEX,
+					composition(hexoses + 1, 2, MassOptions.PERMETHYLATED)
+							- composition(hexoses, 2, MassOptions.PERMETHYLATED),
+					1e-3);
+		}
+	}
+
+	private static double composition(int hexoses, int hexNAcs, String derivatization) throws Exception {
+		CompositionOptions counted = new CompositionOptions();
+		counted.HEX = hexoses;
+		counted.HEXNAC = hexNAcs;
+
+		return counted.getCompositionAsGlycan(massOptions(derivatization)).computeMass();
+	}
+
+	/** The N-glycan core, written with its linkages: Hex3HexNAc2's structure. */
+	private static double linkedMan3GlcNAc2(String derivatization) throws Exception {
+		Glycan linked = Glycan.fromString("freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p--4b1D-Man,p"
+				+ "(--3a1D-Man,p)--6a1D-Man,p$MONO,Und,0,0,freeEnd");
+		linked.setMassOptions(massOptions(derivatization));
+
+		return linked.computeMass();
+	}
+
+	private static MassOptions massOptions(String derivatization) {
+		MassOptions options = new MassOptions();
+		options.DERIVATIZATION = derivatization;
+		options.ION_CLOUD = new IonCloud();
+
+		return options;
+	}
+}


### PR DESCRIPTION
Closes #165.

Underivatized, a composition and the linked structure of the same residues have agreed since 1.34.1. **Derivatized they did not** — the composition gained one group per implicit glycosidic bond, less one.

| glycan | residues / bonds | derivatization | linked | composition, before | after |
|---|---|---|---|---|---|
| Man3GlcNAc2 | 5 / 4 | permethylated | **1148.5938** | 1190.6408 | **1148.5938** |
| Man3GlcNAc2 | 5 / 4 | peracetylated | **1540.4863** | 1666.5179 | **1540.4863** |
| Man5GlcNAc2 | 7 / 6 | permethylated | **1556.7934** | 1626.8716 | **1556.7934** |

A glycosidic bond consumes a hydroxyl that would otherwise be derivatized. The bracket's composition branch takes the **water** off for the N−1 implicit bonds; nothing took the matching **derivatization** off, and the members — attached to the bracket rather than to one another — were derivatized as though they were free.

Measured for N = 2..7, straight and branched alike: the excess is N−2 groups, one fewer than the N−1 whose water is subtracted. The remaining one is already accounted for — the root of a composition returns before it adds its own adjustment.

## That the linked column is the right one is checkable without this code

Permethylated Man3GlcNAc2 as [M+Na]⁺ is **1171.58** in the literature, and **1171.5836** here.

Sharper, because it needs no remembered total: **adding one Hex to a glycan must add exactly one permethylated Hex residue, 204.0998.**

| after adding a Hex | linked | composition, before |
|---|---|---|
| N=3 | 204.0998 | 218.1154 |
| N=4 | 204.0998 | 218.1155 |
| N=5 | 204.0997 | 218.1154 |
| N=6 | 204.0998 | 218.1154 |
| N=7 | 204.0998 | 218.1154 |

The test asserts the increment, so it holds without anyone remembering a total.

## Verified across every combination the mass options offer

Composition against linked, all agreeing to 1e-6: **six derivatizations**, **seven ion adducts** at one to three charges, **four neutral exchanges**, and those crossed with each other.

One combination cannot be asked at all — a reducing-end label on a composition throws `IndexOutOfBoundsException` from `setReducingEndType`, filed as **#166**. It should be refused rather than supported: a composition does not say which residue is at the reducing end, and reductive amination acts on that residue, so the mass is not determined.

## Checks

**120 tests.** The new test fails on the old code with `expected:<1148.5938> but was:<1190.6407813179999>` — verified by reverting.