### PR TITLE
Stop three ways a document lost what was in it

### DIFF
--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -76,9 +76,9 @@ remains, and the issue should say so rather than being closed.
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
-| **#106** | Saving on close offers Save As for an already-saved file | |
-| **#178** | "Open additional document" leaves the document counted as unchanged, so it closes without warning | |
-| **#179** | "Remember files after restarting" carries a customised reducing end into newly imported structures | |
+| ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
+| ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
+| ~~#179~~ | ~~"Remember files after restarting" carries a customised reducing end into new imports~~ | **Done.** The WURCS reader clears it alongside the derivatization and ion cloud it already cleared: what the sequence states is the answer, and what it does not state is a default rather than a leftover |
 
 ## P3 — visibly wrong
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -336,8 +336,23 @@ public abstract class BaseDocument {
         return false;
         }
 
-        // 
-        setFilename(file.getAbsolutePath());        
+        if( merge ) {
+            // Opening a second file *into* this one leaves a document that is neither file: it is
+            // what was here plus what arrived. So it keeps its own name - taking the merged file's
+            // would make a later Save write over a file the user did not edit - and it counts as
+            // changed, because it is (#178). It used to do neither: setFilename cleared the changed
+            // flag as a side effect, so the document came out marked saved, the asterisk never
+            // appeared, Save stayed disabled, and closing threw the merge away without asking.
+            //
+            // Changed rather than initialized: fireDocumentInit clears the flag itself, which is
+            // right for a document that has just become a file's contents and wrong for one that has
+            // just stopped being them.
+            fireDocumentChanged();
+
+            return true;
+        }
+
+        setFilename(file.getAbsolutePath());
         fireDocumentInit();
         return true;
     }

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -492,7 +492,12 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 			int ret = JOptionPane.showConfirmDialog(this,"Save changes to " + doc.getName().toLowerCase() + "?", null, JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 			if( ret == JOptionPane.CANCEL_OPTION ) return false;        
 			if( ret == JOptionPane.YES_OPTION ) {
-				if( !onSaveAs(doc) ) return false;
+				// Save, not Save As. A document that came from a file has one to go back to, and
+				// asking where to put it is asking a question that was answered when it was opened -
+				// the file's name is in the title bar at the time (#106). onSave falls back to Save As
+				// by itself where there is no file yet, or where it cannot be written to, which is
+				// the case this had been written for.
+				if( !onSave(doc) ) return false;
 				return true;
 			}
 			if( ret == JOptionPane.NO_OPTION ) return true;

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
@@ -64,6 +64,15 @@ public class WURCS2Parser implements GlycanParser{
 		if(str.equals("") || !str.contains("WURCS")) throw new Exception(str + " is wrong format");
 		mass_opt.setDerivatization("Und");
 		mass_opt.ION_CLOUD.set("Na", 0);
+
+		// The sequence says what its reducing end is, and where it says nothing it is a free end.
+		// The mass options handed in carry whatever was last chosen in the dialog, and with
+		// "Remember files after restarting" on that outlives the session - so a structure imported
+		// after a restart arrived carrying somebody's -Asn from a previous sitting, on a sequence
+		// that never mentioned one (#179). Cleared here for the same reason the derivatization and
+		// the ion cloud above are: what the sequence states is the answer, and what it does not
+		// state is a default rather than a leftover.
+		mass_opt.setReducingEndType(org.eurocarbdb.application.glycanbuilder.ResidueType.createFreeReducingEnd());
 		
 		str = str.trim();		
 		if(str.contains("\t")) str = str.substring(str.indexOf("\t") + 1);

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/SavedWorkIsNotLostTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/SavedWorkIsNotLostTest.java
@@ -1,0 +1,104 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * The two ways a document could quietly lose what was in it, and the setting that outlived its
+ * session.
+ *
+ * <p>#178: opening a second file <em>into</em> the current one left the document counted as
+ * unchanged, so no asterisk appeared, Save stayed disabled, and closing threw the merge away without
+ * asking. #179: with "Remember files after restarting" on, the reducing end last chosen in the
+ * dialog was applied to structures imported afterwards, on sequences that never mentioned one.
+ */
+public class SavedWorkIsNotLostTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * Merging a file in leaves the document changed, and still called what it was.
+	 *
+	 * <p>Both halves matter. Unchanged meant it closed without asking; taking the merged file's name
+	 * would have meant a later Save writing over a file the user never edited.
+	 */
+	@Test
+	public void mergingAFileInLeavesTheDocumentChanged() throws Exception {
+		File first = gwsFile("freeEnd--?b1D-GlcNAc,p$MONO,perMe,Na,0,freeEnd");
+		File second = gwsFile("freeEnd--?b1D-Man,p$MONO,perMe,Na,0,freeEnd");
+
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.open(first, false, true));
+		assertFalse("a document just opened is not changed", document.hasChanged());
+
+		assertTrue(document.open(second, true, true));
+
+		assertTrue("a document with a file merged into it has changed", document.hasChanged());
+		assertEquals("it should keep its own file, not take the merged one's",
+				first.getAbsolutePath(), document.getFileName());
+		assertEquals("both structures should be there", 2, document.getStructures().size());
+	}
+
+	/** Opening a file normally still counts as unchanged, and takes that file's name. */
+	@Test
+	public void openingAFileNormallyIsNotAChange() throws Exception {
+		File file = gwsFile("freeEnd--?b1D-GlcNAc,p$MONO,perMe,Na,0,freeEnd");
+
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.open(file, false, true));
+
+		assertFalse(document.hasChanged());
+		assertEquals(file.getAbsolutePath(), document.getFileName());
+	}
+
+	/**
+	 * A sequence that names no reducing end gets a free end, whatever was chosen last.
+	 *
+	 * <p>The mass options handed to the parser carry the dialog's last state, and with the history
+	 * setting on that survives a restart - so an import arrived carrying an aglycone from a previous
+	 * sitting.
+	 */
+	@Test
+	public void animportedSequenceDoesNotInheritTheLastReducingEnd() throws Exception {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+
+		MassOptions remembered = workspace.getDefaultMassOptions();
+		remembered.setReducingEndTypeString("Asn");
+		workspace.setDefaultMassOptions(remembered);
+
+		GlycanDocument document = workspace.getStructures();
+		assertTrue(document.importFromString(
+				"WURCS=2.0/1,1,0/[a2122h-1b_1-5_2*NCC/3=O]/1/", "wurcs2"));
+
+		Glycan imported = document.getStructures().get(0);
+		String reducingEnd = imported.getMassOptions().getReducingEndTypeString();
+
+		assertEquals("the sequence named no aglycone, so it should have a free end",
+				"freeEnd", reducingEnd);
+	}
+
+	private static File gwsFile(String contents) throws Exception {
+		File file = File.createTempFile("gb2-", ".gws");
+		file.deleteOnExit();
+		try (FileWriter out = new FileWriter(file)) {
+			out.write(contents);
+		}
+
+		return file;
+	}
+}


