### PR TITLE
Version 1.35.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,28 @@
 ## Change log
+### 1.35.2  (20260812)
+* **A sequence could make the parser go and fetch what it named.** Three of the formats the library
+  accepts are XML - `glycoct_xml`, `cabosml`, `glyde` - and JDOM's `SAXBuilder` reads them, resolving
+  external entities as it meets them. A document declaring an entity with a `SYSTEM` identifier
+  therefore had the process open whatever that pointed at, mid-parse (CVE-2021-33813)
+  * Measured through the public entry point: `importFromString(document, "glycoct_xml")` opened a
+    `file://` path the document chose, by way of `SugarImporterGlycoCT.parse` ->
+    `XMLEntityManager.startEntity` -> `FileURLConnection.getInputStream`. Whoever supplied a sequence
+    decided what was read and what was connected to - which anywhere sequences arrive from outside,
+    a server most of all, is the whole of it
+  * **There is no version to move to.** The advisory's fix is `org.jdom:jdom2:2.0.6.1`, and
+    MolecularFramework and resourcesdb are compiled against `org.jdom` - a different package - so the
+    coordinate in use has no patched version at all and a dependency bump cannot reach it. Getting
+    off it is filed as #175
+  * The document type declaration is refused before the parser sees it. A DTD is the only way to
+    declare an entity and the specification spells the declaration exactly one way, so this leaves no
+    other route to one
+  * **Reading and writing the XML formats is unaffected.** Only a document carrying a declaration is
+    refused, and the library's own output carries none: measured, GlycoCT XML and Glyde II both write
+    and read back unchanged, as does GlycoCT condensed. Nothing was added to the writing side
+  * The test asserts that nothing is fetched rather than that the read failed - a read can fail on its
+    own account long after the parser has been off to collect what it was pointed at. A server is put
+    on loopback where the document points and the assertion is that it is never called
+
 ### 1.35.1  (20260812)
 * **Check for Updates could not reach GitHub from an installed copy**, reporting a
   `handshake_failure` while a browser on the same machine loaded the same page. The runtime image

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.35.1</version>
+	<version>1.35.2</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/GlycoCTParser.java
@@ -319,7 +319,36 @@ public class GlycoCTParser implements GlycanParser {
 	 */
 	public Glycan fromGlycoCT(String str, MassOptions default_mass_opt)
 			throws Exception {
+		refuseDoctype(str);
+
 		return fromSugar(importer.parse(str), default_mass_opt);
+	}
+
+	/**
+	 * Refuses a sequence that carries an XML document type declaration.
+	 *
+	 * <p>The XML formats MolecularFramework reads - GlycoCT XML, CabosML, Glyde II - are parsed by
+	 * JDOM's {@code SAXBuilder}, which resolves external entities as it comes to them. Measured: a
+	 * document declaring {@code <!ENTITY xx SYSTEM "file:///...">} makes the parser open that file
+	 * while reading, so whoever supplies a sequence decides what the process reads and what it
+	 * connects to. That is CVE-2021-33813, and there is no version of {@code org.jdom:jdom} in
+	 * which it is fixed - the fix is in {@code org.jdom:jdom2}, a different package these libraries
+	 * are not compiled against.
+	 *
+	 * <p>So the declaration is refused before the parser sees it. A DTD is the only way to declare
+	 * an entity, and the XML specification spells {@code <!DOCTYPE} exactly that way, so refusing it
+	 * leaves no other route to one. Nothing legitimate is lost: a glycan sequence has no use for a
+	 * document type, and none of the formats define one.
+	 *
+	 * @param str The sequence about to be parsed.
+	 * @throws Exception If it declares a document type.
+	 */
+	static void refuseDoctype(String str) throws Exception {
+		if (str != null && str.contains("<!DOCTYPE")) {
+			throw new Exception("This sequence declares an XML document type, which is refused: a "
+					+ "document type can declare entities that make the parser read files and open "
+					+ "connections while parsing. Remove the <!DOCTYPE declaration.");
+		}
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/MolecularFrameworkParser.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/converterGlycoCT/MolecularFrameworkParser.java
@@ -122,6 +122,10 @@ public class MolecularFrameworkParser extends GlycoCTParser {
     }
 
     public Glycan readGlycan(String buffer, MassOptions default_mass_options) throws Exception {
+    	// Three of the encodings reached from here - glycoct_xml, cabosml, glyde - are XML, and are
+    	// read by a parser that resolves external entities. See GlycoCTParser.refuseDoctype.
+    	refuseDoctype(buffer);
+
 		Sugar s = SugarImporterFactory.importSugar(buffer, encoding);
 		return fromSugar(s, default_mass_options);
     }

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/XmlSequencesFetchNothingTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/XmlSequencesFetchNothingTest.java
@@ -1,0 +1,125 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+/**
+ * That reading a sequence never fetches anything the sequence names (CVE-2021-33813).
+ *
+ * <p>Three of the formats the library accepts are XML - {@code glycoct_xml}, {@code cabosml} and
+ * {@code glyde} - and they are read by JDOM's {@code SAXBuilder}, which resolves external entities
+ * as it meets them. A document declaring {@code <!ENTITY xx SYSTEM "...">} therefore made the
+ * parser open whatever that named: measured before the fix, a {@code file://} entity had the
+ * process open that path mid-parse, so whoever supplied a sequence chose what was read and what was
+ * connected to. On a server taking sequences from callers that is the whole of the vulnerability.
+ *
+ * <p>There is no fixed version to move to. The advisory names {@code org.jdom:jdom2:2.0.6.1}, and
+ * these libraries are compiled against {@code org.jdom}, a different package - which is why the
+ * dependency alert reports no patched version. So the document type declaration is refused before
+ * the parser sees it, a DTD being the only way to declare an entity.
+ *
+ * <p>What is asserted is behaviour rather than the refusal: a local server is put where the
+ * document points, and the test is that it is never called. An assertion that the import failed
+ * would pass just as well if the parse failed for some unrelated reason while still fetching.
+ */
+public class XmlSequencesFetchNothingTest {
+
+	/** Every XML format reachable through the importer factory. */
+	private static final String[] XML_FORMATS = { "glycoct_xml", "cabosml", "glyde" };
+
+	private static HttpServer server;
+
+	/** Counts what the parser asked for, which should stay at zero. */
+	private static final AtomicInteger requests = new AtomicInteger();
+
+	@BeforeClass
+	public static void startTheServerTheDocumentWillPointAt() throws IOException {
+		// Loopback and an ephemeral port: nothing leaves the machine, and nothing is claimed.
+		server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+		server.createContext("/", new HttpHandler() {
+			public void handle(HttpExchange exchange) throws IOException {
+				requests.incrementAndGet();
+				byte[] body = "fetched".getBytes("UTF-8");
+				exchange.sendResponseHeaders(200, body.length);
+				OutputStream out = exchange.getResponseBody();
+				out.write(body);
+				out.close();
+			}
+		});
+		server.start();
+	}
+
+	@AfterClass
+	public static void stopTheServer() {
+		if (server != null) server.stop(0);
+	}
+
+	/**
+	 * A document type naming a URL does not make the parser go and get it.
+	 *
+	 * <p>Before the fix this test fails on the first format: the count reaches one as the parser
+	 * resolves the entity, and the fetched text is spliced into the document it goes on to read.
+	 */
+	@Test
+	public void whatADocumentTypeNamesIsNeverFetched() {
+		String url = "http://" + server.getAddress().getHostString() + ":"
+				+ server.getAddress().getPort() + "/fetched-by-the-parser";
+		String document =
+				"<?xml version=\"1.0\"?>\n"
+				+ "<!DOCTYPE sugar [ <!ENTITY xx SYSTEM \"" + url + "\"> ]>\n"
+				+ "<sugar version=\"1.0\"><residues><basetype id=\"1\">&xx;</basetype></residues>"
+				+ "<linkages/></sugar>";
+
+		for (String format : XML_FORMATS) {
+			requests.set(0);
+
+			boolean imported = importAndReport(document, format);
+
+			assertEquals(format + ": the parser fetched what the document type named",
+					0, requests.get());
+			assertFalse(format + ": a document declaring a document type should not be read",
+					imported);
+		}
+	}
+
+	/**
+	 * The formats that are not XML are untouched by the refusal.
+	 *
+	 * <p>The check is on the text handed to the parser rather than on the format, so this is what
+	 * says it costs nothing: the sequences actually in use still read.
+	 */
+	@Test
+	public void theSequencesInUseStillRead() {
+		assertTrue("GWS should still read",
+				importAndReport("freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p", "gws"));
+		assertTrue("WURCS should still read", importAndReport(
+				"WURCS=2.0/1,1,0/[a2122h-1b_1-5_2*NCC/3=O]/1/", "wurcs2"));
+	}
+
+	private static boolean importAndReport(String sequence, String format) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		try {
+			return document.importFromString(sequence, format);
+		} catch (Exception refused) {
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
Release 1.35.2. A security release, on its own.

**What it fixes.** Three of the formats the library accepts are XML - `glycoct_xml`, `cabosml`,
`glyde` - and JDOM's `SAXBuilder` reads them, resolving external entities as it meets them
(CVE-2021-33813). A document declaring an entity with a `SYSTEM` identifier had the process open
whatever that pointed at, while parsing. Measured through the public entry point:

    importFromString(document, "glycoct_xml")
      -> SugarImporterGlycoCT.parse
      -> XMLEntityManager.startEntity
      -> FileURLConnection.getInputStream      <- opened the path the document named

Whoever supplied a sequence decided what was read and what was connected to.

**There is no version to move to.** The advisory's fix is `org.jdom:jdom2:2.0.6.1`, and
MolecularFramework and resourcesdb are compiled against `org.jdom`, a different package - so the
coordinate in use has no patched version and a dependency bump cannot reach it. That is why
Dependabot reports none, and getting off it is filed as #175. The alert stays open until then.

**Reading and writing the XML formats is unaffected.** Only a document carrying a document type
declaration is refused, and the library's own output carries none - measured: GlycoCT XML and
Glyde II both write and read back unchanged, as does GlycoCT condensed. Nothing was added to the
writing side.

133 tests pass. The web application's own half of this is glyconavi/glycanbuilder2web!101, already
merged; it closes the path an outside caller could reach without waiting for this release.
