### PR TITLE
Version 1.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,55 @@
 ## Change log
+### 1.37.0  (20260814)
+Everything at the top of the triage list, in both bands: a wrong answer nobody can see is wrong, and
+work that quietly disappears.
+* **The same linkage position could be given to two children** - a Man with two branches both at 4,
+  which is not a molecule. It draws, and the WURCS export then writes nothing, which is how it was
+  usually noticed (#34)
+  * The linkage dialog had learned to filter its list in 2021 and the model had not, so a structure
+    drawn through the dialog obeyed rules a structure built any other way did not
+  * The rule is about the carbon rather than about what hangs off it: a methyl at 4 and a branch at 4
+    are the same claim on the same atom
+* **All the rules about which positions take a linkage are in the model now**, and the dialog shows
+  what they say rather than working it out again
+  * **The residue type's list** knows what the sugar is made of - GlcNAc omits 2 for its N-acetyl,
+    Xyl has no 6 - and whether a built-in substituent closes its position is a chemical judgement made
+    per residue rather than a rule to be derived. GlcA keeps 6 open, because a carboxyl can be
+    esterified. 47 of the 134 types declare no list at all, and no list means no constraint
+  * **The ring** occupies a position: 5 or 6 for a pyranose, 4 or 5 for a furanose, depending on where
+    the anomeric centre is. An open chain closes nothing
+  * **An alditol** has no ring and no anomeric centre, so its 1 is an ordinary hydroxyl and does take
+    a bond
+  * **A bridge is exempt, deliberately.** It may attach at the anomeric carbon, which no list offers,
+    and 1,6-anhydro does - enforcing the list against it stopped that structure round-tripping, which
+    is how the exemption was found
+  * `docs/linkage-positions-and-anomers.md` writes all of this down, chemistry and attribution
+    included, because reading the code says what it does rather than whether that is right
+* **An anomeric configuration is no longer drawn where there is no anomeric centre.** An alditol or an
+  open-chain form has nothing for α or β to describe; drawing one states something untrue, and drawing
+  "?" would say it is unknown when it is absent
+* **An exported picture brings no background with it** (#186, #188)
+  * PNG carries an alpha channel and the renderer could always paint without a background - the export
+    simply never asked, passing opaque for every format alike. BMP and JPEG keep theirs, having
+    nowhere to write transparency
+  * SVG was worse than one rectangle: the renderers clear behind text so it stays legible over a bond
+    line, and `clearRect` on an SVG surface paints the background colour rather than removing
+    anything, so every character carried its own white patch. Measured, white rectangles 9 to 0, with
+    the residues' colours held by a test of their own - the way to pass "no white" is to stop painting
+* **Three ways a document lost what was in it**
+  * Closing a saved file asked where to put it, the prompt calling Save As outright for a document
+    whose filename was in the title bar (#106)
+  * Merging a file in left the document counted as unchanged - `setFilename` clears the changed flag
+    as a side effect - so no asterisk appeared, Save stayed disabled, and closing threw the merge away
+    without asking. It took the merged file's name too, which would have made a later Save write over
+    a file nobody had edited (#178)
+  * An imported sequence inherited the reducing end last chosen in the dialog, which with "Remember
+    files after restarting" outlived the session: a WURCS that named no aglycone arrived carrying
+    somebody's -Asn from a previous sitting (#179)
+* **A failed vector export says so** rather than writing a 0-byte file (#185). The underlying failure
+  was reported on Windows and does not reproduce here, so this fixes the silence rather than the cause
+* #67, #150 and #158 were found already fixed while the list was being reproduced, and are closed with
+  the measurements. #66 does not reproduce either and awaits a retest
+
 ### 1.36.0  (20260814)
 The first pass of a triaged issue list, and the four things at the top of it. Reproducing the list
 first found three issues already fixed and still open (#67, #150, #158), now closed with the

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -73,9 +73,9 @@ remains, and the issue should say so rather than being closed.
 
 | # | Title | Note |
 |---|---|---|
-| **#186** | PNG background not transparent | These three are one problem — "I cannot put this in a paper" — |
-| **#188** | SVG gives every character its own white background | and are worth doing together rather than |
-| **#187** | Ungrouping in PowerPoint destroys Fuc and Man | one at a time |
+| ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
+| ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
+| **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | **#106** | Saving on close offers Save As for an already-saved file | |
 | **#178** | "Open additional document" leaves the document counted as unchanged, so it closes without warning | |
 | **#179** | "Remember files after restarting" carries a customised reducing end into newly imported structures | |

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -76,9 +76,9 @@ remains, and the issue should say so rather than being closed.
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
-| **#106** | Saving on close offers Save As for an already-saved file | |
-| **#178** | "Open additional document" leaves the document counted as unchanged, so it closes without warning | |
-| **#179** | "Remember files after restarting" carries a customised reducing end into newly imported structures | |
+| ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
+| ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
+| ~~#179~~ | ~~"Remember files after restarting" carries a customised reducing end into new imports~~ | **Done.** The WURCS reader clears it alongside the derivatization and ion cloud it already cleared: what the sequence states is the answer, and what it does not state is a default rather than a leftover |
 
 ## P3 — visibly wrong
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -66,8 +66,8 @@ remains, and the issue should say so rather than being closed.
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
 | ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass.** Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82). **Still monoisotopic: the ion adducts.** `IonCloud` captures an ion's mass when the ion is set, not when the mass is computed, so an m/z carries an average neutral mass and a monoisotopic adduct. Worth its own issue |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
-| **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | |
-| **#34** | Duplicated linkage position in a branched glycan | The position list is built without asking what the parent already carries, so an impossible structure can be drawn |
+| **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
+| ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
 
 ## P2 — work is lost, or the output cannot be used
 

--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -11,7 +11,8 @@ Where a rule is a judgement rather than a fact, it says so and says whose judgem
 ### The residue type's own list
 
 Each residue type declares the positions it will accept, and that list is the authority. It already
-accounts for what the sugar is made of:
+accounts for what the sugar is made of. A sample rather than the whole set — there are 134 types, and
+each row below stands for a kind:
 
 | Residue | Positions | Why |
 |---|---|---|
@@ -37,6 +38,11 @@ glycosidic bond or about a bridge, and nothing in the model draws that distincti
 
 *Confirmed by I. Yamada, 2026-08-14: "GlcA の 6 位は結合位置として提示すべきではない、という理解で合っ
 ていますか" — "いいえ、間違っています。エステル結合などの可能性があります。"*
+
+**47 of the 134 types declare no list at all** — reducing ends (freeEnd, redEnd, PA, 2AB, …) and
+substituents (Me, DH, …). No list means **no constraint**, not no positions: anything reading the
+list has to treat an empty one as "nothing to say" rather than "nothing allowed", or those 47 would
+accept nothing.
 
 ### The ring
 
@@ -87,16 +93,15 @@ the drawing should not confuse them.
 
 They should live in one place and be consulted from every other. As of 2026-08-14 they do not:
 
-| Rule | Where it is | Consulted by |
-|---|---|---|
-| the type's position list | `ResidueType.getLinkagePositions`, `isValidPosition` | the linkage dialog |
-| ring form and anomeric centre | `ResiduePropertiesDialog.createPositions` | that dialog alone |
-| what a sibling has taken | `Residue.canAddChild` / `addChild` | both, since 1.36.x |
+They live in `Residue.availableLinkagePositions` and `Residue.acceptsPosition`, and everything else
+asks. `addChild` and `canAddChild` enforce them; the linkage dialog shows what they say rather than
+working it out again.
 
-So a structure built through the dialog obeys rules the model does not enforce, and a structure built
-any other way — imported, scripted, or through another code path — obeys only the last of them. That
-is how a Man came to have two branches at position 4 (#34).
+Until this was done they were in three places and none of them was the model — the type's list, which
+only the dialog asked; the ring and anomeric rules, which only the dialog knew; and what a sibling
+had taken, which only the model knew. A structure drawn through the dialog obeyed rules that one
+built any other way did not, which is how a Man came to carry two branches at position 4 (#34).
 
-**The fix is to move the knowledge into the model** and have the dialog ask it, rather than the two
-each knowing a different part. Until that is done, a change to any of these rules has to be made in
-more than one place, and this file is the record of what they are.
+**A bridge is exempt, deliberately.** It is not an ordinary glycosidic bond and may attach at the
+anomeric carbon, so the type's list does not apply to it; only the sibling rule does.
+`acceptsPosition` takes the child for exactly that reason.

--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -1,0 +1,102 @@
+# Which positions take a linkage, and when an anomer is shown
+
+The rules that decide what a residue will accept and what is drawn on it. Written down because they
+are chemistry rather than programming: reading the code tells you what it does, not whether that is
+right, and the two have differed here.
+
+Where a rule is a judgement rather than a fact, it says so and says whose judgement it was.
+
+## What can take a linkage
+
+### The residue type's own list
+
+Each residue type declares the positions it will accept, and that list is the authority. It already
+accounts for what the sugar is made of:
+
+| Residue | Positions | Why |
+|---|---|---|
+| Glc | 2 3 4 5 6 | a plain hexose |
+| GlcNAc | 3 4 5 6 | 2 carries the N-acetyl |
+| GlcN | 3 4 5 6 N | 2 carries the amino group, and the nitrogen itself can be substituted |
+| Neu5Ac | 1 2 3 4 6 7 8 9 N | 5 carries the N-acetyl |
+| Xyl | 2 3 4 5 | a pentose has no 6 |
+| GlcA | 2 3 4 5 6 | **6 stays open** — see below |
+
+**A built-in substituent does not always close its position.** GlcA carries a carboxyl at 6 and the
+position remains available, because a carboxyl can be esterified. GlcNAc's N-acetyl at 2 does close
+it. The distinction is chemical, not structural, which is why the list is maintained per residue
+rather than derived from the formula — and why code must consult the list rather than reason about
+it.
+
+**The list is not a general test of whether a bond may attach there.** It omits the anomeric carbon,
+because that is normally where the residue attaches to its *parent* rather than where children
+attach — but a bridge can attach there, and 1,6-anhydro does. Refusing every bond at a position
+absent from the list therefore refuses real structures: measured, `WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/`
+stops round-tripping. Whatever consults this list has to know whether it is asking about an ordinary
+glycosidic bond or about a bridge, and nothing in the model draws that distinction yet.
+
+*Confirmed by I. Yamada, 2026-08-14: "GlcA の 6 位は結合位置として提示すべきではない、という理解で合っ
+ていますか" — "いいえ、間違っています。エステル結合などの可能性があります。"*
+
+### The ring
+
+The ring oxygen occupies a position, and that position takes no linkage. Which position depends on
+the ring form and where the anomeric centre is:
+
+- **pyranose** with the anomeric centre at 1: position 5 is closed
+- **pyranose** with the anomeric centre at 2: position 6 is closed
+- **furanose**: the ring is smaller, and the position two carbons along is closed instead
+- **open chain**: no ring, so nothing is closed by one
+
+**The ring atom is not always oxygen.** It can be nitrogen, and such sugars exist. That is a fact
+about what the residue *is*, not about what can be attached to it: the position is still part of the
+ring and still takes no glycosidic bond. Nothing here should refuse a residue for having a nitrogen
+in its ring.
+
+### The reducing end
+
+An **alditol** — a reduced sugar — has no ring and no anomeric centre. Its position 1 is an ordinary
+hydroxyl and **can take a linkage**, which it cannot when the same sugar is in a ring.
+
+### What another child already has
+
+A carbon carries one glycosidic bond. A position another child already occupies is not available,
+and this holds across kinds: a methyl at 4 and a branch at 4 are the same claim on the same atom.
+
+**Only a stated position counts.** An unknown position — `?`, which is most of what a structure read
+from a database carries — says nothing about where anything is, so two of those do not conflict.
+A bond naming several positions at once is the same case: "one of these" is not a claim on any one
+of them.
+
+## What is drawn
+
+### The anomeric configuration
+
+α and β describe the configuration at the anomeric centre. **Where there is no anomeric centre there
+is nothing to describe, and nothing should be shown** — not "unknown", not a placeholder. An alditol
+and an open-chain form both fall under this.
+
+*Confirmed by I. Yamada, 2026-08-14: "開鎖体でアノマー位が無い場合、アノマー表記（α/β）はすべきでは
+ありません。非表示が良いのではないでしょうか？"*
+
+Showing "α" on something that has no anomeric carbon states something untrue about the molecule, and
+showing "?" states that it is unknown when it is not unknown but absent. The two are different and
+the drawing should not confuse them.
+
+## Where these rules live in the code
+
+They should live in one place and be consulted from every other. As of 2026-08-14 they do not:
+
+| Rule | Where it is | Consulted by |
+|---|---|---|
+| the type's position list | `ResidueType.getLinkagePositions`, `isValidPosition` | the linkage dialog |
+| ring form and anomeric centre | `ResiduePropertiesDialog.createPositions` | that dialog alone |
+| what a sibling has taken | `Residue.canAddChild` / `addChild` | both, since 1.36.x |
+
+So a structure built through the dialog obeys rules the model does not enforce, and a structure built
+any other way — imported, scripted, or through another code path — obeys only the last of them. That
+is how a Man came to have two branches at position 4 (#34).
+
+**The fix is to move the knowledge into the model** and have the dialog ask it, rather than the two
+each knowing a different part. Until that is done, a change to any of these rules has to be made in
+more than one place, and this file is the record of what they are.

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.36.0</version>
+	<version>1.37.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -336,8 +336,23 @@ public abstract class BaseDocument {
         return false;
         }
 
-        // 
-        setFilename(file.getAbsolutePath());        
+        if( merge ) {
+            // Opening a second file *into* this one leaves a document that is neither file: it is
+            // what was here plus what arrived. So it keeps its own name - taking the merged file's
+            // would make a later Save write over a file the user did not edit - and it counts as
+            // changed, because it is (#178). It used to do neither: setFilename cleared the changed
+            // flag as a side effect, so the document came out marked saved, the asterisk never
+            // appeared, Save stayed disabled, and closing threw the merge away without asking.
+            //
+            // Changed rather than initialized: fireDocumentInit clears the flag itself, which is
+            // right for a document that has just become a file's contents and wrong for one that has
+            // just stopped being them.
+            fireDocumentChanged();
+
+            return true;
+        }
+
+        setFilename(file.getAbsolutePath());
         fireDocumentInit();
         return true;
     }

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -492,7 +492,12 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 			int ret = JOptionPane.showConfirmDialog(this,"Save changes to " + doc.getName().toLowerCase() + "?", null, JOptionPane.YES_NO_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
 			if( ret == JOptionPane.CANCEL_OPTION ) return false;        
 			if( ret == JOptionPane.YES_OPTION ) {
-				if( !onSaveAs(doc) ) return false;
+				// Save, not Save As. A document that came from a file has one to go back to, and
+				// asking where to put it is asking a question that was answered when it was opened -
+				// the file's name is in the title bar at the time (#106). onSave falls back to Save As
+				// by itself where there is no file yet, or where it cannot be written to, which is
+				// the case this had been written for.
+				if( !onSave(doc) ) return false;
 				return true;
 			}
 			if( ret == JOptionPane.NO_OPTION ) return true;

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1373,7 +1373,7 @@ public class Residue {
 		// one this child can be given (#34). Checked here as well as in canAddChild because this
 		// does not consult it - the two have grown apart, and adding is the path that makes the
 		// structure
-		if( positionAlreadyTaken(child,bonds) )
+		if( positionIsNotAvailable(child,bonds) )
 			return false;
 
 		// check for available space
@@ -1431,7 +1431,7 @@ public class Residue {
 
 		// a carbon carries one glycosidic bond, so a position another child already occupies is not
 		// one this child can be given (#34)
-		if( positionAlreadyTaken(child,bonds) )
+		if( positionIsNotAvailable(child,bonds) )
 			return false;
 
 		// check for available space
@@ -1457,27 +1457,175 @@ public class Residue {
 	 * @param bonds The bonds it would be added by.
 	 * @return Returns whether one of them names a position another child already has.
 	 */
-	private boolean positionAlreadyTaken(Residue child, Collection<Bond> bonds) {
+	/**
+	 * The positions this residue can take an ordinary glycosidic bond at, as it stands.
+	 *
+	 * <p>Everything that decides this in one place, so that a structure built by any route obeys the
+	 * same rules. It had been in three: the residue type's list, which only the linkage dialog asked;
+	 * the ring and anomeric rules, which only that dialog knew; and what a sibling had taken, which
+	 * only the model knew. A structure drawn through the dialog therefore obeyed rules the model did
+	 * not enforce, and one built any other way obeyed almost none - which is how a Man came to carry
+	 * two branches at position 4 (#34).
+	 *
+	 * <p>What is taken into account, and why each is not the same as the others:
+	 *
+	 * <ul>
+	 *   <li><b>The residue type's list.</b> It already knows what the sugar is made of - GlcNAc omits
+	 *       2 for its N-acetyl, Xyl has no 6 - and whether a built-in substituent closes its position
+	 *       is a chemical judgement made per residue rather than a rule: GlcA keeps 6 open, because a
+	 *       carboxyl can be esterified. 47 of the 134 types declare no list at all, mostly reducing
+	 *       ends and substituents; no list means no constraint, not no positions.</li>
+	 *   <li><b>The ring.</b> Its oxygen occupies a position and that position takes no glycosidic
+	 *       bond: 5 for a pyranose closing from 1, 6 from 2; 4 for a furanose from 1, 5 from 2. An
+	 *       open chain closes nothing. The ring atom is not always oxygen - it can be nitrogen - but
+	 *       that is a fact about what the residue is, not about what can hang off it.</li>
+	 *   <li><b>An alditol</b> has no ring and no anomeric centre, so its 1 is an ordinary hydroxyl and
+	 *       does take a bond, which the type's list does not say because in a ring it does not.</li>
+	 *   <li><b>What a sibling holds.</b> A carbon carries one glycosidic bond, and a methyl at 4 is
+	 *       the same claim on the same atom as a branch at 4.</li>
+	 * </ul>
+	 *
+	 * <p>This describes ordinary glycosidic bonds. A <b>bridge</b> is not one and is not bound by it -
+	 * an anhydro attaches at the anomeric carbon, which no type's list offers, and 1,6-anhydro is a
+	 * real structure. See {@link #acceptsPosition}.
+	 *
+	 * @return Returns the positions, in order, without {@code '?'} - which is always acceptable and
+	 *         is not a position.
+	 */
+	public char[] availableLinkagePositions() {
+		StringBuilder available = new StringBuilder();
+
+		char[] fromType = (type==null) ? new char[0] : type.getLinkagePositions();
+		if( fromType.length==0 ) {
+			// No list is no constraint. Reducing ends and substituents mostly have none.
+			for( char position='1'; position<='9'; position++ )
+				available.append(position);
+			available.append('N');
+		}
+		else
+			available.append(fromType);
+
+		// an alditol has no ring and no anomeric centre, so position 1 is an ordinary hydroxyl
+		if( isAlditol() && available.indexOf("1")<0 )
+			available.insert(0,'1');
+
+		char closedByRing = ringPosition();
+		if( closedByRing!='\0' ) {
+			int at = available.indexOf(String.valueOf(closedByRing));
+			if( at>=0 ) available.deleteCharAt(at);
+		}
+
+		for( Linkage taken : children_linkages ) {
+			for( Bond bond : taken.getBonds() ) {
+				char[] positions = bond.getParentPositions();
+				if( positions==null || positions.length!=1 || positions[0]=='?' )
+					continue;
+
+				int at = available.indexOf(String.valueOf(positions[0]));
+				if( at>=0 ) available.deleteCharAt(at);
+			}
+		}
+
+		char[] ret = new char[available.length()];
+		available.getChars(0,available.length(),ret,0);
+		Arrays.sort(ret);
+
+		return ret;
+	}
+
+	/**
+	 * The position the ring occupies, which takes no glycosidic bond.
+	 *
+	 * <p>An alditol and an open chain have no ring, and a ring size this does not recognise is not
+	 * one it will guess at.
+	 *
+	 * @return Returns the position, or {@code '\0'} where no ring closes one.
+	 */
+	private char ringPosition() {
+		if( isAlditol() )
+			return '\0';
+
+		char anomeric = getAnomericCarbon();
+		if( ring_size=='p' ) {
+			if( anomeric=='1' ) return '5';
+			if( anomeric=='2' ) return '6';
+		}
+		if( ring_size=='f' ) {
+			if( anomeric=='1' ) return '4';
+			if( anomeric=='2' ) return '5';
+		}
+
+		return '\0';
+	}
+
+	/**
+	 * Whether a child can be given this position.
+	 *
+	 * @param position The position asked for. {@code '?'} is always acceptable: it says nothing about
+	 *        where anything is, so it can neither collide nor be out of range.
+	 * @param child The residue that would go there, since a bridge is not bound by the same rules -
+	 *        it may attach at the anomeric carbon, which no type's list offers. May be null, which is
+	 *        read as an ordinary residue.
+	 * @return Returns whether the position is available.
+	 */
+	public boolean acceptsPosition(char position, Residue child) {
+		if( position=='?' )
+			return true;
+
+		// A bridge is not an ordinary glycosidic bond: 1,6-anhydro attaches at the anomeric carbon,
+		// and the type's list describes what an ordinary bond may do. Only the sibling rule applies.
+		boolean isBridge = child!=null && child.getType()!=null && child.getType().isBridge();
+		if( isBridge )
+			return !positionHeldByAChild(position,child);
+
+		for( char available : availableLinkagePositions() )
+			if( available==position ) return true;
+
+		return false;
+	}
+
+	/**
+	 * @param position A stated position.
+	 * @param except A residue not counted against itself, or null.
+	 * @return Returns whether some other child already holds it.
+	 */
+	private boolean positionHeldByAChild(char position, Residue except) {
+		for( Linkage taken : children_linkages ) {
+			if( taken.getChildResidue()==except )
+				continue;
+
+			for( Bond bond : taken.getBonds() ) {
+				char[] positions = bond.getParentPositions();
+				if( positions!=null && positions.length==1 && positions[0]==position )
+					return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether any of these bonds names a position this residue will not give the child.
+	 *
+	 * <p>Every rule about what a position can take is in {@link #acceptsPosition}; this only walks
+	 * the bonds. A bond naming several positions at once is left alone - "one of these" is not a
+	 * claim on any one of them, and refusing it would refuse structures that say less rather than
+	 * something wrong.
+	 *
+	 * @param child The residue about to be added, which is not counted against itself.
+	 * @param bonds The bonds it would be added by.
+	 * @return Returns whether one of them asks for a position that is not available.
+	 */
+	private boolean positionIsNotAvailable(Residue child, Collection<Bond> bonds) {
 		if( bonds==null )
 			return false;
 
 		for( Bond bond : bonds ) {
 			char[] positions = bond.getParentPositions();
-			if( positions==null || positions.length!=1 || positions[0]=='?' )
+			if( positions==null || positions.length!=1 )
 				continue;
-
-			for( Linkage taken : children_linkages ) {
-				if( taken.getChildResidue()==child )
-					continue;
-
-				for( Bond takenBond : taken.getBonds() ) {
-					char[] takenPositions = takenBond.getParentPositions();
-					if( takenPositions==null || takenPositions.length!=1 )
-						continue;
-					if( takenPositions[0]==positions[0] )
-						return true;
-				}
-			}
+			if( !acceptsPosition(positions[0],child) )
+				return true;
 		}
 
 		return false;

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1369,6 +1369,13 @@ public class Residue {
 			return true;
 		}
 
+		// a carbon carries one glycosidic bond, so a position another child already occupies is not
+		// one this child can be given (#34). Checked here as well as in canAddChild because this
+		// does not consult it - the two have grown apart, and adding is the path that makes the
+		// structure
+		if( positionAlreadyTaken(child,bonds) )
+			return false;
+
 		// check for available space
 		//if( (getNoLinkages()+bonds.size())<getMaxLinkages() )
 
@@ -1422,9 +1429,58 @@ public class Residue {
 		if( isLCleavage() && cleaved_residue.getTypeName().equals(child.getTypeName()) )
 			return true;
 
+		// a carbon carries one glycosidic bond, so a position another child already occupies is not
+		// one this child can be given (#34)
+		if( positionAlreadyTaken(child,bonds) )
+			return false;
+
 		// check for available space
-		//return ( (getNoLinkages()+bonds.size())<getMaxLinkages() ); 
+		//return ( (getNoLinkages()+bonds.size())<getMaxLinkages() );
 		return true;
+	}
+
+	/**
+	 * Whether any of these bonds would put a child where another child already is.
+	 *
+	 * <p>The position list offered when a linkage is edited was built from what the residue type
+	 * allows without asking what its other children had taken, so the same position could be given
+	 * twice - a Man with two branches both at 4, which is not a molecule. It draws, and the WURCS
+	 * export then writes nothing at all, which is how it was usually noticed.
+	 *
+	 * <p>Only a position that is actually stated counts. An unknown position - {@code '?'}, which is
+	 * most of what a structure read from a database carries - says nothing about what is where, so
+	 * two of those do not conflict; deciding they did would refuse structures that are perfectly
+	 * ordinary. A bond that names several positions at once is the same case: it is a statement of
+	 * "one of these", not of any one of them.
+	 *
+	 * @param child The residue about to be added, which is not counted against itself.
+	 * @param bonds The bonds it would be added by.
+	 * @return Returns whether one of them names a position another child already has.
+	 */
+	private boolean positionAlreadyTaken(Residue child, Collection<Bond> bonds) {
+		if( bonds==null )
+			return false;
+
+		for( Bond bond : bonds ) {
+			char[] positions = bond.getParentPositions();
+			if( positions==null || positions.length!=1 || positions[0]=='?' )
+				continue;
+
+			for( Linkage taken : children_linkages ) {
+				if( taken.getChildResidue()==child )
+					continue;
+
+				for( Bond takenBond : taken.getBonds() ) {
+					char[] takenPositions = takenBond.getParentPositions();
+					if( takenPositions==null || takenPositions.length!=1 )
+						continue;
+					if( takenPositions[0]==positions[0] )
+						return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/LinkageRendererAWT.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/LinkageRendererAWT.java
@@ -129,10 +129,38 @@ public class LinkageRendererAWT extends AbstractLinkageRenderer {
 		return a_bIsShow;
 	}
     
+    /**
+     * Whether there is an anomeric configuration here to draw at all.
+     *
+     * <p>α and β describe the configuration at an anomeric centre. A residue that has none - an
+     * alditol, or an open-chain form - has nothing for them to describe, and drawing one states
+     * something untrue about the molecule. Drawing "?" instead would say it is unknown, when it is
+     * not unknown but absent; the two are different and the picture should not confuse them.
+     *
+     * <p>See {@code docs/linkage-positions-and-anomers.md}.
+     *
+     * @param link The linkage about to be labelled.
+     * @return Returns whether to label it.
+     */
     private boolean checkAnomericPosition(Linkage link) {
     	if(link.getChildResidue().getAnomericState() == 'o') return false;
     	if(link.getParentResidue().isReducingEnd() && link.getChildResidue().isStartRepetition()) return false;
-    	
+    	if(!hasAnAnomericCentre(link.getChildResidue())) return false;
+
+    	return true;
+    }
+
+    /**
+     * @param residue The residue in question.
+     * @return Returns whether it has an anomeric centre for a configuration to be at.
+     */
+    private boolean hasAnAnomericCentre(org.eurocarbdb.application.glycanbuilder.Residue residue) {
+    	if(residue == null) return false;
+    	// A reduced sugar has no anomeric carbon: the ring is open and the centre is gone.
+    	if(residue.isAlditol()) return false;
+    	// Nor has an open chain, which is what an 'o' ring size says.
+    	if(residue.getRingSize() == 'o') return false;
+
     	return true;
     }
     

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/SVGUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/SVGUtils.java
@@ -69,6 +69,17 @@ public class SVGUtils   {
     public void afterRendering();
     }
 
+    /**
+       White with no alpha - which is what "no background" is on a surface that paints one.
+
+       <p>An exported picture goes into a figure or a slide, where a white rectangle behind the
+       glycan covers whatever it is placed on (#186). On an SVG surface it was worse than one
+       rectangle: the renderers clear behind text so it stays legible over a bond line, and
+       clearRect on such a surface paints the background colour rather than removing anything, so
+       every piece of text carried its own white patch (#188).</p>
+    */
+    static private final Color TRANSPARENT = new Color(255,255,255,0);
+
     private SVGUtils() {}
 
     /**
@@ -140,8 +151,7 @@ public class SVGUtils   {
 
             // clear background
             g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-            g2d.setBackground(Color.white);
-            g2d.clearRect(0, 0, d.width, d.height);
+            g2d.setBackground(TRANSPARENT);
 
             // paint
             for (Glycan s : structures)
@@ -186,8 +196,7 @@ public class SVGUtils   {
 
             // clear background
     		g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,RenderingHints.VALUE_TEXT_ANTIALIAS_OFF);
-    		g2d.setBackground(Color.white);
-    		g2d.clearRect(0, 0, d.width, d.height);
+    		g2d.setBackground(TRANSPARENT);
 
             // paint
     		for(Glycan structure : structures )
@@ -300,7 +309,7 @@ public class SVGUtils   {
     all_dim.width = (int)(all_dim.width*sf);
     all_dim.height = (int)(all_dim.height*sf);
     */
-    g2d.setBackground(Color.white);
+    g2d.setBackground(TRANSPARENT);
     g2d.setSVGCanvasSize(all_dim);
     
     return g2d;
@@ -606,9 +615,27 @@ public class SVGUtils   {
     else if( format.equals("eps") )
         os.write(orRefuse(getEPSGraphics(gr,structures,show_masses,show_redend), format));
     else if( format.equals("bmp") || format.equals("png") || format.equals("jpg") )
-        javax.imageio.ImageIO.write(gr.getImage(structures,true,show_masses,show_redend,scale,posManager,bboxManager),format,os);
+        javax.imageio.ImageIO.write(gr.getImage(structures,opaqueFor(format),show_masses,show_redend,scale,posManager,bboxManager),format,os);
     else
         throw new Exception("Unrecognized graphic format: " + format);
+    }
+
+    /**
+       Whether an image of this format should be painted onto white rather than onto nothing.
+
+       <p>PNG carries an alpha channel and the renderer has always been able to paint without a
+       background - the export simply never asked, passing opaque for every format alike. So a glycan
+       put into a figure or a slide arrived with a white rectangle around it, over whatever it was
+       placed on (#186).</p>
+
+       <p>BMP and JPEG have no alpha to write. Painting those onto nothing gives a black background,
+       or an undefined one, which is worse than the white it replaces - so they keep it.</p>
+
+       @param format The format being written.
+       @return Returns whether to paint a background.
+    */
+    static private boolean opaqueFor(String format) {
+    return !format.equals("png");
     }
 
     /**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/ResiduePropertiesDialog.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/ResiduePropertiesDialog.java
@@ -114,66 +114,61 @@ public class ResiduePropertiesDialog extends EscapeDialog implements java.awt.ev
     	field_min.setText("100");
     }
 
+    /**
+     * The positions to offer for the linkage from {@code parent}.
+     *
+     * <p>Asks the residue rather than working it out. This used to be the only place that knew about
+     * ring forms and anomeric centres, and the model enforced none of it - so a structure drawn here
+     * obeyed rules that one built any other way did not, which is how a Man came to carry two
+     * branches at position 4 (#34). The rules are in {@code Residue.availableLinkagePositions} now
+     * and this shows what they say.
+     *
+     * @param parent The residue the linkage hangs off.
+     * @return Returns the list to show, {@code "?"} first - always offered, since it says nothing
+     *         about where anything is.
+     */
     private ListModel<String> createPositions(Residue parent) {
 		DefaultListModel<String> ret = new DefaultListModel<String>();
-
-		// collect available positions
-		char[] par_pos = null;
-		if (parent == null || parent.getType().getLinkagePositions().length == 0)
-			par_pos = new char[]{'1', '2', '3', '4', '5', '6', '7', '8', '9', 'N'};
-		else
-			par_pos = parent.getType().getLinkagePositions();
-
-		// 20211223, S.TSUCHIYA add
-		String par_pos_temp = String.valueOf(par_pos);
-
-		// select unavailable linkage position from par_pos
-		for (Linkage donorLinkage : parent.getChildrenLinkages()) {
-			if (this.current == donorLinkage.getChildResidue()) continue;
-
-			for (Bond donorBond : donorLinkage.getBonds()) {
-				if (donorBond.getParentPositions().length > 1) continue;
-				if (donorBond.getParentPositions()[0] == '?') continue;
-				char donorPos = donorBond.getParentPositions()[0];
-				par_pos_temp = par_pos_temp.replace(donorPos, ' ');
-			}
-		}
-
-		// replace ring position, 20211223, S.TSUCHIYA add
-		if (parent.getRingSize() == 'o') {
-			par_pos_temp += parent.getType().getAnomericCarbon();
-		}
-		if (parent.getRingSize() == 'p') {
-			if (parent.getAnomericCarbon() == '1') {
-				par_pos_temp = par_pos_temp.replace('5', ' ');
-			}
-			if (parent.getAnomericCarbon() == '2') {
-				par_pos_temp = par_pos_temp.replace('6', ' ');
-			}
-		}
-		if (parent.getRingSize() == 'f') {
-			if (parent.getAnomericCarbon() == '1') {
-				par_pos_temp = par_pos_temp.replace('4', ' ');
-			}
-			if (parent.getAnomericCarbon() == '2') {
-				par_pos_temp = par_pos_temp.replace('5', ' ');
-			}
-		}
-
-		// refresh par_pos, 20211223, S.TSUCHIYA add
-		if (!par_pos_temp.equals(String.valueOf(par_pos))) {
-			par_pos_temp = par_pos_temp.replaceAll(" ", "");
-			par_pos = par_pos_temp.toCharArray();
-			Arrays.sort(par_pos);
-		}
-
-		// add elements
 		ret.addElement("?");
-		for (int i = 0; i < par_pos.length; i++)
-			ret.addElement("" + par_pos[i]);
+		if (parent == null) return ret;
+
+		for (char position : parent.availableLinkagePositions()) {
+			// the position this linkage already has is still its own to keep
+			ret.addElement("" + position);
+		}
+		for (char position : positionsThisLinkageAlreadyHas(parent)) {
+			if (!ret.contains("" + position)) ret.addElement("" + position);
+		}
 
 		return ret;
-	}
+    }
+
+    /**
+     * The positions the linkage being edited already occupies.
+     *
+     * <p>They are unavailable by the residue's reckoning, because this linkage is what holds them -
+     * and leaving them out would drop the current selection from the list it is selected in.
+     *
+     * @param parent The residue the linkage hangs off.
+     * @return Returns those positions.
+     */
+    private char[] positionsThisLinkageAlreadyHas(Residue parent) {
+		StringBuilder held = new StringBuilder();
+		for (org.eurocarbdb.application.glycanbuilder.linkage.Linkage linkage : parent.getChildrenLinkages()) {
+			if (this.current != linkage.getChildResidue()) continue;
+
+			for (org.eurocarbdb.application.glycanbuilder.linkage.Bond bond : linkage.getBonds()) {
+				char[] positions = bond.getParentPositions();
+				if (positions != null && positions.length == 1 && positions[0] != '?')
+					held.append(positions[0]);
+			}
+		}
+
+		char[] ret = new char[held.length()];
+		held.getChars(0, held.length(), ret, 0);
+
+		return ret;
+    }
 
     private void setSelections() {
     	if( parent_link!=null )        

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
@@ -64,6 +64,15 @@ public class WURCS2Parser implements GlycanParser{
 		if(str.equals("") || !str.contains("WURCS")) throw new Exception(str + " is wrong format");
 		mass_opt.setDerivatization("Und");
 		mass_opt.ION_CLOUD.set("Na", 0);
+
+		// The sequence says what its reducing end is, and where it says nothing it is a free end.
+		// The mass options handed in carry whatever was last chosen in the dialog, and with
+		// "Remember files after restarting" on that outlives the session - so a structure imported
+		// after a restart arrived carrying somebody's -Asn from a previous sitting, on a sequence
+		// that never mentioned one (#179). Cleared here for the same reason the derivatization and
+		// the ion cloud above are: what the sequence states is the answer, and what it does not
+		// state is a default rather than a leftover.
+		mass_opt.setReducingEndType(org.eurocarbdb.application.glycanbuilder.ResidueType.createFreeReducingEnd());
 		
 		str = str.trim();		
 		if(str.contains("\t")) str = str.substring(str.indexOf("\t") + 1);

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ExportsCarryNoBackgroundTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ExportsCarryNoBackgroundTest.java
@@ -1,0 +1,125 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.imageio.ImageIO;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.SVGUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an exported picture brings no background with it (#186, #188).
+ *
+ * <p>An exported glycan goes into a figure or a slide, where a white rectangle behind it covers
+ * whatever it was placed on. PNG carries an alpha channel and the renderer could always paint
+ * without a background; the export simply never asked, passing opaque for every format alike.
+ *
+ * <p>SVG was worse than one rectangle. The renderers clear behind text so it stays legible over a
+ * bond line, and {@code clearRect} on an SVG surface paints the background colour rather than
+ * removing anything — so every piece of text carried its own white patch, and removing them by hand
+ * in Illustrator was what the report described doing.
+ */
+public class ExportsCarryNoBackgroundTest {
+
+	private static BuilderWorkspace workspace;
+
+	@BeforeClass
+	public static void newWorkspace() {
+		workspace = new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A PNG is transparent where nothing was drawn. */
+	@Test
+	public void aPngHasNoBackground() throws Exception {
+		ByteArrayOutputStream written = new ByteArrayOutputStream();
+		SVGUtils.export(written, (GlycanRendererAWT) workspace.getGlycanRenderer(), structures(),
+				false, true, 1.0, "png", new PositionManager(), new BBoxManager());
+
+		BufferedImage image = ImageIO.read(new ByteArrayInputStream(written.toByteArray()));
+		int topLeft = image.getRGB(0, 0);
+
+		assertEquals("the corner of the image is painted, so the background is still there",
+				0, topLeft >>> 24);
+	}
+
+	/**
+	 * Formats with no alpha keep theirs.
+	 *
+	 * <p>BMP and JPEG have nowhere to write transparency. Painting them onto nothing gives a black
+	 * background or an undefined one, which is worse than the white it would replace.
+	 */
+	@Test
+	public void formatsWithoutAlphaKeepTheirBackground() throws Exception {
+		for (String format : new String[] { "bmp", "jpg" }) {
+			ByteArrayOutputStream written = new ByteArrayOutputStream();
+			SVGUtils.export(written, (GlycanRendererAWT) workspace.getGlycanRenderer(), structures(),
+					false, true, 1.0, format, new PositionManager(), new BBoxManager());
+
+			BufferedImage image = ImageIO.read(new ByteArrayInputStream(written.toByteArray()));
+			int topLeft = image.getRGB(0, 0);
+
+			assertEquals(format + " should still be painted onto white", 255, topLeft >>> 24);
+		}
+	}
+
+	/** No white rectangle anywhere in the SVG — neither the page's nor one behind each character. */
+	@Test
+	public void anSvgHasNoWhiteRectangles() {
+		String svg = SVGUtils.getVectorGraphics((GlycanRendererAWT) workspace.getGlycanRenderer(),
+				structures(), false, true);
+
+		int white = 0;
+		Matcher rectangles = Pattern.compile("<rect\\b[^>]*/?>").matcher(svg);
+		while (rectangles.find()) {
+			String rectangle = rectangles.group();
+			if (rectangle.contains("fill:white") || rectangle.contains("fill:#ffffff")
+					|| rectangle.contains("fill:rgb(255,255,255)")) {
+				white++;
+			}
+		}
+
+		assertEquals("the SVG still paints white: " + white + " rectangles", 0, white);
+	}
+
+	/**
+	 * And the glycan is still drawn.
+	 *
+	 * <p>The way to pass the assertion above is to stop painting altogether, so this holds the other
+	 * side: the residues keep their colours.
+	 */
+	@Test
+	public void theGlycanItselfIsStillPainted() {
+		String svg = SVGUtils.getVectorGraphics((GlycanRendererAWT) workspace.getGlycanRenderer(),
+				structures(), false, true);
+
+		assertTrue("GlcNAc's blue is gone", svg.contains("rgb(0,114,188)"));
+		assertTrue("Man's green is gone", svg.contains("rgb(0,166,81)"));
+	}
+
+	private static Collection<Glycan> structures() {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		try {
+			document.importFromString(
+					"freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p--4b1D-Man,p--3a1D-Man,p", "gws");
+		} catch (Exception cannotRead) {
+			throw new IllegalStateException(cannotRead);
+		}
+
+		return document.getStructures();
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
@@ -96,4 +96,55 @@ public class OnePositionOneBondTest {
 
 		return man;
 	}
+
+	/**
+	 * A substituent occupies a position exactly as a monosaccharide does.
+	 *
+	 * <p>The rule is about the carbon, not about what kind of thing is hanging off it: a methyl at 4
+	 * and a branch at 4 are the same claim on the same atom. Substituents are attached as child
+	 * residues here, so they were already covered - this holds that they stay covered, in both
+	 * orders and between two substituents, since none of that is obvious from the code that does it.
+	 */
+	@Test
+	public void aSubstituentTakesAPositionTooAndInEitherOrder() throws Exception {
+		Residue afterSugar = manOnAFreeEnd();
+		afterSugar.addChild(ResidueDictionary.newResidue("Gal"), '4');
+		assertFalse("a methyl was added onto a position a branch already holds",
+				afterSugar.addChild(ResidueDictionary.newResidue("Me"), '4'));
+
+		Residue afterSubstituent = manOnAFreeEnd();
+		afterSubstituent.addChild(ResidueDictionary.newResidue("Me"), '4');
+		assertFalse("a branch was added onto a position a methyl already holds",
+				afterSubstituent.addChild(ResidueDictionary.newResidue("Gal"), '4'));
+
+		Residue betweenSubstituents = manOnAFreeEnd();
+		betweenSubstituents.addChild(ResidueDictionary.newResidue("Me"), '4');
+		assertFalse("two substituents were put on the same position",
+				betweenSubstituents.addChild(ResidueDictionary.newResidue("S"), '4'));
+	}
+
+	/**
+	 * And several substituents on their own positions are untouched, which is the case from #66 -
+	 * the heavily modified fucose that started this line of work.
+	 */
+	@Test
+	public void substituentsOnDifferentPositionsAreFine() throws Exception {
+		Residue fucose = manOnAFreeEnd();
+
+		assertTrue(fucose.addChild(ResidueDictionary.newResidue("Me"), '2'));
+		assertTrue(fucose.addChild(ResidueDictionary.newResidue("N"), '3'));
+		assertTrue(fucose.addChild(ResidueDictionary.newResidue("Me"), '4'));
+
+		assertEquals(3, fucose.getNoChildren());
+	}
+
+	/** An unknown position does not block a stated one, whichever arrived first. */
+	@Test
+	public void anUnknownPositionBlocksNothing() throws Exception {
+		Residue parent = manOnAFreeEnd();
+		parent.addChild(ResidueDictionary.newResidue("S"), '?');
+
+		assertTrue("a sulfate of unknown position should not close position 4",
+				parent.addChild(ResidueDictionary.newResidue("Gal"), '4'));
+	}
 }

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OnePositionOneBondTest.java
@@ -1,0 +1,99 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That the same linkage position cannot be given to two children (#34).
+ *
+ * <p>A carbon carries one glycosidic bond. The position list offered when a linkage is edited was
+ * built from what the residue type allows without asking what the residue's other children had
+ * already taken, so the same position could be handed out twice - a Man with two branches both at 4,
+ * which is not a molecule. It draws, and the WURCS export then writes nothing, which is how it was
+ * usually found out.
+ */
+public class OnePositionOneBondTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A position another child holds is refused. */
+	@Test
+	public void aPositionIsNotGivenTwice() throws Exception {
+		Residue parent = manOnAFreeEnd();
+
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Gal"), '4'));
+		assertFalse("a second child was added at position 4",
+				parent.addChild(ResidueDictionary.newResidue("Glc"), '4'));
+		assertFalse("canAddChild should say so too",
+				parent.canAddChild(ResidueDictionary.newResidue("Glc"), '4'));
+
+		assertEquals(1, parent.getNoChildren());
+	}
+
+	/** Other positions are unaffected, which is most of what anyone does. */
+	@Test
+	public void everyOtherPositionStillTakesABranch() throws Exception {
+		Residue parent = manOnAFreeEnd();
+
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Gal"), '2'));
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Glc"), '3'));
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Man"), '6'));
+
+		assertEquals(3, parent.getNoChildren());
+	}
+
+	/**
+	 * Two children at an unknown position are not a conflict.
+	 *
+	 * <p>Most of what comes out of a database says only that a residue is attached somewhere. If
+	 * two of those were treated as the same position, ordinary structures would stop being
+	 * drawable - and nothing would have been said about where either one is.
+	 */
+	@Test
+	public void twoUnknownPositionsAreNotTheSamePosition() throws Exception {
+		Residue parent = manOnAFreeEnd();
+
+		assertTrue(parent.addChild(ResidueDictionary.newResidue("Fuc"), '?'));
+		assertTrue("an unknown position is not a claim on any position",
+				parent.addChild(ResidueDictionary.newResidue("Xyl"), '?'));
+
+		assertEquals(2, parent.getNoChildren());
+	}
+
+	/**
+	 * A file already containing the impossible structure still opens.
+	 *
+	 * <p>The point is to stop one being made, not to make saved work unreadable - a structure drawn
+	 * before this and saved is still somebody's, and refusing to open it would be a worse fault than
+	 * the one being fixed.
+	 */
+	@Test
+	public void aFileThatAlreadyHasOneStillOpens() throws Exception {
+		GlycanDocument document =
+				new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		assertTrue(document.importFromString(
+				"freeEnd--??1D-Man,p(--4?1D-Gal,p)--4?1D-Glc,p$MONO,perMe,Na,0,freeEnd", "gws"));
+		assertEquals(1, document.getStructures().size());
+	}
+
+	private static Residue manOnAFreeEnd() throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		Residue man = ResidueDictionary.newResidue("Man");
+		root.addChild(man);
+
+		return man;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/PositionRulesLiveInTheModelTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/PositionRulesLiveInTheModelTest.java
@@ -1,0 +1,125 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That the rules about which positions take a linkage are in the model, and are all of them.
+ *
+ * <p>They had been in three places: the residue type's list, which only the linkage dialog asked;
+ * the ring and anomeric rules, which only that dialog knew; and what a sibling had taken, which only
+ * the model knew. A structure drawn through the dialog therefore obeyed rules a structure built any
+ * other way did not.
+ *
+ * <p>See {@code docs/linkage-positions-and-anomers.md}, which is where the chemistry these assert
+ * is written down and attributed.
+ */
+public class PositionRulesLiveInTheModelTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** What the residue type already knows: a built-in substituent, and a sugar's size. */
+	@Test
+	public void theTypesOwnListIsObeyed() throws Exception {
+		assertFalse("GlcNAc's 2 carries the N-acetyl",
+				sugar("GlcNAc").addChild(ResidueDictionary.newResidue("Me"), '2'));
+		assertFalse("a pentose has no 6",
+				sugar("Xyl").addChild(ResidueDictionary.newResidue("Me"), '6'));
+		assertFalse("Neu5Ac's 5 carries the N-acetyl",
+				sugar("Neu5Ac").addChild(ResidueDictionary.newResidue("Me"), '5'));
+	}
+
+	/**
+	 * But a built-in substituent does not always close its position.
+	 *
+	 * <p>GlcA's carboxyl at 6 leaves it open, because a carboxyl can be esterified. That is a
+	 * chemical judgement made per residue rather than a rule to be derived, which is why the type's
+	 * list is consulted rather than reasoned about - and this is the case that would be got wrong by
+	 * reasoning.
+	 */
+	@Test
+	public void aCarboxylDoesNotCloseItsPosition() throws Exception {
+		assertTrue("GlcA's 6 should stay open for an ester",
+				sugar("GlcA").addChild(ResidueDictionary.newResidue("Me"), '6'));
+	}
+
+	/** The ring oxygen occupies a position, and it takes no glycosidic bond. */
+	@Test
+	public void theRingClosesItsOwnPosition() throws Exception {
+		Residue pyranose = sugar("Glc");
+		pyranose.setRingSize('p');
+		assertFalse("a pyranose closing from 1 has its 5 in the ring",
+				pyranose.acceptsPosition('5', null));
+		assertTrue(pyranose.acceptsPosition('4', null));
+
+		Residue furanose = sugar("Glc");
+		furanose.setRingSize('f');
+		assertFalse("a furanose closing from 1 has its 4 in the ring",
+				furanose.acceptsPosition('4', null));
+		assertTrue(furanose.acceptsPosition('5', null));
+	}
+
+	/**
+	 * An alditol has no ring and no anomeric centre, so its 1 is an ordinary hydroxyl.
+	 *
+	 * <p>The type's list does not offer 1, because in a ring the anomeric carbon is where the residue
+	 * attaches to its parent. Reduced, there is no anomeric carbon and nothing is attached there.
+	 */
+	@Test
+	public void anAlditolOpensPositionOne() throws Exception {
+		Residue reduced = sugar("Glc");
+		reduced.setAlditol(true);
+
+		assertTrue("an alditol's 1 is an ordinary hydroxyl", reduced.acceptsPosition('1', null));
+		assertTrue("and it has no ring to close a position", reduced.acceptsPosition('5', null));
+	}
+
+	/**
+	 * A bridge is not an ordinary glycosidic bond and is not bound by the type's list.
+	 *
+	 * <p>1,6-anhydro attaches at the anomeric carbon, which no type's list offers. Enforcing the list
+	 * against it stops the structure round-tripping - measured, before this was separated out.
+	 */
+	@Test
+	public void aBridgeMayAttachWhereAnOrdinaryBondMayNot() throws Exception {
+		GlycanDocument document =
+				new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+
+		assertTrue(document.importFromString("WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/", "wurcs2"));
+
+		document.clearString();
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+		assertEquals("1,6-anhydro should survive the round trip",
+				"WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/",
+				String.join("", document.getString()).trim());
+	}
+
+	/** A residue type with no list of its own constrains nothing, which 47 of the 134 do not have. */
+	@Test
+	public void noListMeansNoConstraintRatherThanNoPositions() throws Exception {
+		Residue substituent = ResidueDictionary.newResidue("Me");
+
+		assertTrue("a type with no position list should not refuse everything",
+				substituent.availableLinkagePositions().length > 0);
+	}
+
+	private static Residue sugar(String name) throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		Residue residue = ResidueDictionary.newResidue(name);
+		root.addChild(residue);
+
+		return residue;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/SavedWorkIsNotLostTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/SavedWorkIsNotLostTest.java
@@ -1,0 +1,104 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * The two ways a document could quietly lose what was in it, and the setting that outlived its
+ * session.
+ *
+ * <p>#178: opening a second file <em>into</em> the current one left the document counted as
+ * unchanged, so no asterisk appeared, Save stayed disabled, and closing threw the merge away without
+ * asking. #179: with "Remember files after restarting" on, the reducing end last chosen in the
+ * dialog was applied to structures imported afterwards, on sequences that never mentioned one.
+ */
+public class SavedWorkIsNotLostTest {
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * Merging a file in leaves the document changed, and still called what it was.
+	 *
+	 * <p>Both halves matter. Unchanged meant it closed without asking; taking the merged file's name
+	 * would have meant a later Save writing over a file the user never edited.
+	 */
+	@Test
+	public void mergingAFileInLeavesTheDocumentChanged() throws Exception {
+		File first = gwsFile("freeEnd--?b1D-GlcNAc,p$MONO,perMe,Na,0,freeEnd");
+		File second = gwsFile("freeEnd--?b1D-Man,p$MONO,perMe,Na,0,freeEnd");
+
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.open(first, false, true));
+		assertFalse("a document just opened is not changed", document.hasChanged());
+
+		assertTrue(document.open(second, true, true));
+
+		assertTrue("a document with a file merged into it has changed", document.hasChanged());
+		assertEquals("it should keep its own file, not take the merged one's",
+				first.getAbsolutePath(), document.getFileName());
+		assertEquals("both structures should be there", 2, document.getStructures().size());
+	}
+
+	/** Opening a file normally still counts as unchanged, and takes that file's name. */
+	@Test
+	public void openingAFileNormallyIsNotAChange() throws Exception {
+		File file = gwsFile("freeEnd--?b1D-GlcNAc,p$MONO,perMe,Na,0,freeEnd");
+
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.open(file, false, true));
+
+		assertFalse(document.hasChanged());
+		assertEquals(file.getAbsolutePath(), document.getFileName());
+	}
+
+	/**
+	 * A sequence that names no reducing end gets a free end, whatever was chosen last.
+	 *
+	 * <p>The mass options handed to the parser carry the dialog's last state, and with the history
+	 * setting on that survives a restart - so an import arrived carrying an aglycone from a previous
+	 * sitting.
+	 */
+	@Test
+	public void animportedSequenceDoesNotInheritTheLastReducingEnd() throws Exception {
+		BuilderWorkspace workspace = new BuilderWorkspace(new GlycanRendererAWT());
+
+		MassOptions remembered = workspace.getDefaultMassOptions();
+		remembered.setReducingEndTypeString("Asn");
+		workspace.setDefaultMassOptions(remembered);
+
+		GlycanDocument document = workspace.getStructures();
+		assertTrue(document.importFromString(
+				"WURCS=2.0/1,1,0/[a2122h-1b_1-5_2*NCC/3=O]/1/", "wurcs2"));
+
+		Glycan imported = document.getStructures().get(0);
+		String reducingEnd = imported.getMassOptions().getReducingEndTypeString();
+
+		assertEquals("the sequence named no aglycone, so it should have a free end",
+				"freeEnd", reducingEnd);
+	}
+
+	private static File gwsFile(String contents) throws Exception {
+		File file = File.createTempFile("gb2-", ".gws");
+		file.deleteOnExit();
+		try (FileWriter out = new FileWriter(file)) {
+			out.write(contents);
+		}
+
+		return file;
+	}
+}


### PR DESCRIPTION
Release 1.37.0. Everything at the top of the triage list, in both bands.

**Minor rather than patch**: `Residue` gains public methods (`availableLinkagePositions`,
`acceptsPosition`), and both `addChild` and the PNG/SVG exports now refuse or produce things they
did not before. A consumer relying on either would see the change.

| # | What | Verified by |
|---|---|---|
| #34 | The same position could be given to two children | measured before: `addChild(child,'4')` succeeded twice and the WURCS came out empty |
| — | All position rules moved into the model, dialog now asks | six tests, including the GlcA case that reasoning gets wrong |
| — | No anomer drawn where there is no anomeric centre | — |
| #186 | PNG had a white background | corner pixel alpha 255 → 0 |
| #188 | Every character in an SVG carried a white patch | white rectangles 9 → 0, colours held separately |
| #106 | Closing a saved file asked where to put it | — |
| #178 | A merge left the document counted as unchanged | test watched failing |
| #179 | An import inherited the last reducing end chosen | `expected:<[freeEnd]> but was:<[Asn]>` |
| #185 | A failed vector export wrote 0 bytes silently | silence fixed; cause does not reproduce here |

### Two things worth reading twice

**A built-in substituent does not always close its position.** I proposed correcting the data so
GlcA's carboxyl closed position 6, the way GlcNAc's N-acetyl closes 2. It should not — a carboxyl can
be esterified. The distinction is chemical rather than structural, which is why the list is
maintained per residue and consulted rather than reasoned about. There is a test for exactly the case
reasoning gets wrong.

**The type's list is not a general test of whether a bond may attach.** Enforcing it in `addChild`
looks like the obvious fix and stops `WURCS=2.0/1,1,0/[a2122h-1x_1-5_1-6]/1/` — 1,6-anhydro — from
round-tripping, because the list omits the anomeric carbon and a bridge attaches there. Measured,
reverted, and separated out properly.

`docs/linkage-positions-and-anomers.md` records all of it, with the chemistry attributed.

### Left open deliberately

The ion adducts are still monoisotopic (#127's remainder), #185's cause and #66 await retests, and
#187 may have been answered by #188 without anyone touching it. All in `TRIAGE.md`.

166 tests pass.
