### PR TITLE
Export a picture without a background behind it

### DIFF
--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -73,9 +73,9 @@ remains, and the issue should say so rather than being closed.
 
 | # | Title | Note |
 |---|---|---|
-| **#186** | PNG background not transparent | These three are one problem — "I cannot put this in a paper" — |
-| **#188** | SVG gives every character its own white background | and are worth doing together rather than |
-| **#187** | Ungrouping in PowerPoint destroys Fuc and Man | one at a time |
+| ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
+| ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
+| **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | **#106** | Saving on close offers Save As for an already-saved file | |
 | **#178** | "Open additional document" leaves the document counted as unchanged, so it closes without warning | |
 | **#179** | "Remember files after restarting" carries a customised reducing end into newly imported structures | |

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/SVGUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/SVGUtils.java
@@ -69,6 +69,17 @@ public class SVGUtils   {
     public void afterRendering();
     }
 
+    /**
+       White with no alpha - which is what "no background" is on a surface that paints one.
+
+       <p>An exported picture goes into a figure or a slide, where a white rectangle behind the
+       glycan covers whatever it is placed on (#186). On an SVG surface it was worse than one
+       rectangle: the renderers clear behind text so it stays legible over a bond line, and
+       clearRect on such a surface paints the background colour rather than removing anything, so
+       every piece of text carried its own white patch (#188).</p>
+    */
+    static private final Color TRANSPARENT = new Color(255,255,255,0);
+
     private SVGUtils() {}
 
     /**
@@ -140,8 +151,7 @@ public class SVGUtils   {
 
             // clear background
             g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-            g2d.setBackground(Color.white);
-            g2d.clearRect(0, 0, d.width, d.height);
+            g2d.setBackground(TRANSPARENT);
 
             // paint
             for (Glycan s : structures)
@@ -186,8 +196,7 @@ public class SVGUtils   {
 
             // clear background
     		g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-    		g2d.setBackground(Color.white);
-    		g2d.clearRect(0, 0, d.width, d.height);
+    		g2d.setBackground(TRANSPARENT);
 
             // paint
     		for(Glycan structure : structures )
@@ -300,7 +309,7 @@ public class SVGUtils   {
     all_dim.width = (int)(all_dim.width*sf);
     all_dim.height = (int)(all_dim.height*sf);
     */
-    g2d.setBackground(Color.white);
+    g2d.setBackground(TRANSPARENT);
     g2d.setSVGCanvasSize(all_dim);
     
     return g2d;
