### PR TITLE
Version 1.35.1

### DIFF
--- a/.github/workflows/jpackage_installer_linux.yml
+++ b/.github/workflows/jpackage_installer_linux.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -91,7 +91,7 @@ jobs:
       shell: bash
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-linux-debian
         path: installers/*
@@ -99,7 +99,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-linux-debian
         path: |

--- a/.github/workflows/jpackage_installer_linux.yml
+++ b/.github/workflows/jpackage_installer_linux.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_macos.yml
+++ b/.github/workflows/jpackage_installer_macos.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -41,7 +41,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -161,7 +161,7 @@ jobs:
       shell: bash
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-${{ matrix.platform }}
         path: installers/*
@@ -169,7 +169,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-${{ matrix.platform }}
         path: |

--- a/.github/workflows/jpackage_installer_macos.yml
+++ b/.github/workflows/jpackage_installer_macos.yml
@@ -105,7 +105,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_rpm.yml
+++ b/.github/workflows/jpackage_installer_rpm.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_rpm.yml
+++ b/.github/workflows/jpackage_installer_rpm.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ matrix.distro }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -113,7 +113,7 @@ jobs:
       shell: bash
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-linux-rpm-${{ matrix.distro }}
         path: installers/*
@@ -121,7 +121,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-linux-rpm-${{ matrix.distro }}
         path: |

--- a/.github/workflows/jpackage_installer_windows.yml
+++ b/.github/workflows/jpackage_installer_windows.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Create runtime image with jlink
       run: |
         $JAVA_HOME/bin/jlink \
-          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming \
+          --add-modules java.base,java.desktop,java.logging,java.xml,java.prefs,java.datatransfer,java.sql,java.scripting,java.management,java.naming,jdk.crypto.ec \
           --output runtime-image \
           --strip-debug \
           --compress=2 \

--- a/.github/workflows/jpackage_installer_windows.yml
+++ b/.github/workflows/jpackage_installer_windows.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
         server-password: GITHUB_TOKEN
 
     - name: Cache Maven dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2
         key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
@@ -126,7 +126,7 @@ jobs:
       shell: powershell
 
     - name: Upload installer artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: glycanbuilder2-installer-windows
         path: installers/*
@@ -134,7 +134,7 @@ jobs:
 
     - name: Upload build logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: build-logs-windows
         path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Download installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
@@ -42,7 +42,7 @@ jobs:
           find artifacts -type f -name "*" | sort
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           name: Release ${{ github.ref_name }}
           draft: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,23 @@
 ## Change log
+### 1.35.1  (20260812)
+* **Check for Updates could not reach GitHub from an installed copy**, reporting a
+  `handshake_failure` while a browser on the same machine loaded the same page. The runtime image
+  the installers ship is built by `jlink` from a named list of modules, and `jdk.crypto.ec` was not
+  on it - so the runtime offered no elliptic-curve suites, GitHub accepts nothing else, and the TLS
+  handshake was refused before any request was sent. GitHub was reachable throughout; the two could
+  not agree on encryption
+  * Reproduced by removing the module on JDK 17 and 21.0.12 and confirmed absent on a full JDK,
+    which is why this was not seen while the feature was being written - it was only ever exercised
+    on a development JDK, never on the runtime that is actually shipped
+  * Added to all four installer builds, so macOS, Linux, RPM and Windows images can each speak TLS
+  * Anything else the installers do over HTTPS was affected the same way, not only the update check
+* A failure now says *which* failure it was. Everything was reported as being unable to reach
+  GitHub, which was wrong for the one that actually happened - someone told that checks a network
+  that is working. A refused handshake, an unresolvable host and a timeout are told apart, and the
+  handshake case says in as many words that it is not a network problem
+* The workflows run on Node 24. GitHub has deprecated the Node 20 action runtime and warns on every
+  run; the actions in use publish Node 24 majors, so each was moved to one
+
 ### 1.35.0  (20260812)
 * Added **Help > Check for Updates**, so a macOS or Linux copy can find out that a newer one exists
   * Windows has the Microsoft Store for this; macOS and Linux are installed from files people

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,40 @@
 ## Change log
+### 1.35.0  (20260812)
+* Added **Help > Check for Updates**, so a macOS or Linux copy can find out that a newer one exists
+  * Windows has the Microsoft Store for this; macOS and Linux are installed from files people
+    download, and nothing told them
+  * **Nothing checks on its own.** No outbound call is made unless the menu item is chosen, so
+    startup is untouched - offline, behind a proxy, or with GitHub down, the application starts
+    exactly as before - and whether to talk to GitHub stays the user's choice
+  * It reads the redirect rather than the API: `api.github.com` allows 60 unauthenticated requests
+    an hour *per address*, and an institute behind one NAT is one address, while
+    `github.com/.../releases/latest` answers 302 to the tag's page and is not limited that way. It
+    also excludes pre-releases, which fits how this project releases - the workflow publishes as a
+    pre-release until someone marks it Latest, so no one is pointed at a release whose installers
+    are not built yet
+  * Where it sends people depends on where their builds are: **Windows** the Microsoft Store (the
+    releases carry no Windows installer at all), **macOS**
+    [glycanbuilder.glyconavi.org](https://glycanbuilder.glyconavi.org/en#download), **Linux** the
+    release's own assets, and anything else - a jar run directly, a build from source - the releases
+    page
+  * Versions are compared part by numeric part. As text "1.34.10" sorts before "1.34.9", so a text
+    comparison would stop reporting updates the moment a version reached double digits, quietly and
+    only then. What cannot be compared is not announced, and a check that could not reach GitHub
+    says so rather than reporting that the application is up to date
+  * Measured against the live service: 476 ms to answer, 136 ms to fail and say why with the network
+    blocked
+* **The About window showed the wrong icon.** It carried the 2021 "GB2" wordmark while the dock, the
+  installers and the Store showed the current one - two files that had drifted since the icons were
+  replaced. It references `icons/icon_large.png` now rather than carrying a copy: that is the file
+  jpackage builds every installer's icon from, so replacing it replaces this too
+* **The About window's links did nothing when clicked.** A `JEditorPane` reports a click and leaves
+  following it to whoever is listening, and nothing was: `addHyperlinkListener` is called nowhere in
+  this application. They open now, through the same code the update check uses - including its
+  fallback of showing the address where the desktop cannot open a browser
+* The paper is cited by its DOI, [10.1016/j.carres.2017.04.015](https://doi.org/10.1016/j.carres.2017.04.015),
+  rather than by a publisher URL - the identifier the article keeps wherever it is hosted. Confirmed
+  against CrossRef to be the same article: it resolves to the PII the direct link named
+
 ### 1.34.3  (20260812)
 * Took the derivatization off a composition's implicit bonds, so a derivatized composition weighs
   what the same glycan written with its linkages weighs (#165)

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.35.0</version>
+	<version>1.35.1</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.34.3</version>
+	<version>1.35.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheck.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheck.java
@@ -83,9 +83,37 @@ public final class UpdateCheck {
 
 			return new Result(installed, latest, downloadPage, null);
 		} catch (IOException couldNotAsk) {
-			return new Result(installed, null, downloadPage,
-					"Could not reach GitHub (" + couldNotAsk.getMessage() + ").");
+			return new Result(installed, null, downloadPage, describe(couldNotAsk));
 		}
+	}
+
+	/**
+	 * Says what went wrong in terms of what the user can do about it.
+	 *
+	 * <p>Everything used to be reported as "could not reach GitHub", which was wrong for the failure
+	 * that actually happened first: the runtime image shipped in the installers had no elliptic-curve
+	 * provider, so the TLS handshake was refused. GitHub was reachable - the connection got as far as
+	 * agreeing on nothing. Someone reading "could not reach" checks their network, which is fine, and
+	 * learns nothing.
+	 *
+	 * @param problem What the connection threw.
+	 * @return Returns a sentence naming the kind of failure.
+	 */
+	static String describe(IOException problem) {
+		if (problem instanceof javax.net.ssl.SSLException) {
+			return "Could not make a secure connection to GitHub (" + problem.getMessage() + "). "
+					+ "This is not a network problem: the connection was made and the encryption "
+					+ "could not be agreed on.";
+		}
+		if (problem instanceof java.net.UnknownHostException) {
+			return "Could not find GitHub (" + problem.getMessage()
+					+ "). Check the network connection.";
+		}
+		if (problem instanceof java.net.SocketTimeoutException) {
+			return "GitHub did not answer in time.";
+		}
+
+		return "Could not ask GitHub (" + problem.getMessage() + ").";
 	}
 
 	/**

--- a/src/test/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheckTest.java
+++ b/src/test/java/org/glycoinfo/application/glycanbuilder/update/UpdateCheckTest.java
@@ -85,6 +85,32 @@ public class UpdateCheckTest {
 	}
 
 	/**
+	 * A failure says which failure it was.
+	 *
+	 * <p>Every failure used to be reported as "could not reach GitHub", and the first one that
+	 * actually happened was not that: the runtime image in the installers had no elliptic-curve
+	 * provider, so the TLS handshake was refused. GitHub was reached; the two could not agree on
+	 * encryption. Someone told "could not reach" goes and checks their network, which is working.
+	 */
+	@Test
+	public void aFailureSaysWhichFailureItWas() {
+		String tls = UpdateCheck.describe(
+				new javax.net.ssl.SSLHandshakeException("Received fatal alert: handshake_failure"));
+		assertTrue(tls, tls.contains("secure connection"));
+		assertTrue("it should say this is not a network problem: " + tls,
+				tls.contains("not a network problem"));
+
+		String dns = UpdateCheck.describe(new java.net.UnknownHostException("github.com"));
+		assertTrue(dns, dns.contains("Could not find GitHub"));
+
+		String slow = UpdateCheck.describe(new java.net.SocketTimeoutException("Read timed out"));
+		assertTrue(slow, slow.contains("did not answer in time"));
+
+		String other = UpdateCheck.describe(new java.io.IOException("something else"));
+		assertTrue(other, other.contains("something else"));
+	}
+
+	/**
 	 * Where a person is sent depends on how their copy was published.
 	 *
 	 * <p>Windows goes to the Microsoft Store, and this is the assertion worth having: the releases


### PR DESCRIPTION
Release 1.35.1.

**The fix this release exists for.** Check for Updates could not reach GitHub from an installed
copy — `handshake_failure`, while a browser on the same machine loaded the same page fine. The
runtime image the installers ship is built by `jlink` from a named module list, and `jdk.crypto.ec`
was not on it, so the runtime offered no elliptic-curve suites and GitHub accepts nothing else. The
handshake was refused before any request was sent. Reproduced by removing the module on JDK 17 and
21.0.12; absent on a full JDK, which is why it was not seen while the feature was written — it was
only ever exercised on a development JDK, never on the runtime that actually ships. Added to all
four installer builds. Anything else the installers do over HTTPS was affected the same way.

Also: failures now say *which* failure they were (a refused handshake is not a network problem, and
saying so is the difference between a useful message and someone checking a network that works),
and the workflows moved off the deprecated Node 20 action runtime to Node 24.

**One thing to note about the history.** The 1.35.0 version bump was committed on master instead of
on develop before the release PR, and that commit was never pushed — only the tag was, which is why
the release built while both `origin/master` and `develop` still read 1.34.3. `ec77a8c` merges the
`v1.35.0` tag back onto develop, so the released commit is reachable from the branches again and
this release is cut from a develop that knows what was last released. That merge is why this PR
also carries the 1.35.0 pom and CHANGELOG.

131 tests pass.