### PR TITLE
Write down which positions take a linkage, and when an anomer is shown

### DIFF
--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -1,0 +1,102 @@
+# Which positions take a linkage, and when an anomer is shown
+
+The rules that decide what a residue will accept and what is drawn on it. Written down because they
+are chemistry rather than programming: reading the code tells you what it does, not whether that is
+right, and the two have differed here.
+
+Where a rule is a judgement rather than a fact, it says so and says whose judgement it was.
+
+## What can take a linkage
+
+### The residue type's own list
+
+Each residue type declares the positions it will accept, and that list is the authority. It already
+accounts for what the sugar is made of:
+
+| Residue | Positions | Why |
+|---|---|---|
+| Glc | 2 3 4 5 6 | a plain hexose |
+| GlcNAc | 3 4 5 6 | 2 carries the N-acetyl |
+| GlcN | 3 4 5 6 N | 2 carries the amino group, and the nitrogen itself can be substituted |
+| Neu5Ac | 1 2 3 4 6 7 8 9 N | 5 carries the N-acetyl |
+| Xyl | 2 3 4 5 | a pentose has no 6 |
+| GlcA | 2 3 4 5 6 | **6 stays open** — see below |
+
+**A built-in substituent does not always close its position.** GlcA carries a carboxyl at 6 and the
+position remains available, because a carboxyl can be esterified. GlcNAc's N-acetyl at 2 does close
+it. The distinction is chemical, not structural, which is why the list is maintained per residue
+rather than derived from the formula — and why code must consult the list rather than reason about
+it.
+
+**The list is not a general test of whether a bond may attach there.** It omits the anomeric carbon,
+because that is normally where the residue attaches to its *parent* rather than where children
+attach — but a bridge can attach there, and 1,6-anhydro does. Refusing every bond at a position
+absent from the list therefore refuses real structures: measured, `WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/`
+stops round-tripping. Whatever consults this list has to know whether it is asking about an ordinary
+glycosidic bond or about a bridge, and nothing in the model draws that distinction yet.
+
+*Confirmed by I. Yamada, 2026-08-14: "GlcA の 6 位は結合位置として提示すべきではない、という理解で合っ
+ていますか" — "いいえ、間違っています。エステル結合などの可能性があります。"*
+
+### The ring
+
+The ring oxygen occupies a position, and that position takes no linkage. Which position depends on
+the ring form and where the anomeric centre is:
+
+- **pyranose** with the anomeric centre at 1: position 5 is closed
+- **pyranose** with the anomeric centre at 2: position 6 is closed
+- **furanose**: the ring is smaller, and the position two carbons along is closed instead
+- **open chain**: no ring, so nothing is closed by one
+
+**The ring atom is not always oxygen.** It can be nitrogen, and such sugars exist. That is a fact
+about what the residue *is*, not about what can be attached to it: the position is still part of the
+ring and still takes no glycosidic bond. Nothing here should refuse a residue for having a nitrogen
+in its ring.
+
+### The reducing end
+
+An **alditol** — a reduced sugar — has no ring and no anomeric centre. Its position 1 is an ordinary
+hydroxyl and **can take a linkage**, which it cannot when the same sugar is in a ring.
+
+### What another child already has
+
+A carbon carries one glycosidic bond. A position another child already occupies is not available,
+and this holds across kinds: a methyl at 4 and a branch at 4 are the same claim on the same atom.
+
+**Only a stated position counts.** An unknown position — `?`, which is most of what a structure read
+from a database carries — says nothing about where anything is, so two of those do not conflict.
+A bond naming several positions at once is the same case: "one of these" is not a claim on any one
+of them.
+
+## What is drawn
+
+### The anomeric configuration
+
+α and β describe the configuration at the anomeric centre. **Where there is no anomeric centre there
+is nothing to describe, and nothing should be shown** — not "unknown", not a placeholder. An alditol
+and an open-chain form both fall under this.
+
+*Confirmed by I. Yamada, 2026-08-14: "開鎖体でアノマー位が無い場合、アノマー表記（α/β）はすべきでは
+ありません。非表示が良いのではないでしょうか？"*
+
+Showing "α" on something that has no anomeric carbon states something untrue about the molecule, and
+showing "?" states that it is unknown when it is not unknown but absent. The two are different and
+the drawing should not confuse them.
+
+## Where these rules live in the code
+
+They should live in one place and be consulted from every other. As of 2026-08-14 they do not:
+
+| Rule | Where it is | Consulted by |
+|---|---|---|
+| the type's position list | `ResidueType.getLinkagePositions`, `isValidPosition` | the linkage dialog |
+| ring form and anomeric centre | `ResiduePropertiesDialog.createPositions` | that dialog alone |
+| what a sibling has taken | `Residue.canAddChild` / `addChild` | both, since 1.36.x |
+
+So a structure built through the dialog obeys rules the model does not enforce, and a structure built
+any other way — imported, scripted, or through another code path — obeys only the last of them. That
+is how a Man came to have two branches at position 4 (#34).
+
+**The fix is to move the knowledge into the model** and have the dialog ask it, rather than the two
+each knowing a different part. Until that is done, a change to any of these rules has to be made in
+more than one place, and this file is the record of what they are.


### PR DESCRIPTION
Writes down the rules that decide what a residue accepts and what is drawn on it — chemistry rather
than programming, and the two have differed here.

### Why a document rather than only code

The knowledge is in three places and none of them is the model:

| Rule | Where it is | Consulted by |
|---|---|---|
| the type's position list | `ResidueType.getLinkagePositions` | the linkage dialog |
| ring form and anomeric centre | `ResiduePropertiesDialog.createPositions` | that dialog alone |
| what a sibling has taken | `Residue.canAddChild` / `addChild` | both, since #193 |

A structure built through the dialog obeys rules the model does not enforce; a structure built any
other way obeys only the last. That is how a Man came to have two branches at position 4 (#34).

### Two corrections it records

Both were my reading of the rules, and both were wrong:

**A built-in substituent does not always close its position.** I assumed GlcA's carboxyl closed
position 6 the way GlcNAc's N-acetyl closes 2, and proposed correcting the data. It does not — a
carboxyl can be esterified, and the list is right as it stands. The distinction is chemical rather
than structural, which is why the list is maintained per residue and must be consulted rather than
reasoned about.

**The list is not a general test of whether a bond may attach.** I implemented `addChild` consulting
`isValidPosition`, which looks like the obvious fix for the built-in case. It omits the anomeric
carbon — normally where a residue attaches to its parent — and a bridge attaches there:
`WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/`, 1,6-anhydro, stops round-tripping. Measured, then reverted.
Whatever consults the list has to know whether it is asking about an ordinary glycosidic bond or a
bridge, and nothing in the model draws that distinction yet.

### The display rule

α and β describe the configuration at an anomeric centre. Where there is none — an alditol, an
open-chain form — nothing should be shown: not "unknown", not a placeholder. Showing "α" states
something untrue, and showing "?" says it is unknown when it is absent. Not yet implemented; this
records what it should be.

No code changes. 153 tests pass unchanged.