@@ -606,9 +615,27 @@ public class SVGUtils   {
     else if( format.equals("eps") )
         os.write(orRefuse(getEPSGraphics(gr,structures,show_masses,show_redend), format));
     else if( format.equals("bmp") || format.equals("png") || format.equals("jpg") )
-        javax.imageio.ImageIO.write(gr.getImage(structures,true,show_masses,show_redend,scale,posManager,bboxManager),format,os);
+        javax.imageio.ImageIO.write(gr.getImage(structures,opaqueFor(format),show_masses,show_redend,scale,posManager,bboxManager),format,os);
     else
         throw new Exception("Unrecognized graphic format: " + format);
+    }
+
+    /**
+       Whether an image of this format should be painted onto white rather than onto nothing.
+
+       <p>PNG carries an alpha channel and the renderer has always been able to paint without a
+       background - the export simply never asked, passing opaque for every format alike. So a glycan
+       put into a figure or a slide arrived with a white rectangle around it, over whatever it was
+       placed on (#186).</p>
+
+       <p>BMP and JPEG have no alpha to write. Painting those onto nothing gives a black background,
+       or an undefined one, which is worse than the white it replaces - so they keep it.</p>
+
+       @param format The format being written.
+       @return Returns whether to paint a background.
+    */
+    static private boolean opaqueFor(String format) {
+    return !format.equals("png");
     }
 
     /**

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ExportsCarryNoBackgroundTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ExportsCarryNoBackgroundTest.java
@@ -1,0 +1,125 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.imageio.ImageIO;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an exported picture brings no background with it (#186, #188).
+ *
+ * <p>An exported glycan goes into a figure or a slide, where a white rectangle behind it covers
+ * whatever it was placed on. PNG carries an alpha channel and the renderer could always paint
+ * without a background; the export simply never asked, passing opaque for every format alike.
+ *
+ * <p>SVG was worse than one rectangle. The renderers clear behind text so it stays legible over a
+ * bond line, and {@code clearRect} on an SVG surface paints the background colour rather than
+ * removing anything — so every piece of text carried its own white patch, and removing them by hand
+ * in Illustrator was what the report described doing.
+ */
+public class ExportsCarryNoBackgroundTest {
+
+	private static BuilderWorkspace workspace;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		workspace = new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A PNG is transparent where nothing was drawn. */
+	@Test
+	public void aPngHasNoBackground() throws Exception {
+		ByteArrayOutputStream written = new ByteArrayOutputStream();
+		SVGUtils.export(written, (GlycanRendererAWT) workspace.getGlycanRenderer(), structures(),
+				false, true, 1.0, "png", new PositionManager(), new BBoxManager());
+
+		BufferedImage image = ImageIO.read(new ByteArrayInputStream(written.toByteArray()));
+		int topLeft = image.getRGB(0, 0);
+
+		assertEquals("the corner of the image is painted, so the background is still there",
+				0, topLeft >>> 24);
+	}
+
+	/**
+	 * Formats with no alpha keep theirs.
+	 *
+	 * <p>BMP and JPEG have nowhere to write transparency. Painting them onto nothing gives a black
+	 * background or an undefined one, which is worse than the white it would replace.
+	 */
+	@Test
+	public void formatsWithoutAlphaKeepTheirBackground() throws Exception {
+		for (String format : new String[] { "bmp", "jpg" }) {
+			ByteArrayOutputStream written = new ByteArrayOutputStream();
+			SVGUtils.export(written, (GlycanRendererAWT) workspace.getGlycanRenderer(), structures(),
+					false, true, 1.0, format, new PositionManager(), new BBoxManager());
+
+			BufferedImage image = ImageIO.read(new ByteArrayInputStream(written.toByteArray()));
+			int topLeft = image.getRGB(0, 0);
+
+			assertEquals(format + " should still be painted onto white", 255, topLeft >>> 24);
+		}
+	}
+
+	/** No white rectangle anywhere in the SVG — neither the page's nor one behind each character. */
+	@Test
+	public void anSvgHasNoWhiteRectangles() {
+		String svg = SVGUtils.getVectorGraphics((GlycanRendererAWT) workspace.getGlycanRenderer(),
+				structures(), false, true);
+
+		int white = 0;
+		Matcher rectangles = Pattern.compile("<rect\\b[^>]*/?>").matcher(svg);
+		while (rectangles.find()) {
+			String rectangle = rectangles.group();
+			if (rectangle.contains("fill:white") || rectangle.contains("fill:#ffffff")
+					|| rectangle.contains("fill:rgb(255,255,255)")) {
+				white++;
+			}
+		}
+
+		assertEquals("the SVG still paints white: " + white + " rectangles", 0, white);
+	}
+
+	/**
+	 * And the glycan is still drawn.
+	 *
+	 * <p>The way to pass the assertion above is to stop painting altogether, so this holds the other
+	 * side: the residues keep their colours.
+	 */
+	@Test
+	public void theGlycanItselfIsStillPainted() {
+		String svg = SVGUtils.getVectorGraphics((GlycanRendererAWT) workspace.getGlycanRenderer(),
+				structures(), false, true);
+
+		assertTrue("GlcNAc's blue is gone", svg.contains("rgb(0,114,188)"));
+		assertTrue("Man's green is gone", svg.contains("rgb(0,166,81)"));
+	}
+
+	private static Collection<Glycan> structures() {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		try {
+			document.importFromString(
+					"freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p--4b1D-Man,p--3a1D-Man,p", "gws");
+		} catch (Exception cannotRead) {
+			throw new IllegalStateException(cannotRead);
+		}
+
+		return document.getStructures();
+	}
+}


### PR DESCRIPTION
Closes #186 and #188, and may answer #187.

An exported glycan goes into a figure or a slide, where a white rectangle behind it covers whatever
it was placed on.

### #186 — PNG

The renderer could always paint without a background. The export never asked, passing opaque for
every format alike. Measured, corner pixel: alpha 255 → 0.

BMP and JPEG keep theirs — they have nowhere to write transparency, and painting them onto nothing
gives a black or undefined background, which is worse than the white it would replace. Held by a
test.

### #188 — SVG, and why it was worse than one rectangle

The renderers clear behind text so it stays legible over a bond line. `clearRect` on an SVG surface
**paints the background colour** rather than removing anything, and the export set that colour to
white — so every piece of text carried its own white patch. Removing them by hand in Illustrator is
what the report described doing.

Measured: white rectangles 9 → 0.

The tests hold the other side as well — that GlcNAc's blue and Man's green are still there — because
the way to pass "no white rectangles" is to stop painting altogether.

### #187 — left open

Ungrouping in PowerPoint destroyed Fuc and Man. It was described as happening while hunting for the
white background to delete, and there is no longer one to hunt for, so the operation that broke the
residues may no longer be one anybody performs. That is a guess about somebody else's workflow rather
than a fix, so the issue stays open pending a retest.

163 tests pass.
