### PR TITLE
Put the position rules in the model, and let the dialog ask

### DIFF
--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -11,7 +11,8 @@ Where a rule is a judgement rather than a fact, it says so and says whose judgem
 ### The residue type's own list
 
 Each residue type declares the positions it will accept, and that list is the authority. It already
-accounts for what the sugar is made of:
+accounts for what the sugar is made of. A sample rather than the whole set — there are 134 types, and
+each row below stands for a kind:
 
 | Residue | Positions | Why |
 |---|---|---|
@@ -37,6 +38,11 @@ glycosidic bond or about a bridge, and nothing in the model draws that distincti
 
 *Confirmed by I. Yamada, 2026-08-14: "GlcA の 6 位は結合位置として提示すべきではない、という理解で合っ
 ていますか" — "いいえ、間違っています。エステル結合などの可能性があります。"*
+
+**47 of the 134 types declare no list at all** — reducing ends (freeEnd, redEnd, PA, 2AB, …) and
+substituents (Me, DH, …). No list means **no constraint**, not no positions: anything reading the
+list has to treat an empty one as "nothing to say" rather than "nothing allowed", or those 47 would
+accept nothing.
 
 ### The ring
 
@@ -87,16 +93,15 @@ the drawing should not confuse them.
 
 They should live in one place and be consulted from every other. As of 2026-08-14 they do not:
 
-| Rule | Where it is | Consulted by |
-|---|---|---|
-| the type's position list | `ResidueType.getLinkagePositions`, `isValidPosition` | the linkage dialog |
-| ring form and anomeric centre | `ResiduePropertiesDialog.createPositions` | that dialog alone |
-| what a sibling has taken | `Residue.canAddChild` / `addChild` | both, since 1.36.x |
+They live in `Residue.availableLinkagePositions` and `Residue.acceptsPosition`, and everything else
+asks. `addChild` and `canAddChild` enforce them; the linkage dialog shows what they say rather than
+working it out again.
 
