### PR TITLE
Refuse a linkage position another child already has

### DIFF
--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -66,8 +66,8 @@ remains, and the issue should say so rather than being closed.
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
 | ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass.** Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82). **Still monoisotopic: the ion adducts.** `IonCloud` captures an ion's mass when the ion is set, not when the mass is computed, so an m/z carries an average neutral mass and a monoisotopic adduct. Worth its own issue |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
-| **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | |
-| **#34** | Duplicated linkage position in a branched glycan | The position list is built without asking what the parent already carries, so an impossible structure can be drawn |
+| **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
+| ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
 
 ## P2 — work is lost, or the output cannot be used
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1369,6 +1369,13 @@ public class Residue {
 			return true;
 		}
 
+		// a carbon carries one glycosidic bond, so a position another child already occupies is not
+		// one this child can be given (#34). Checked here as well as in canAddChild because this
+		// does not consult it - the two have grown apart, and adding is the path that makes the
+		// structure
+		if( positionAlreadyTaken(child,bonds) )
+			return false;
+
 		// check for available space
 		//if( (getNoLinkages()+bonds.size())<getMaxLinkages() )
 
@@ -1422,9 +1429,58 @@ public class Residue {
 		if( isLCleavage() && cleaved_residue.getTypeName().equals(child.getTypeName()) )
 			return true;
 
+		// a carbon carries one glycosidic bond, so a position another child already occupies is not
+		// one this child can be given (#34)
+		if( positionAlreadyTaken(child,bonds) )
+			return false;
+
 		// check for available space
-		//return ( (getNoLinkages()+bonds.size())<getMaxLinkages() ); 
+		//return ( (getNoLinkages()+bonds.size())<getMaxLinkages() );
 		return true;
+	}
+
+	/**
+	 * Whether any of these bonds would put a child where another child already is.
+	 *
+	 * <p>The position list offered when a linkage is edited was built from what the residue type
+	 * allows without asking what its other children had taken, so the same position could be given
+	 * twice - a Man with two branches both at 4, which is not a molecule. It draws, and the WURCS
+	 * export then writes nothing at all, which is how it was usually noticed.
+	 *
+	 * <p>Only a position that is actually stated counts. An unknown position - {@code '?'}, which is
+	 * most of what a structure read from a database carries - says nothing about what is where, so
+	 * two of those do not conflict; deciding they did would refuse structures that are perfectly
+	 * ordinary. A bond that names several positions at once is the same case: it is a statement of
+	 * "one of these", not of any one of them.
+	 *
+	 * @param child The residue about to be added, which is not counted against itself.
+	 * @param bonds The bonds it would be added by.
+	 * @return Returns whether one of them names a position another child already has.
+	 */
+	private boolean positionAlreadyTaken(Residue child, Collection<Bond> bonds) {
+		if( bonds==null )
+			return false;
+
+		for( Bond bond : bonds ) {
+			char[] positions = bond.getParentPositions();
+			if( positions==null || positions.length!=1 || positions[0]=='?' )
+				continue;
+
+			for( Linkage taken : children_linkages ) {
+				if( taken.getChildResidue()==child )
+					continue;
+
+				for( Bond takenBond : taken.getBonds() ) {
+					char[] takenPositions = takenBond.getParentPositions();
+					if( takenPositions==null || takenPositions.length!=1 )
+						continue;
+					if( takenPositions[0]==positions[0] )
+						return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
@@ -96,4 +96,55 @@ public class OnePositionOneBondTest {
 
 		return man;
 	}
+
+	/**
+	 * A substituent occupies a position exactly as a monosaccharide does.
+	 *
+	 * <p>The rule is about the carbon, not about what kind of thing is hanging off it: a methyl at 4
+	 * and a branch at 4 are the same claim on the same atom. Substituents are attached as child
+	 * residues here, so they were already covered - this holds that they stay covered, in both
+	 * orders and between two substituents, since none of that is obvious from the code that does it.
+	 */
+	@Test
+	public void aSubstituentTakesAPositionTooAndInEitherOrder() throws Exception {
+		Residue afterSugar = manOnAFreeEnd();
+		afterSugar.addChild(ResidueDictionary.newResidue("Gal"), '4');
+		assertFalse("a methyl was added onto a position a branch already holds",
+				afterSugar.addChild(ResidueDictionary.newResidue("Me"), '4'));
+
+		Residue afterSubstituent = manOnAFreeEnd();
+		afterSubstituent.addChild(ResidueDictionary.newResidue("Me"), '4');
+		assertFalse("a branch was added onto a position a methyl already holds",
+				afterSubstituent.addChild(ResidueDictionary.newResidue("Gal"), '4'));
+
+		Residue betweenSubstituents = manOnAFreeEnd();
+		betweenSubstituents.addChild(ResidueDictionary.newResidue("Me"), '4');
+		assertFalse("two substituents were put on the same position",
+				betweenSubstituents.addChild(ResidueDictionary.newResidue("S"), '4'));
+	}
+
+	/**
+	 * And several substituents on their own positions are untouched, which is the case from #66 -
+	 * the heavily modified fucose that started this line of work.
+	 */
+	@Test
+	public void substituentsOnDifferentPositionsAreFine() throws Exception {
+		Residue fucose = manOnAFreeEnd();
+
+		assertTrue(fucose.addChild(ResidueDictionary.newResidue("Me"), '2'));
+		assertTrue(fucose.addChild(ResidueDictionary.newResidue("N"), '3'));
+		assertTrue(fucose.addChild(ResidueDictionary.newResidue("Me"), '4'));
+
+		assertEquals(3, fucose.getNoChildren());
+	}
+
+	/** An unknown position does not block a stated one, whichever arrived first. */
+	@Test
+	public void anUnknownPositionBlocksNothing() throws Exception {
+		Residue parent = manOnAFreeEnd();
+		parent.addChild(ResidueDictionary.newResidue("S"), '?');
+
+		assertTrue("a sulfate of unknown position should not close position 4",
+				parent.addChild(ResidueDictionary.newResidue("Gal"), '4'));
+	}
 }

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
@@ -1,0 +1,99 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That the same linkage position cannot be given to two children (#34).
+ *
+ * <p>A carbon carries one glycosidic bond. The position list offered when a linkage is edited was
+ * built from what the residue type allows without asking what the residue's other children had
+ * already taken, so the same position could be handed out twice - a Man with two branches both at 4,
+ * which is not a molecule. It draws, and the WURCS export then writes nothing, which is how it was
+ * usually found out.
+ */
+public class OnePositionOneBondTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A position another child holds is refused. */
+	@Test
+	public void aPositionIsNotGivenTwice() throws Exception {
+		Residue parent = manOnAFreeEnd();
+
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Gal"), '4'));
+		assertFalse("a second child was added at position 4",
+				parent.addChild(ResidueDictionary.newResidue("Glc"), '4'));
+		assertFalse("canAddChild should say so too",
+				parent.canAddChild(ResidueDictionary.newResidue("Glc"), '4'));
+
+		assertEquals(1, parent.getNoChildren());
+	}
+
+	/** Other positions are unaffected, which is most of what anyone does. */
+	@Test
+	public void everyOtherPositionStillTakesABranch() throws Exception {
+		Residue parent = manOnAFreeEnd();
+
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Gal"), '2'));
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Glc"), '3'));
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Man"), '6'));
+
+		assertEquals(3, parent.getNoChildren());
+	}
+
+	/**
+	 * Two children at an unknown position are not a conflict.
+	 *
+	 * <p>Most of what comes out of a database says only that a residue is attached somewhere. If
+	 * two of those were treated as the same position, ordinary structures would stop being
+	 * drawable - and nothing would have been said about where either one is.
+	 */
+	@Test
+	public void twoUnknownPositionsAreNotTheSamePosition() throws Exception {
+		Residue parent = manOnAFreeEnd();
+
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Fuc"), '?'));
+		assertTrue("an unknown position is not a claim on any position",
+				parent.addChild(ResidueDictionary.newResidue("Xyl"), '?'));
+
+		assertEquals(2, parent.getNoChildren());
+	}
+
+	/**
+	 * A file already containing the impossible structure still opens.
+	 *
+	 * <p>The point is to stop one being made, not to make saved work unreadable - a structure drawn
+	 * before this and saved is still somebody's, and refusing to open it would be a worse fault than
+	 * the one being fixed.
+	 */
+	@Test
+	public void aFileThatAlreadyHasOneStillOpens() throws Exception {
+		GlycanDocument document =
+				new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		assertTrue(document.importFromString(
+				"freeEnd--??1D-Man,p(--4?1D-Gal,p)--4?1D-Glc,p$MONO,perMe,Na,0,freeEnd", "gws"));
+		assertEquals(1, document.getStructures().size());
+	}
+
+	private static Residue manOnAFreeEnd() throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		Residue man = ResidueDictionary.newResidue("Man");
+		root.addChild(man);
+
+		return man;
+	}
+}


### PR DESCRIPTION
Closes #34, and reports on #66 without closing it.

### #34 — the same position could be given twice

A carbon carries one glycosidic bond. The position list offered when a linkage is edited was built
from what the residue type allows without asking what the residue's other children had already
taken, so a Man could be given two branches both at 4. It draws, and the WURCS export then writes
nothing, which is how it was usually found out.

Measured before the fix:

```
man.addChild(Gal, '4')  → true
man.addChild(Glc, '4')  → true      ← two children at position 4
export to WURCS         → empty
```

**The dialog had learned to filter the list in 2021; the model had not.** The check goes in
`canAddChild` *and* `addChild`, because `addChild` does not consult `canAddChild` — the two have
grown apart, and adding is the path that makes the structure.

**Only a stated position counts.** An unknown position — `?`, which is most of what a structure read
from a database carries — says nothing about what is where, so two of those do not conflict.
Deciding they did would refuse ordinary structures and explain nothing.

**A file that already has one still opens.** Somebody drew that before this existed and saved it;
refusing to read their work would be a worse fault than the one being fixed. Held by a test.

### #66 — does not reproduce

A Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS on 1.36.0, drawn as substituent residues or
imported from WURCS, alone or as a branch on an N-glycan core. Measurements are on the issue, with a
request for a retest and the GWS — the substituent MAP handling has been reworked since it was filed
in January 2024, and one of those changes may have taken it.

150 tests pass.