### PR DESCRIPTION
Closes #106, #178 and #179 — the rest of P2. Three different bugs with one thing in common: a
document quietly stopped being what the person thought it was.

### #106 — closing a saved file asked where to put it

The close prompt called `onSaveAs` outright. Answering "yes, save" opened a file dialog for a
document whose filename was in the title bar at the time. `onSave` writes to the file the document
came from and falls back to Save As by itself where there is none — which is the case the direct
call had been written for.

### #178 — a merge left the document counted as unchanged

`setFilename` clears the changed flag as a side effect, and `open` called it whether or not it was
merging. So a document that had just become neither file came out marked saved: no asterisk, Save
disabled, and closing threw the merge away without asking.

It also took the merged file's name, which would have made a later Save write over a file nobody had
edited. Both halves are fixed, and both are asserted.

Fired as a *change* rather than an init, because `fireDocumentInit` clears the flag itself — right
for a document that has just become a file's contents, wrong for one that has just stopped being
them.

### #179 — an import inherited the last reducing end chosen

The mass options handed to the WURCS reader carry the dialog's state, and with "Remember files after
restarting" on that outlives the session. A structure imported after a restart arrived carrying an
`-Asn` from a previous sitting, on a sequence that never mentioned one.

Cleared where the derivatization and the ion cloud already were: what the sequence states is the
answer, and what it does not state is a default rather than a leftover.

### Verified

Each fix was removed and the tests watched failing:

```
animportedSequenceDoesNotInheritTheLastReducingEnd  expected:<[freeEnd]> but was:<[Asn]>
mergingAFileInLeavesTheDocumentChanged              a document with a file merged into it has changed
```

166 tests pass.