-So a structure built through the dialog obeys rules the model does not enforce, and a structure built
-any other way — imported, scripted, or through another code path — obeys only the last of them. That
-is how a Man came to have two branches at position 4 (#34).
+Until this was done they were in three places and none of them was the model — the type's list, which
+only the dialog asked; the ring and anomeric rules, which only the dialog knew; and what a sibling
+had taken, which only the model knew. A structure drawn through the dialog obeyed rules that one
+built any other way did not, which is how a Man came to carry two branches at position 4 (#34).
 
-**The fix is to move the knowledge into the model** and have the dialog ask it, rather than the two
-each knowing a different part. Until that is done, a change to any of these rules has to be made in
-more than one place, and this file is the record of what they are.
+**A bridge is exempt, deliberately.** It is not an ordinary glycosidic bond and may attach at the
+anomeric carbon, so the type's list does not apply to it; only the sibling rule does.
+`acceptsPosition` takes the child for exactly that reason.

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1373,7 +1373,7 @@ public class Residue {
 		// one this child can be given (#34). Checked here as well as in canAddChild because this
 		// does not consult it - the two have grown apart, and adding is the path that makes the
 		// structure
-		if( positionAlreadyTaken(child,bonds) )
+		if( positionIsNotAvailable(child,bonds) )
 			return false;
 
 		// check for available space
@@ -1431,7 +1431,7 @@ public class Residue {
 
 		// a carbon carries one glycosidic bond, so a position another child already occupies is not
 		// one this child can be given (#34)
-		if( positionAlreadyTaken(child,bonds) )
+		if( positionIsNotAvailable(child,bonds) )
 			return false;
 
 		// check for available space
@@ -1457,27 +1457,175 @@ public class Residue {
 	 * @param bonds The bonds it would be added by.
 	 * @return Returns whether one of them names a position another child already has.
 	 */
-	private boolean positionAlreadyTaken(Residue child, Collection<Bond> bonds) {
+	/**
+	 * The positions this residue can take an ordinary glycosidic bond at, as it stands.
+	 *
+	 * <p>Everything that decides this in one place, so that a structure built by any route obeys the
+	 * same rules. It had been in three: the residue type's list, which only the linkage dialog asked;
+	 * the ring and anomeric rules, which only that dialog knew; and what a sibling had taken, which
+	 * only the model knew. A structure drawn through the dialog therefore obeyed rules the model did
+	 * not enforce, and one built any other way obeyed almost none - which is how a Man came to carry
+	 * two branches at position 4 (#34).
+	 *
+	 * <p>What is taken into account, and why each is not the same as the others:
+	 *
+	 * <ul>
+	 *   <li><b>The residue type's list.</b> It already knows what the sugar is made of - GlcNAc omits
+	 *       2 for its N-acetyl, Xyl has no 6 - and whether a built-in substituent closes its position
+	 *       is a chemical judgement made per residue rather than a rule: GlcA keeps 6 open, because a
+	 *       carboxyl can be esterified. 47 of the 134 types declare no list at all, mostly reducing
+	 *       ends and substituents; no list means no constraint, not no positions.</li>
+	 *   <li><b>The ring.</b> Its oxygen occupies a position and that position takes no glycosidic
+	 *       bond: 5 for a pyranose closing from 1, 6 from 2; 4 for a furanose from 1, 5 from 2. An
+	 *       open chain closes nothing. The ring atom is not always oxygen - it can be nitrogen - but
+	 *       that is a fact about what the residue is, not about what can hang off it.</li>
+	 *   <li><b>An alditol</b> has no ring and no anomeric centre, so its 1 is an ordinary hydroxyl and
+	 *       does take a bond, which the type's list does not say because in a ring it does not.</li>
+	 *   <li><b>What a sibling holds.</b> A carbon carries one glycosidic bond, and a methyl at 4 is
+	 *       the same claim on the same atom as a branch at 4.</li>
+	 * </ul>
+	 *
+	 * <p>This describes ordinary glycosidic bonds. A <b>bridge</b> is not one and is not bound by it -
+	 * an anhydro attaches at the anomeric carbon, which no type's list offers, and 1,6-anhydro is a
+	 * real structure. See {@link #acceptsPosition}.
+	 *
+	 * @return Returns the positions, in order, without {@code '?'} - which is always acceptable and
+	 *         is not a position.
+	 */
+	public char[] availableLinkagePositions() {
+		StringBuilder available = new StringBuilder();
+
+		char[] fromType = (type==null) ? new char[0] : type.getLinkagePositions();
+		if( fromType.length==0 ) {
+			// No list is no constraint. Reducing ends and substituents mostly have none.
+			for( char position='1'; position<='9'; position++ )
+				available.append(position);
+			available.append('N');
+		}
+		else
+			available.append(fromType);
+
+		// an alditol has no ring and no anomeric centre, so position 1 is an ordinary hydroxyl
+		if( isAlditol() && available.indexOf("1")<0 )
+			available.insert(0,'1');
+
+		char closedByRing = ringPosition();
+		if( closedByRing!='\0' ) {
+			int at = available.indexOf(String.valueOf(closedByRing));
+			if( at>=0 ) available.deleteCharAt(at);
+		}
+
+		for( Linkage taken : children_linkages ) {
+			for( Bond bond : taken.getBonds() ) {
+				char[] positions = bond.getParentPositions();
+				if( positions==null || positions.length!=1 || positions[0]=='?' )
+					continue;
+
+				int at = available.indexOf(String.valueOf(positions[0]));
+				if( at>=0 ) available.deleteCharAt(at);
+			}
+		}
+
+		char[] ret = new char[available.length()];
+		available.getChars(0,available.length(),ret,0);
+		Arrays.sort(ret);
+
+		return ret;
+	}
+
+	/**
+	 * The position the ring occupies, which takes no glycosidic bond.
+	 *
+	 * <p>An alditol and an open chain have no ring, and a ring size this does not recognise is not
+	 * one it will guess at.
+	 *
+	 * @return Returns the position, or {@code '\0'} where no ring closes one.
+	 */
+	private char ringPosition() {
+		if( isAlditol() )
+			return '\0';
+
+		char anomeric = getAnomericCarbon();
+		if( ring_size=='p' ) {
+			if( anomeric=='1' ) return '5';
+			if( anomeric=='2' ) return '6';
+		}
+		if( ring_size=='f' ) {
+			if( anomeric=='1' ) return '4';
+			if( anomeric=='2' ) return '5';
+		}
+
+		return '\0';
+	}
+
+	/**
+	 * Whether a child can be given this position.
+	 *
+	 * @param position The position asked for. {@code '?'} is always acceptable: it says nothing about
+	 *        where anything is, so it can neither collide nor be out of range.
+	 * @param child The residue that would go there, since a bridge is not bound by the same rules -
+	 *        it may attach at the anomeric carbon, which no type's list offers. May be null, which is
+	 *        read as an ordinary residue.
+	 * @return Returns whether the position is available.
+	 */
+	public boolean acceptsPosition(char position, Residue child) {
+		if( position=='?' )
+			return true;
+
+		// A bridge is not an ordinary glycosidic bond: 1,6-anhydro attaches at the anomeric carbon,
+		// and the type's list describes what an ordinary bond may do. Only the sibling rule applies.
+		boolean isBridge = child!=null && child.getType()!=null && child.getType().isBridge();
+		if( isBridge )
+			return !positionHeldByAChild(position,child);
+
+		for( char available : availableLinkagePositions() )
+			if( available==position ) return true;
+
+		return false;
+	}
+
+	/**
+	 * @param position A stated position.
+	 * @param except A residue not counted against itself, or null.
+	 * @return Returns whether some other child already holds it.
+	 */
+	private boolean positionHeldByAChild(char position, Residue except) {
+		for( Linkage taken : children_linkages ) {
+			if( taken.getChildResidue()==except )
+				continue;
+
+			for( Bond bond : taken.getBonds() ) {
+				char[] positions = bond.getParentPositions();
+				if( positions!=null && positions.length==1 && positions[0]==position )
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether any of these bonds names a position this residue will not give the child.
+	 *
+	 * <p>Every rule about what a position can take is in {@link #acceptsPosition}; this only walks
+	 * the bonds. A bond naming several positions at once is left alone - "one of these" is not a
+	 * claim on any one of them, and refusing it would refuse structures that say less rather than
+	 * something wrong.
+	 *
+	 * @param child The residue about to be added, which is not counted against itself.
+	 * @param bonds The bonds it would be added by.
+	 * @return Returns whether one of them asks for a position that is not available.
+	 */
+	private boolean positionIsNotAvailable(Residue child, Collection<Bond> bonds) {
 		if( bonds==null )
 			return false;
 
 		for( Bond bond : bonds ) {
 			char[] positions = bond.getParentPositions();
-			if( positions==null || positions.length!=1 || positions[0]=='?' )
+			if( positions==null || positions.length!=1 )
 				continue;
-
-			for( Linkage taken : children_linkages ) {
-				if( taken.getChildResidue()==child )
-					continue;
-
-				for( Bond takenBond : taken.getBonds() ) {
-					char[] takenPositions = takenBond.getParentPositions();
-					if( takenPositions==null || takenPositions.length!=1 )
-						continue;
-					if( takenPositions[0]==positions[0] )
-						return true;
-				}
-			}
+			if( !acceptsPosition(positions[0],child) )
+				return true;
 		}
 
 		return false;

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/LinkageRendererAWT.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/LinkageRendererAWT.java
@@ -129,10 +129,38 @@ public class LinkageRendererAWT extends AbstractLinkageRenderer {
 		return a_bIsShow;
 	}
     
+    /**
+     * Whether there is an anomeric configuration here to draw at all.
+     *
+     * <p>α and β describe the configuration at an anomeric centre. A residue that has none - an
+     * alditol, or an open-chain form - has nothing for them to describe, and drawing one states
+     * something untrue about the molecule. Drawing "?" instead would say it is unknown, when it is
+     * not unknown but absent; the two are different and the picture should not confuse them.
+     *
+     * <p>See {@code docs/linkage-positions-and-anomers.md}.
+     *
+     * @param link The linkage about to be labelled.
+     * @return Returns whether to label it.
+     */
     private boolean checkAnomericPosition(Linkage link) {
     	if(link.getChildResidue().getAnomericState() == 'o') return false;
     	if(link.getParentResidue().isReducingEnd() && link.getChildResidue().isStartRepetition()) return false;
-    	
+    	if(!hasAnAnomericCentre(link.getChildResidue())) return false;
+
+    	return true;
+    }
+
+    /**
+     * @param residue The residue in question.
+     * @return Returns whether it has an anomeric centre for a configuration to be at.
+     */
+    private boolean hasAnAnomericCentre(org.eurocarbdb.application.glycanbuilder.Residue residue) {
+    	if(residue == null) return false;
+    	// A reduced sugar has no anomeric carbon: the ring is open and the centre is gone.
+    	if(residue.isAlditol()) return false;
+    	// Nor has an open chain, which is what an 'o' ring size says.
+    	if(residue.getRingSize() == 'o') return false;
+
     	return true;
     }
     

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/ResiduePropertiesDialog.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/ResiduePropertiesDialog.java
@@ -114,66 +114,61 @@ public class ResiduePropertiesDialog extends EscapeDialog implements java.awt.ev
     	field_min.setText("100");
     }
 
+    /**
+     * The positions to offer for the linkage from {@code parent}.
+     *
+     * <p>Asks the residue rather than working it out. This used to be the only place that knew about
+     * ring forms and anomeric centres, and the model enforced none of it - so a structure drawn here
+     * obeyed rules that one built any other way did not, which is how a Man came to carry two
+     * branches at position 4 (#34). The rules are in {@code Residue.availableLinkagePositions} now
+     * and this shows what they say.
+     *
+     * @param parent The residue the linkage hangs off.
+     * @return Returns the list to show, {@code "?"} first - always offered, since it says nothing
+     *         about where anything is.
+     */
     private ListModel<String> createPositions(Residue parent) {
 		DefaultListModel<String> ret = new DefaultListModel<String>();
-
-		// collect available positions
-		char[] par_pos = null;
-		if (parent == null || parent.getType().getLinkagePositions().length == 0)
-			par_pos = new char[]{'1', '2', '3', '4', '5', '6', '7', '8', '9', 'N'};
-		else
-			par_pos = parent.getType().getLinkagePositions();
-
-		// 20211223, S.TSUCHIYA add
-		String par_pos_temp = String.valueOf(par_pos);
-
-		// select unavailable linkage position from par_pos
-		for (Linkage donorLinkage : parent.getChildrenLinkages()) {
-			if (this.current == donorLinkage.getChildResidue()) continue;
-
-			for (Bond donorBond : donorLinkage.getBonds()) {
-				if (donorBond.getParentPositions().length > 1) continue;
-				if (donorBond.getParentPositions()[0] == '?') continue;
-				char donorPos = donorBond.getParentPositions()[0];
-				par_pos_temp = par_pos_temp.replace(donorPos, ' ');
-			}
-		}
-
-		// replace ring position, 20211223, S.TSUCHIYA add
-		if (parent.getRingSize() == 'o') {
-			par_pos_temp += parent.getType().getAnomericCarbon();
-		}
-		if (parent.getRingSize() == 'p') {
-			if (parent.getAnomericCarbon() == '1') {
-				par_pos_temp = par_pos_temp.replace('5', ' ');
-			}
-			if (parent.getAnomericCarbon() == '2') {
-				par_pos_temp = par_pos_temp.replace('6', ' ');
-			}
-		}
-		if (parent.getRingSize() == 'f') {
-			if (parent.getAnomericCarbon() == '1') {
-				par_pos_temp = par_pos_temp.replace('4', ' ');
-			}
-			if (parent.getAnomericCarbon() == '2') {
-				par_pos_temp = par_pos_temp.replace('5', ' ');
-			}
-		}
-
-		// refresh par_pos, 20211223, S.TSUCHIYA add
-		if (!par_pos_temp.equals(String.valueOf(par_pos))) {
-			par_pos_temp = par_pos_temp.replaceAll(" ", "");
-			par_pos = par_pos_temp.toCharArray();
-			Arrays.sort(par_pos);
-		}
-
-		// add elements
 		ret.addElement("?");
-		for (int i = 0; i < par_pos.length; i++)
-			ret.addElement("" + par_pos[i]);
+		if (parent == null) return ret;
+
+		for (char position : parent.availableLinkagePositions()) {
+			// the position this linkage already has is still its own to keep
+			ret.addElement("" + position);
+		}
+		for (char position : positionsThisLinkageAlreadyHas(parent)) {
+			if (!ret.contains("" + position)) ret.addElement("" + position);
+		}
 
 		return ret;
-	}
+    }
+
+    /**
+     * The positions the linkage being edited already occupies.
+     *
+     * <p>They are unavailable by the residue's reckoning, because this linkage is what holds them -
+     * and leaving them out would drop the current selection from the list it is selected in.
+     *
+     * @param parent The residue the linkage hangs off.
+     * @return Returns those positions.
+     */
+    private char[] positionsThisLinkageAlreadyHas(Residue parent) {
+		StringBuilder held = new StringBuilder();
+		for (org.eurocarbdb.application.glycanbuilder.linkage.Linkage linkage : parent.getChildrenLinkages()) {
+			if (this.current != linkage.getChildResidue()) continue;
+
+			for (org.eurocarbdb.application.glycanbuilder.linkage.Bond bond : linkage.getBonds()) {
+				char[] positions = bond.getParentPositions();
+				if (positions != null && positions.length == 1 && positions[0] != '?')
+					held.append(positions[0]);
+			}
+		}
+
+		char[] ret = new char[held.length()];
+		held.getChars(0, held.length(), ret, 0);
+
+		return ret;
+    }
 
     private void setSelections() {
     	if( parent_link!=null )        

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/PositionRulesLiveInTheModelTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/PositionRulesLiveInTheModelTest.java
@@ -1,0 +1,125 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That the rules about which positions take a linkage are in the model, and are all of them.
+ *
+ * <p>They had been in three places: the residue type's list, which only the linkage dialog asked;
+ * the ring and anomeric rules, which only that dialog knew; and what a sibling had taken, which only
+ * the model knew. A structure drawn through the dialog therefore obeyed rules a structure built any
+ * other way did not.
+ *
+ * <p>See {@code docs/linkage-positions-and-anomers.md}, which is where the chemistry these assert
+ * is written down and attributed.
+ */
+public class PositionRulesLiveInTheModelTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** What the residue type already knows: a built-in substituent, and a sugar's size. */
+	@Test
+	public void theTypesOwnListIsObeyed() throws Exception {
+		assertFalse("GlcNAc's 2 carries the N-acetyl",
+				sugar("GlcNAc").addChild(ResidueDictionary.newResidue("Me"), '2'));
+		assertFalse("a pentose has no 6",
+				sugar("Xyl").addChild(ResidueDictionary.newResidue("Me"), '6'));
+		assertFalse("Neu5Ac's 5 carries the N-acetyl",
+				sugar("Neu5Ac").addChild(ResidueDictionary.newResidue("Me"), '5'));
+	}
+
+	/**
+	 * But a built-in substituent does not always close its position.
+	 *
+	 * <p>GlcA's carboxyl at 6 leaves it open, because a carboxyl can be esterified. That is a
+	 * chemical judgement made per residue rather than a rule to be derived, which is why the type's
+	 * list is consulted rather than reasoned about - and this is the case that would be got wrong by
+	 * reasoning.
+	 */
+	@Test
+	public void aCarboxylDoesNotCloseItsPosition() throws Exception {
+		assertTrue("GlcA's 6 should stay open for an ester",
+				sugar("GlcA").addChild(ResidueDictionary.newResidue("Me"), '6'));
+	}
+
+	/** The ring oxygen occupies a position, and it takes no glycosidic bond. */
+	@Test
+	public void theRingClosesItsOwnPosition() throws Exception {
+		Residue pyranose = sugar("Glc");
+		pyranose.setRingSize('p');
+		assertFalse("a pyranose closing from 1 has its 5 in the ring",
+				pyranose.acceptsPosition('5', null));
+		assertTrue(pyranose.acceptsPosition('4', null));
+
+		Residue furanose = sugar("Glc");
+		furanose.setRingSize('f');
+		assertFalse("a furanose closing from 1 has its 4 in the ring",
+				furanose.acceptsPosition('4', null));
+		assertTrue(furanose.acceptsPosition('5', null));
+	}
+
+	/**
+	 * An alditol has no ring and no anomeric centre, so its 1 is an ordinary hydroxyl.
+	 *
+	 * <p>The type's list does not offer 1, because in a ring the anomeric carbon is where the residue
+	 * attaches to its parent. Reduced, there is no anomeric carbon and nothing is attached there.
+	 */
+	@Test
+	public void anAlditolOpensPositionOne() throws Exception {
+		Residue reduced = sugar("Glc");
+		reduced.setAlditol(true);
+
+		assertTrue("an alditol's 1 is an ordinary hydroxyl", reduced.acceptsPosition('1', null));
+		assertTrue("and it has no ring to close a position", reduced.acceptsPosition('5', null));
+	}
+
+	/**
+	 * A bridge is not an ordinary glycosidic bond and is not bound by the type's list.
+	 *
+	 * <p>1,6-anhydro attaches at the anomeric carbon, which no type's list offers. Enforcing the list
+	 * against it stops the structure round-tripping - measured, before this was separated out.
+	 */
+	@Test
+	public void aBridgeMayAttachWhereAnOrdinaryBondMayNot() throws Exception {
+		GlycanDocument document =
+				new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		assertTrue(document.importFromString("WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/", "wurcs2"));
+
+		document.clearString();
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+		assertEquals("1,6-anhydro should survive the round trip",
+				"WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/",
+				String.join("", document.getString()).trim());
+	}
+
+	/** A residue type with no list of its own constrains nothing, which 47 of the 134 do not have. */
+	@Test
+	public void noListMeansNoConstraintRatherThanNoPositions() throws Exception {
+		Residue substituent = ResidueDictionary.newResidue("Me");
+
+		assertTrue("a type with no position list should not refuse everything",
+				substituent.availableLinkagePositions().length > 0);
+	}
+
+	private static Residue sugar(String name) throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		Residue residue = ResidueDictionary.newResidue(name);
+		root.addChild(residue);
+
+		return residue;
+	}
+}


### PR DESCRIPTION
Implements the three rules #34 turned out to be part of, and puts all of them in one place.

### What moved

| Rule | Was | Is |
|---|---|---|
| the type's position list | known by the linkage dialog only | `Residue.availableLinkagePositions` |
| ring form and anomeric centre | known by that dialog only | same |
| what a sibling holds | enforced by the model only | same |

`addChild` and `canAddChild` enforce them; the dialog shows what they say instead of working it out
again. A structure drawn through the dialog used to obey rules that one built any other way did not,
which is how a Man came to carry two branches at position 4.

### The chemistry, and why none of it is derivable

- **A built-in substituent does not always close its position.** GlcNAc's N-acetyl closes 2; GlcA's
  carboxyl leaves 6 open, because a carboxyl can be esterified. Per residue, so the list is consulted
  rather than reasoned about — there is a test for exactly the case reasoning gets wrong.
- **The ring occupies a position**: 5 or 6 for a pyranose, 4 or 5 for a furanose, depending on where
  the anomeric centre is. An open chain closes nothing. The ring atom may be nitrogen, which changes
  what the residue *is* and not what can hang off it.
- **An alditol** has no ring and no anomeric centre, so its 1 is an ordinary hydroxyl and does take a
  bond — which the type's list does not say, because in a ring it does not.
- **An empty list means no constraint**, not no positions. 47 of the 134 types have none.

### The exemption, which is why the first attempt was reverted

A bridge is not an ordinary glycosidic bond and may attach at the anomeric carbon. Enforcing the
type's list against one stops `WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/` — 1,6-anhydro — from
round-tripping. `acceptsPosition` takes the child so it can tell the two apart, and there is a test
holding the round trip.

### And the display rule

An anomeric configuration is not drawn where there is no anomeric centre. An alditol or an open chain
has nothing for α or β to describe; drawing one states something untrue, and drawing "?" would say it
is unknown when it is absent.

`docs/linkage-positions-and-anomers.md` is updated to describe what the code now does, including the
sample-not-set caveat on its residue table and the 47 types with no list.

159 tests pass.
