### PR TITLE
Move the actions off Node 20, and give the shipped runtime its crypto

### DIFF
--- a/.github/workflows/jpackage_installer_linux.yml
+++ b/.github/workflows/jpackage_installer_linux.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -91,7 +91,7 @@ jobs:
       shell: bash
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-linux-debian
         path: installers/*
@@ -99,7 +99,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-linux-debian
         path: |

--- a/.github/workflows/jpackage_installer_linux.yml
+++ b/.github/workflows/jpackage_installer_linux.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_macos.yml
+++ b/.github/workflows/jpackage_installer_macos.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -161,7 +161,7 @@ jobs:
       shell: bash
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-${{ matrix.platform }}
         path: installers/*
@@ -169,7 +169,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-${{ matrix.platform }}
         path: |

--- a/.github/workflows/jpackage_installer_macos.yml
+++ b/.github/workflows/jpackage_installer_macos.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_rpm.yml
+++ b/.github/workflows/jpackage_installer_rpm.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_rpm.yml
+++ b/.github/workflows/jpackage_installer_rpm.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ matrix.distro }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -113,7 +113,7 @@ jobs:
       shell: bash
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-linux-rpm-${{ matrix.distro }}
         path: installers/*
@@ -121,7 +121,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-linux-rpm-${{ matrix.distro }}
         path: |

--- a/.github/workflows/jpackage_installer_windows.yml
+++ b/.github/workflows/jpackage_installer_windows.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_windows.yml
+++ b/.github/workflows/jpackage_installer_windows.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -126,7 +126,7 @@ jobs:
       shell: powershell
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-windows
         path: installers/*
@@ -134,7 +134,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-windows
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Download installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
@@ -42,7 +42,7 @@ jobs:
           find artifacts -type f -name "*" | sort
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: Release ${{ github.ref_name }}
           draft: false

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheck.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheck.java
@@ -83,9 +83,37 @@ public final class UpdateCheck {
 
 			return new Result(installed, latest, downloadPage, null);
 		} catch (IOException couldNotAsk) {
-			return new Result(installed, null, downloadPage,
-					"Could not reach GitHub (" + couldNotAsk.getMessage() + ").");
+			return new Result(installed, null, downloadPage, describe(couldNotAsk));
 		}
+	}
+
+	/**
+	 * Says what went wrong in terms of what the user can do about it.
+	 *
+	 * <p>Everything used to be reported as "could not reach GitHub", which was wrong for the failure
+	 * that actually happened first: the runtime image shipped in the installers had no elliptic-curve
+	 * provider, so the TLS handshake was refused. GitHub was reachable - the connection got as far as
+	 * agreeing on nothing. Someone reading "could not reach" checks their network, which is fine, and
+	 * learns nothing.
+	 *
+	 * @param problem What the connection threw.
+	 * @return Returns a sentence naming the kind of failure.
+	 */
+	static String describe(IOException problem) {
+		if (problem instanceof javax.net.ssl.SSLException) {
+			return "Could not make a secure connection to GitHub (" + problem.getMessage() + "). "
+					+ "This is not a network problem: the connection was made and the encryption "
+					+ "could not be agreed on.";
+		}
+		if (problem instanceof java.net.UnknownHostException) {
+			return "Could not find GitHub (" + problem.getMessage()
+					+ "). Check the network connection.";
+		}
+		if (problem instanceof java.net.SocketTimeoutException) {
+			return "GitHub did not answer in time.";
+		}
+
+		return "Could not ask GitHub (" + problem.getMessage() + ").";
 	}
 
 	/**

--- a/src/test/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheckTest.java
+++ b/src/test/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheckTest.java
@@ -85,6 +85,32 @@ public class UpdateCheckTest {
 	}
 
 	/**
+	 * A failure says which failure it was.
+	 *
+	 * <p>Every failure used to be reported as "could not reach GitHub", and the first one that
+	 * actually happened was not that: the runtime image in the installers had no elliptic-curve
+	 * provider, so the TLS handshake was refused. GitHub was reached; the two could not agree on
+	 * encryption. Someone told "could not reach" goes and checks their network, which is working.
+	 */
+	@Test
+	public void aFailureSaysWhichFailureItWas() {
+		String tls = UpdateCheck.describe(
+				new javax.net.ssl.SSLHandshakeException("Received fatal alert: handshake_failure"));
+		assertTrue(tls, tls.contains("secure connection"));
+		assertTrue("it should say this is not a network problem: " + tls,
+				tls.contains("not a network problem"));
+
+		String dns = UpdateCheck.describe(new java.net.UnknownHostException("github.com"));
+		assertTrue(dns, dns.contains("Could not find GitHub"));
+
+		String slow = UpdateCheck.describe(new java.net.SocketTimeoutException("Read timed out"));
+		assertTrue(slow, slow.contains("did not answer in time"));
+
+		String other = UpdateCheck.describe(new java.io.IOException("something else"));
+		assertTrue(other, other.contains("something else"));
+	}
+
+	/**
 	 * Where a person is sent depends on how their copy was published.
 	 *
 	 * <p>Windows goes to the Microsoft Store, and this is the assertion worth having: the releases


### PR DESCRIPTION
Two changes to the installer workflows. One is upkeep; the other is a fault that made every
installed copy unable to open an HTTPS connection.

## The shipped runtime had no elliptic-curve provider

The installers bundle a runtime jlink builds from a named list of modules, and `jdk.crypto.ec` was
not on it. That module carries the EC provider, and every modern TLS server — GitHub included —
offers only ECDHE key exchange, so the handshake was refused before any request was made:

```
Could not reach GitHub ((handshake_failure) Received fatal alert: handshake_failure)
```

**This is not about the update check.** A copy installed from any of these installers could not make
an HTTPS connection at all. The update check is simply the first thing that tried.

All four workflows carried the same module list, so **macOS, Linux, Windows and the RPMs were
affected equally** — the fault is in the module set, not the platform.

Reproduced and fixed against the JDK the installers actually ship, **21.0.12**:

| runtime | result |
|---|---|
| modules as they were | `handshake_failure` |
| **+ `jdk.crypto.ec`** | **302, the redirect the check reads** |

It is specific to that JDK line — the same list on JDK 25 connects fine, which is why nothing
suggested a problem when the check was written and tested on a full JDK. The deficient runtime only
exists inside the installers, and it had never been tested there. `jdk.crypto.cryptoki` was tried
too and changes nothing; `jdk.crypto.ec` alone is what is needed.

**The message now says which failure it was.** A refused handshake says the connection was made and
the encryption could not be agreed; an unknown host says to check the network; a timeout says GitHub
did not answer. Telling someone to check a network that is working sends them looking in the wrong
place.

Verified end to end on a runtime image built from the corrected list: installed 1.34.3, latest
1.35.0, update available, pointed at the macOS download page.

## The actions were still declaring Node 20

Every run warned that five actions declare Node 20 and are being forced onto Node 24. They work
today because GitHub does that forcing; they stop when Node 20 goes.

| action | was | now | newest |
|---|---|---|---|
| actions/checkout | v4 | **v5** | v7.0.1 |
| actions/cache | v4 | **v5** | v6.1.0 |
| actions/upload-artifact | v4 | **v6** | v7.0.1 |
| actions/download-artifact | v4 | **v7** | v8.0.1 |
| softprops/action-gh-release | v2 | **v3** | v3.0.2 |

`actions/setup-java@v5` already declared node24.

**The earliest node24 major, not the newest.** Those majors are runtime changes and nothing else —
each release note says so. The newest are not: `upload-artifact@v7` moves to ESM and adds an
`archive` parameter, and `download-artifact@v8` moves to ESM, stops unzipping everything, and
**makes a hash mismatch an error by default**. That last one would add a way for the release
workflow to fail on a check it does not have today, in exchange for nothing this project needs — and
the run this follows failed on a transient network fault, which is exactly when a hash check would
bite.

upload and download moved together on purpose: they are the two ends of one handover, and v3 → v4
showed what happens when those ends disagree.

Runner requirement (2.327.1) is met — every job runs on a GitHub-hosted runner.

## Checks

- `runs.using` read from each tag's own `action.yml`: **all six actions now declare node24**
- the corrected module list built and exercised on **JDK 17, 21.0.12 and 25**
- **131 tests**

A release workflow can only really be checked by releasing, so the next release proves both halves.