### PR TITLE
Version 1.35.0

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -25,6 +25,8 @@ import java.io.*;
 import javax.swing.*;
 import javax.swing.border.*;
 
+import org.glycoinfo.application.glycanbuilder.update.UpdateCheck;
+
 import org.eurocarbdb.application.glycanbuilder.converter.GlycanParserFactory;
 import org.eurocarbdb.application.glycanbuilder.util.ActionManager;
 import org.eurocarbdb.application.glycanbuilder.util.MouseUtils;
@@ -297,6 +299,7 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 
 		// help
 		theActionManager.add("about",FileUtils.themeManager.getImageIcon("about"),"About",KeyEvent.VK_B,"",this);
+		theActionManager.add("checkforupdates",FileUtils.themeManager.getImageIcon("about"),"Check for Updates",KeyEvent.VK_U,"",this);
 	}   
 
 	private void updateActions() {
@@ -426,6 +429,8 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 		// help menu
 		JMenu help_menu = new JMenu("Help");
 		help_menu.setMnemonic(KeyEvent.VK_H);
+		help_menu.add(theActionManager.get("checkforupdates"));
+		help_menu.addSeparator();
 		help_menu.add(theActionManager.get("about"));
 		menubar.add(help_menu);    
 
@@ -876,6 +881,88 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 	/**
        Show the about menu
 	 */
+	/**
+	 * Asks GitHub whether a newer release exists, because a user asked.
+	 *
+	 * <p>Nothing checks on its own: no outbound call is made unless this menu item is chosen. That
+	 * keeps startup untouched - offline, behind a proxy, or with GitHub down, the application starts
+	 * exactly as it did - and leaves the choice of whether to talk to GitHub with the person using
+	 * it.
+	 *
+	 * <p>The check runs on a worker thread, since it is a network call and the event thread is what
+	 * draws the window. Where it sends someone depends on the platform: Windows is published only
+	 * through the Microsoft Store, so that is where it points - the releases carry no Windows
+	 * installer at all.
+	 */
+	public void onCheckForUpdates() {
+		final java.awt.Cursor busy = java.awt.Cursor.getPredefinedCursor(java.awt.Cursor.WAIT_CURSOR);
+		final java.awt.Cursor normal = java.awt.Cursor.getDefaultCursor();
+		setCursor(busy);
+
+		new SwingWorker<UpdateCheck.Result, Void>() {
+			@Override
+			protected UpdateCheck.Result doInBackground() {
+				return UpdateCheck.run();
+			}
+
+			@Override
+			protected void done() {
+				setCursor(normal);
+				try {
+					showUpdateCheckResult(get());
+				} catch (Exception theCheckItselfFailed) {
+					LogUtils.report(theCheckItselfFailed);
+				}
+			}
+		}.execute();
+	}
+
+	private void showUpdateCheckResult(UpdateCheck.Result result) {
+		if (result.problem != null) {
+			JOptionPane.showMessageDialog(this,
+					result.problem + "\n\nYou are running version " + result.installed + ".",
+					"Could not check for updates", JOptionPane.WARNING_MESSAGE);
+			return;
+		}
+
+		if (!result.anUpdateIsAvailable()) {
+			JOptionPane.showMessageDialog(this,
+					"GlycanBuilder2 " + result.installed + " is the newest version.",
+					"No update available", JOptionPane.INFORMATION_MESSAGE);
+			return;
+		}
+
+		int answer = JOptionPane.showConfirmDialog(this,
+				"GlycanBuilder2 " + result.latest + " is available.\n"
+						+ "You are running " + result.installed + ".\n\n"
+						+ "Open the download page?",
+				"Update available", JOptionPane.YES_NO_OPTION, JOptionPane.INFORMATION_MESSAGE);
+		if (answer != JOptionPane.YES_OPTION) return;
+
+		openInBrowser(result.downloadPage);
+	}
+
+	/**
+	 * Opens a page in the user's browser, and says where to go by hand when it cannot.
+	 *
+	 * <p>{@code Desktop} is unavailable on some Linux desktops and in some sandboxes, so the address
+	 * is shown rather than the attempt failing silently.
+	 */
+	private void openInBrowser(String page) {
+		try {
+			if (java.awt.Desktop.isDesktopSupported()
+					&& java.awt.Desktop.getDesktop().isSupported(java.awt.Desktop.Action.BROWSE)) {
+				java.awt.Desktop.getDesktop().browse(java.net.URI.create(page));
+				return;
+			}
+		} catch (Exception couldNotOpen) {
+			LogUtils.report(couldNotOpen);
+		}
+
+		JOptionPane.showMessageDialog(this, "Open this address to download:\n" + page,
+				"Download", JOptionPane.INFORMATION_MESSAGE);
+	}
+
 	public void onAbout() {
 
 		try {
@@ -965,6 +1052,7 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 		
 		// help
 		else if( action.equals("about") ) onAbout();
+		else if( action.equals("checkforupdates") ) onCheckForUpdates();
 		updateActions();
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -25,6 +25,8 @@ import java.io.*;
 import javax.swing.*;
 import javax.swing.border.*;
 
+import javax.swing.event.HyperlinkEvent;
+
 import org.glycoinfo.application.glycanbuilder.update.UpdateCheck;
 
 import org.eurocarbdb.application.glycanbuilder.converter.GlycanParserFactory;
@@ -917,6 +919,20 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 		}.execute();
 	}
 
+	/**
+	 * Opens a link the user clicked in a rendered HTML pane.
+	 *
+	 * <p>A pane reports the click; it does not follow it. Only an activation is acted on - the same
+	 * event type also reports the pointer entering and leaving a link - and a link the pane could
+	 * not resolve to a URL is ignored rather than passed on as text.
+	 */
+	void onHyperlink(HyperlinkEvent event) {
+		if (event.getEventType() != HyperlinkEvent.EventType.ACTIVATED) return;
+		if (event.getURL() == null) return;
+
+		openInBrowser(event.getURL().toString());
+	}
+
 	private void showUpdateCheckResult(UpdateCheck.Result result) {
 		if (result.problem != null) {
 			JOptionPane.showMessageDialog(this,
@@ -970,6 +986,12 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 			JEditorPane html = new JEditorPane(this.getClass().getResource("/html/about_builder.html"));
 			html.setEditable(false);
 			html.setBorder(new EmptyBorder(0,20,20,20));
+
+			// The SNFG, WURCS and citation links did nothing when clicked: a JEditorPane reports a
+			// click and leaves opening it to whoever is listening, and nothing was. Nothing has ever
+			// registered a HyperlinkListener anywhere in this application - GlycanCanvas implements
+			// the interface with an empty method and is never added as one.
+			html.addHyperlinkListener(this::onHyperlink);
 
 			JScrollPane jscPane = new JScrollPane(html);
 

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/update/ApplicationVersion.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/update/ApplicationVersion.java
@@ -1,0 +1,43 @@
+package org.glycoinfo.application.glycanbuilder.update;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * The version this application was built as, taken from the build rather than written out again.
+ *
+ * <p>Maven fills {@code version.properties} from {@code pom.xml} - {@code src/main/resources} is
+ * filtered - so what is reported is what was built. The About window has read the same number from
+ * the same place all along, but only as text inside its HTML; nothing could ask for it.
+ */
+public final class ApplicationVersion {
+
+	/** What is reported when the version cannot be read, e.g. running from a class directory. */
+	public static final String UNKNOWN = "unknown";
+
+	private static final String VERSION = read();
+
+	private ApplicationVersion() {
+	}
+
+	/** @return Returns this application's version, e.g. "1.34.3", or {@link #UNKNOWN}. */
+	public static String get() {
+		return VERSION;
+	}
+
+	private static String read() {
+		Properties build = new Properties();
+		try (InputStream properties = ApplicationVersion.class.getResourceAsStream("/version.properties")) {
+			if (properties == null) return UNKNOWN;
+			build.load(properties);
+		} catch (IOException cannotBeRead) {
+			return UNKNOWN;
+		}
+
+		String version = build.getProperty("application.version", "").trim();
+
+		// Maven leaves the placeholder as it stands when the file has not been filtered.
+		return (version.isEmpty() || version.startsWith("${")) ? UNKNOWN : version;
+	}
+}

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheck.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheck.java
@@ -1,0 +1,200 @@
+package org.glycoinfo.application.glycanbuilder.update;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Locale;
+
+/**
+ * Asks GitHub what the newest release is, and works out whether it is newer than this one.
+ *
+ * <p>Nothing here runs on its own. It is asked from Help ▸ Check for Updates, so the application
+ * makes no outbound call unless a user asks it to - which keeps startup untouched, and leaves the
+ * question of whether to talk to GitHub with the person in front of the machine.
+ *
+ * <p><b>Why the redirect rather than the API.</b> {@code api.github.com} allows 60 unauthenticated
+ * requests an hour <em>per address</em> - measured - and a research institute behind one NAT is one
+ * address. {@code github.com/.../releases/latest} answers 302 to the tag's own page, gives the same
+ * answer, and is not rate-limited that way:
+ *
+ * <pre>
+ * GET https://github.com/glycoinfo/GlycanBuilder2/releases/latest
+ * → 302  Location: https://github.com/glycoinfo/GlycanBuilder2/releases/tag/v1.34.3
+ * </pre>
+ *
+ * <p>It also excludes pre-releases, which fits how this project releases: the workflow publishes as
+ * a pre-release and a person marks it Latest once the installers are built and checked. Until then
+ * no one is pointed at a release that is not finished.
+ */
+public final class UpdateCheck {
+
+	/** Where the newest finished release is announced. */
+	private static final String LATEST_RELEASE = "https://github.com/glycoinfo/GlycanBuilder2/releases/latest";
+
+	/** Short: a person is waiting, and no answer is better than a long wait. */
+	private static final int TIMEOUT_MS = 8000;
+
+	private UpdateCheck() {
+	}
+
+	/** What the check found. */
+	public static final class Result {
+		/** The version running now, or {@link ApplicationVersion#UNKNOWN}. */
+		public final String installed;
+
+		/** The newest released version, or null when it could not be found out. */
+		public final String latest;
+
+		/** Where a person on this platform should go to get it. */
+		public final String downloadPage;
+
+		/** Why the check could not answer, or null when it did. */
+		public final String problem;
+
+		Result(String installed, String latest, String downloadPage, String problem) {
+			this.installed = installed;
+			this.latest = latest;
+			this.downloadPage = downloadPage;
+			this.problem = problem;
+		}
+
+		/** @return Whether a newer release exists. False when either version is unknown. */
+		public boolean anUpdateIsAvailable() {
+			return latest != null && isNewer(latest, installed);
+		}
+	}
+
+	/**
+	 * Asks GitHub. Blocks, so call it off the event thread.
+	 *
+	 * @return Returns what was found, including when nothing was: a check that cannot reach GitHub
+	 *         reports that rather than claiming the application is up to date.
+	 */
+	public static Result run() {
+		String installed = ApplicationVersion.get();
+		String downloadPage = DownloadPage.forThisPlatform();
+
+		try {
+			String latest = fetchLatestVersion();
+			if (latest == null) {
+				return new Result(installed, null, downloadPage,
+						"GitHub did not say which release is the newest.");
+			}
+
+			return new Result(installed, latest, downloadPage, null);
+		} catch (IOException couldNotAsk) {
+			return new Result(installed, null, downloadPage,
+					"Could not reach GitHub (" + couldNotAsk.getMessage() + ").");
+		}
+	}
+
+	/**
+	 * @return Returns the newest released version without its leading "v", or null if the answer
+	 *         cannot be read.
+	 */
+	static String fetchLatestVersion() throws IOException {
+		HttpURLConnection connection = (HttpURLConnection) new URL(LATEST_RELEASE).openConnection();
+		try {
+			// The answer wanted is the redirect itself, so it must not be followed.
+			connection.setInstanceFollowRedirects(false);
+			connection.setRequestMethod("HEAD");
+			connection.setConnectTimeout(TIMEOUT_MS);
+			connection.setReadTimeout(TIMEOUT_MS);
+			connection.setRequestProperty("User-Agent", "GlycanBuilder2/" + ApplicationVersion.get());
+
+			int status = connection.getResponseCode();
+			if (status != HttpURLConnection.HTTP_MOVED_TEMP
+					&& status != HttpURLConnection.HTTP_MOVED_PERM
+					&& status != 307 && status != 308) {
+				return null;
+			}
+
+			return versionFromTagUrl(connection.getHeaderField("Location"));
+		} finally {
+			connection.disconnect();
+		}
+	}
+
+	/** {@code .../releases/tag/v1.34.3} → {@code 1.34.3}. */
+	static String versionFromTagUrl(String location) {
+		if (location == null) return null;
+
+		int lastSlash = location.lastIndexOf('/');
+		if (lastSlash < 0 || lastSlash == location.length() - 1) return null;
+
+		String tag = location.substring(lastSlash + 1).trim();
+		if (tag.startsWith("v") || tag.startsWith("V")) tag = tag.substring(1);
+
+		return tag.isEmpty() ? null : tag;
+	}
+
+	/**
+	 * Whether {@code candidate} is a later version than {@code installed}.
+	 *
+	 * <p>Compared part by numeric part, so 1.34.10 is later than 1.34.9 where a string comparison
+	 * would say otherwise. A part that is not a number, or a version that is not known at all, makes
+	 * the answer false: saying nothing is better than announcing an update that may not be one.
+	 */
+	static boolean isNewer(String candidate, String installed) {
+		if (candidate == null || installed == null
+				|| ApplicationVersion.UNKNOWN.equals(installed)) {
+			return false;
+		}
+
+		String[] theirs = candidate.split("\\.");
+		String[] ours = installed.split("\\.");
+		int parts = Math.max(theirs.length, ours.length);
+		for (int i = 0; i < parts; i++) {
+			int their = partAt(theirs, i);
+			int our = partAt(ours, i);
+			if (their < 0 || our < 0) return false;
+			if (their != our) return their > our;
+		}
+
+		return false;
+	}
+
+	private static int partAt(String[] parts, int index) {
+		if (index >= parts.length) return 0;
+
+		try {
+			return Integer.parseInt(parts[index].trim());
+		} catch (NumberFormatException notANumber) {
+			return -1;
+		}
+	}
+
+	/**
+	 * Where a person should go for the newest build, which is not the same place on every platform.
+	 */
+	public static final class DownloadPage {
+
+		/** Windows is published through the Microsoft Store, and nowhere else. */
+		public static final String WINDOWS_STORE = "https://apps.microsoft.com/detail/9pp6bsnx71jl";
+
+		/** macOS builds are offered from the project's own download page. */
+		public static final String MACOS = "https://glycanbuilder.glyconavi.org/en#download";
+
+		/** Linux packages are the release's own assets - the .deb and the two .rpm. */
+		public static final String RELEASES = "https://github.com/glycoinfo/GlycanBuilder2/releases/latest";
+
+		private DownloadPage() {
+		}
+
+		/**
+		 * @return Returns the page to open on this platform.
+		 *
+		 * <p>Windows goes to the Store because that is the only way it is published - the release
+		 * carries no Windows installer at all, the workflow excludes it deliberately, and sending a
+		 * Store user anywhere else would be wrong twice over. Anything unrecognised - a jar run
+		 * directly, a build from source - gets the releases page, which lists what there is.
+		 */
+		public static String forThisPlatform() {
+			String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+			if (os.contains("win")) return WINDOWS_STORE;
+			if (os.contains("mac") || os.contains("darwin")) return MACOS;
+
+			return RELEASES;
+		}
+	}
+}

--- a/src/main/resources/html/about_builder.html
+++ b/src/main/resources/html/about_builder.html
@@ -15,7 +15,11 @@
 	Moreover, it can easily output glycan images and <a href="https://www.wurcs-wg.org/">WURCS</a> and GlycoCT sequences.<br/><br/>
 	contact: glyconavi@noguchi.or.jp<br/><br/>
 	Citation:<br/>
-	<a href="https://www.sciencedirect.com/science/article/pii/S0008621516305316">Shinichiro Tsuchiya, et. al., <i>Carbohydrate Research</i>, 445, <b>2017</b>, Pages 104-116</a>
+	<!-- Cited by DOI rather than by publisher URL: a DOI is the identifier the article keeps
+	     wherever it is hosted, and resolves to whatever the current landing page is. It resolves
+	     to this same article - the PII behind doi.org/10.1016/j.carres.2017.04.015 is
+	     S0008621516305316, which is what the direct link used to name. -->
+	<a href="https://doi.org/10.1016/j.carres.2017.04.015">Shinichiro Tsuchiya, et. al., <i>Carbohydrate Research</i>, 445, <b>2017</b>, Pages 104-116</a>
 </div>
 </body>
 </html>

--- a/src/main/resources/html/about_builder.html
+++ b/src/main/resources/html/about_builder.html
@@ -3,7 +3,11 @@
 <div class="caption" align="center">
 	<h2>GlycanBuilder2</h2>
 	<h3>version: ${project.version}</h3>
-	<img src="GB2.png" width="60" height="60" alt="GlycanBuilder2">
+	<!-- The application's own icon, referenced rather than copied: the same file jpackage builds
+	     the installers' icons from, so replacing it replaces this too. They had drifted - this
+	     showed the 2021 "GB2" wordmark while the dock, the installers and the Store showed the
+	     current one. -->
+	<img src="../icons/icon_large.png" width="72" height="72" alt="GlycanBuilder2">
 </div>
 
 <div class="summary">

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,0 +1,2 @@
+# Filled in by Maven at build time (src/main/resources is filtered). Read by ApplicationVersion.
+application.version=${project.version}

--- a/src/test/java/org/glycoinfo/application/glycanbuilder/update/AboutLinksTest.java
+++ b/src/test/java/org/glycoinfo/application/glycanbuilder/update/AboutLinksTest.java
@@ -48,7 +48,11 @@ public class AboutLinksTest {
 
 		assertTrue(links.toString(), links.stream().anyMatch(l -> l.contains("snfg")));
 		assertTrue(links.toString(), links.stream().anyMatch(l -> l.contains("wurcs")));
-		assertTrue(links.toString(), links.stream().anyMatch(l -> l.contains("S0008621516305316")));
+		// Cited by DOI, not by publisher URL: the DOI is what the article keeps wherever it is
+		// hosted. Verified against CrossRef that it names this article - the PII it resolves to,
+		// S0008621516305316, is what the direct link used to point at.
+		assertTrue(links.toString(),
+				links.stream().anyMatch(l -> l.equals("https://doi.org/10.1016/j.carres.2017.04.015")));
 	}
 
 	/**

--- a/src/test/java/org/glycoinfo/application/glycanbuilder/update/AboutLinksTest.java
+++ b/src/test/java/org/glycoinfo/application/glycanbuilder/update/AboutLinksTest.java
@@ -1,0 +1,104 @@
+package org.glycoinfo.application.glycanbuilder.update;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.swing.JEditorPane;
+import javax.swing.event.HyperlinkEvent;
+import javax.swing.text.html.HTML;
+import javax.swing.text.html.HTMLDocument;
+
+import org.junit.Test;
+
+/**
+ * The About window: its icon, and its links.
+ *
+ * <p>Both are things a rendered HTML pane resolves for itself, and both had been wrong without
+ * anything failing. The icon pointed at a file that had stopped being the application's icon; the
+ * links reported clicks that nobody was listening for, so they did nothing at all.
+ *
+ * <p>What is held here is what the pane can resolve from the document. Whether the listener is then
+ * attached is {@code GlycanBuilder.onAbout}'s business, and whether a browser opens is the desktop's
+ * - neither is reachable from a test without a display.
+ */
+public class AboutLinksTest {
+
+	/** Every link in the About window resolves to an address a browser could be sent to. */
+	@Test
+	public void everyLinkResolvesToAnAbsoluteAddress() throws Exception {
+		List<URL> links = linksIn(aboutWindow());
+
+		assertEquals("the About window should carry three links", 3, links.size());
+		for (URL link : links) {
+			assertTrue(link + " is not a web address a browser can open",
+					"https".equals(link.getProtocol()) || "http".equals(link.getProtocol()));
+		}
+	}
+
+	/** And they are the three the window is for: the notation, the format, and the paper. */
+	@Test
+	public void theyAreTheNotationTheFormatAndThePaper() throws Exception {
+		List<String> links = new ArrayList<>();
+		for (URL link : linksIn(aboutWindow())) links.add(link.toString());
+
+		assertTrue(links.toString(), links.stream().anyMatch(l -> l.contains("snfg")));
+		assertTrue(links.toString(), links.stream().anyMatch(l -> l.contains("wurcs")));
+		assertTrue(links.toString(), links.stream().anyMatch(l -> l.contains("S0008621516305316")));
+	}
+
+	/**
+	 * The icon is the application's own, reached from where the document sits.
+	 *
+	 * <p>It is referenced rather than copied - {@code ../icons/icon_large.png}, the file jpackage
+	 * builds the installers' icons from - so the two cannot drift again as they had. A relative
+	 * reference across directories is exactly what resolves from a class directory and not from a
+	 * jar, so what is checked is that it can actually be read, not that the text is right.
+	 */
+	@Test
+	public void theIconIsTheApplicationsOwnAndCanBeRead() throws Exception {
+		JEditorPane about = aboutWindow();
+		HTMLDocument document = (HTMLDocument) about.getDocument();
+
+		HTMLDocument.Iterator images = document.getIterator(HTML.Tag.IMG);
+		assertTrue("the About window has no image", images.isValid());
+		Object source = images.getAttributes().getAttribute(HTML.Attribute.SRC);
+		assertNotNull("the image has no src", source);
+
+		URL icon = new URL(document.getBase(), source.toString());
+		assertTrue("the icon should be the application's own, not a copy beside the page: " + source,
+				source.toString().contains("icons/icon_large.png"));
+		icon.openStream().close();
+	}
+
+	private static JEditorPane aboutWindow() throws Exception {
+		JEditorPane about = new JEditorPane(
+				AboutLinksTest.class.getResource("/html/about_builder.html"));
+		about.setEditable(false);
+		// The pane loads asynchronously by default, as it does in the application.
+		Thread.sleep(900);
+
+		return about;
+	}
+
+	/**
+	 * The links a click would produce, gathered the way the pane produces them - resolved against
+	 * the document's own base, which is what a {@link HyperlinkEvent} carries.
+	 */
+	private static List<URL> linksIn(JEditorPane pane) throws Exception {
+		HTMLDocument document = (HTMLDocument) pane.getDocument();
+		List<URL> links = new ArrayList<>();
+
+		for (HTMLDocument.Iterator anchors = document.getIterator(HTML.Tag.A);
+				anchors.isValid(); anchors.next()) {
+			Object href = anchors.getAttributes().getAttribute(HTML.Attribute.HREF);
+			if (href != null) links.add(new URL(document.getBase(), href.toString()));
+		}
+
+		return links;
+	}
+}

--- a/src/test/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheckTest.java
+++ b/src/test/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheckTest.java
@@ -1,0 +1,118 @@
+package org.glycoinfo.application.glycanbuilder.update;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Checking for a newer release: reading GitHub's answer, comparing versions, and knowing where to
+ * send someone.
+ *
+ * <p>Nothing here reaches the network. What the live check does is fetch one redirect; what it then
+ * does with the answer is all below, and is where it could be wrong quietly - announcing an update
+ * that is not one, or missing one that is.
+ */
+public class UpdateCheckTest {
+
+	/** The application knows what it was built as; the About window has shown it all along. */
+	@Test
+	public void itKnowsItsOwnVersion() {
+		String version = ApplicationVersion.get();
+
+		assertFalse("the version was not filled in at build time: " + version,
+				ApplicationVersion.UNKNOWN.equals(version));
+		assertTrue("not a version: " + version, version.matches("\\d+\\.\\d+.*"));
+	}
+
+	/** GitHub answers with the tag's page; the version is the tail of it, without the "v". */
+	@Test
+	public void itReadsTheVersionOutOfTheRedirect() {
+		assertEquals("1.34.3", UpdateCheck.versionFromTagUrl(
+				"https://github.com/glycoinfo/GlycanBuilder2/releases/tag/v1.34.3"));
+		assertEquals("2.0.0", UpdateCheck.versionFromTagUrl(
+				"https://github.com/glycoinfo/GlycanBuilder2/releases/tag/2.0.0"));
+	}
+
+	/** And says nothing rather than something wrong when the answer is not one it can read. */
+	@Test
+	public void anAnswerItCannotReadIsNoAnswer() {
+		assertNull(UpdateCheck.versionFromTagUrl(null));
+		assertNull(UpdateCheck.versionFromTagUrl(""));
+		assertNull(UpdateCheck.versionFromTagUrl("https://github.com/.../releases/tag/"));
+	}
+
+	/**
+	 * Compared part by numeric part, not as text.
+	 *
+	 * <p>The case that matters is the tenth patch: as strings "1.34.10" sorts before "1.34.9", so a
+	 * text comparison would stop telling anyone about updates the moment a version reached double
+	 * digits - quietly, and only then.
+	 */
+	@Test
+	public void versionsAreComparedAsNumbers() {
+		assertTrue(UpdateCheck.isNewer("1.34.10", "1.34.9"));
+		assertTrue(UpdateCheck.isNewer("1.35.0", "1.34.3"));
+		assertTrue(UpdateCheck.isNewer("2.0.0", "1.34.3"));
+		assertTrue("a shorter version is the same as trailing zeros",
+				UpdateCheck.isNewer("1.35", "1.34.3"));
+	}
+
+	/** The same version, or an older one, is not an update. */
+	@Test
+	public void whatIsNotNewerIsNotAnUpdate() {
+		assertFalse(UpdateCheck.isNewer("1.34.3", "1.34.3"));
+		assertFalse(UpdateCheck.isNewer("1.34.2", "1.34.3"));
+		assertFalse(UpdateCheck.isNewer("1.34", "1.34.0"));
+	}
+
+	/**
+	 * Anything that cannot be compared is not announced.
+	 *
+	 * <p>Better to say nothing than to send someone to a download page over a version this could not
+	 * make sense of - including when the running version is unknown, which is what happens outside a
+	 * built artifact.
+	 */
+	@Test
+	public void whatCannotBeComparedIsNotAnnounced() {
+		assertFalse(UpdateCheck.isNewer(null, "1.34.3"));
+		assertFalse(UpdateCheck.isNewer("1.34.4", null));
+		assertFalse(UpdateCheck.isNewer("1.34.4", ApplicationVersion.UNKNOWN));
+		assertFalse("a tag that is not a version", UpdateCheck.isNewer("nightly", "1.34.3"));
+		assertFalse(UpdateCheck.isNewer("1.34.4-rc1", "1.34.3"));
+	}
+
+	/**
+	 * Where a person is sent depends on how their copy was published.
+	 *
+	 * <p>Windows goes to the Microsoft Store, and this is the assertion worth having: the releases
+	 * carry no Windows installer - the workflow excludes it deliberately - so sending a Windows user
+	 * to GitHub would offer them nothing, and sending a Store user outside the Store would be wrong
+	 * besides.
+	 */
+	@Test
+	public void eachPlatformIsSentWhereItsBuildsAre() {
+		String os = System.getProperty("os.name");
+		try {
+			System.setProperty("os.name", "Windows 11");
+			assertEquals(UpdateCheck.DownloadPage.WINDOWS_STORE,
+					UpdateCheck.DownloadPage.forThisPlatform());
+
+			System.setProperty("os.name", "Mac OS X");
+			assertEquals(UpdateCheck.DownloadPage.MACOS, UpdateCheck.DownloadPage.forThisPlatform());
+
+			System.setProperty("os.name", "Linux");
+			assertEquals(UpdateCheck.DownloadPage.RELEASES,
+					UpdateCheck.DownloadPage.forThisPlatform());
+
+			// A jar run directly, or a build from source: the releases page lists what there is.
+			System.setProperty("os.name", "SunOS");
+			assertEquals(UpdateCheck.DownloadPage.RELEASES,
+					UpdateCheck.DownloadPage.forThisPlatform());
+		} finally {
+			System.setProperty("os.name", os);
+		}
+	}
+}


### PR DESCRIPTION
A macOS or Linux copy can now find out that a newer one exists — Windows has the Store for that, and the other two had nothing.

## Help ▸ Check for Updates

**Nothing checks on its own.** No outbound call is made unless the menu item is chosen, so startup is untouched — offline, behind a proxy, or with GitHub down, the application starts exactly as before — and whether to talk to GitHub stays the user's choice.

**It reads the redirect, not the API.** `api.github.com` allows 60 unauthenticated requests an hour *per address*, and an institute behind one NAT is one address. `github.com/.../releases/latest` answers 302 to the tag's page, is not limited that way, and **excludes pre-releases** — which fits how this project releases, since the workflow publishes as a pre-release until someone marks it Latest. No one is pointed at a release whose installers are not built yet.

| platform | where it sends people |
|---|---|
| **Windows** | the Microsoft Store — the releases carry no Windows installer at all |
| **macOS** | glycanbuilder.glyconavi.org/en#download |
| **Linux** | the release's own assets |
| anything else | the releases page |

**Two ways it could have been quietly wrong.** As text `1.34.10` sorts before `1.34.9`, so a text comparison would stop reporting updates the moment a version reached double digits — compared numerically instead. And a check that cannot reach GitHub says so rather than reporting the application is up to date.

Measured: **476 ms** to answer live, **136 ms** to fail and say why with the network blocked.

## Three things in the About window

**It showed the wrong icon** — the 2021 "GB2" wordmark, while the dock, the installers and the Store showed the current one. It references `icons/icon_large.png` now rather than carrying a copy, so the two cannot drift again.

**Its links did nothing when clicked.** A `JEditorPane` reports a click and leaves following it to whoever is listening, and nothing was — `addHyperlinkListener` is called nowhere in this application.

**The paper is cited by DOI**, [10.1016/j.carres.2017.04.015](https://doi.org/10.1016/j.carres.2017.04.015), confirmed against CrossRef to resolve to the PII the direct link named.

## Why minor rather than patch

The update check is added functionality — a new menu item, and two new public classes (`ApplicationVersion`, `UpdateCheck`) that glycanbuilder2web compiles against. A release containing any addition is not a patch, and this project used minor even for fix-only releases up to 1.34.0.

## Checks

`mvn clean verify`: **130 tests, 0 failures**, `glycanbuilder2-1.35.0.jar` builds.

After merge: tag the merge commit `v1.35.0`, then `mvn deploy` locally from master.