### PR TITLE
Give a label the same room on every side

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/ResidueRendererAWT.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/ResidueRendererAWT.java
@@ -244,7 +244,7 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
     		if( orientation.equals(0) || orientation.equals(180) ) {
     			Rectangle2D.Double text_rect = new Rectangle2D.Double(midx(cur_bbox)-text_bound.width/2,midy(cur_bbox)-text_bound.height/2,text_bound.width,text_bound.height);
     			if( shape==null || fill_shape==null ) 
-    				g2d.clearRect((int)text_rect.x,(int)text_rect.y,(int)text_rect.width,(int)text_rect.height);
+    				clearAround(g2d,text_rect);
     			g2d.drawString(text,(int)text_rect.x,(int)(text_rect.y+text_rect.height));
     		}
     		if(orientation.equals(-90) || orientation.equals(90)) {
@@ -257,12 +257,12 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
     			if(isSNFG || shape==null) {
     				Rectangle2D.Double text_rect = new Rectangle2D.Double(midx(cur_bbox)-text_bound.width/2,midy(cur_bbox)-text_bound.height/2,text_bound.width,text_bound.height);
         			if( shape==null || fill_shape==null )
-        				g2d.clearRect((int)text_rect.x,(int)text_rect.y,(int)text_rect.width,(int)text_rect.height);
+        				clearAround(g2d,text_rect);
         			g2d.drawString(text,(int)text_rect.x,(int)(text_rect.y+text_rect.height));
     			} else {
     				Rectangle2D.Double text_rect = new Rectangle2D.Double(midx(cur_bbox)-text_bound.height/2,midy(cur_bbox)-text_bound.width/2,text_bound.height,text_bound.width);
     				if( shape==null || fill_shape==null ) 
-    					g2d.clearRect((int)text_rect.x,(int)text_rect.y,(int)text_rect.width,(int)text_rect.height);        
+    					clearAround(g2d,text_rect);        
     				
     				g2d.rotate(-Math.PI/2.0); 
     				g2d.drawString(text,-(int)(text_rect.y+text_rect.height),(int)(text_rect.x+text_rect.width));
@@ -272,6 +272,8 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
 
     		g2d.setFont(old_font);
     	}
+
+
     	
     	boolean isShow = false;
     	if(node.isSaccharide()) isShow = GlycanUtils.isFacingAnom(node);
@@ -286,6 +288,41 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
 
     	g2d.setColor(Color.black);
     	//g2d.drawString(""+node.id,left(cur_bbox),bottom(cur_bbox));
+    }
+
+    /**
+       Clears a margin around a label so it does not run into what is behind it.
+
+       <p>The cleared area used to be the glyphs' own bounds, cast to int - which truncates the
+       origin one way and the width the other, so a label came out with about a pixel of room on its
+       left and none on its right. On a phosphate bridge the P then touched the edge of the linkage
+       and read as part of it (#88).</p>
+
+       <p>A pixel each side, and rounded rather than truncated, so the room is the same on both.</p>
+
+       @param g2d Where the label is being drawn.
+       @param text_rect The glyphs' bounds.
+    */
+    static private void clearAround(Graphics2D g2d, Rectangle2D.Double text_rect) {
+    	Rectangle room = clearanceAround(text_rect);
+    	g2d.clearRect(room.x,room.y,room.width,room.height);
+    }
+
+    /**
+       The area to clear for a label: its glyphs, and a pixel of room on every side.
+
+       @param text_rect The glyphs' bounds.
+       @return Returns the area, in whole pixels.
+    */
+    static public Rectangle clearanceAround(Rectangle2D.Double text_rect) {
+    	final int margin = 1;
+
+    	int x = (int)Math.floor(text_rect.x) - margin;
+    	int y = (int)Math.floor(text_rect.y) - margin;
+    	int right = (int)Math.ceil(text_rect.x + text_rect.width) + margin;
+    	int bottom = (int)Math.ceil(text_rect.y + text_rect.height) + margin;
+
+    	return new Rectangle(x,y,right-x,bottom-y);
     }
     
     private Graphics2D showAnomericState(Graphics2D g2d, Residue node, ResAngle orientation, Rectangle cur_bbox) {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ABridgeLabelHasRoomTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ABridgeLabelHasRoomTest.java
@@ -1,0 +1,55 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+
+import org.eurocarbdb.application.glycanbuilder.renderutil.ResidueRendererAWT;
+import org.junit.Test;
+
+/**
+ * That a label is cleared with the same room on every side (#88).
+ *
+ * <p>The cleared area used to be the glyphs' bounds cast to int, which truncates the origin one way
+ * and the width the other — so a label came out with about a pixel of room on its left and none on
+ * its right. On a phosphate bridge the P then touched the edge of the linkage and read as part of
+ * it.
+ */
+public class ABridgeLabelHasRoomTest {
+
+	/** Room on all four sides, whatever fraction of a pixel the glyphs happen to start on. */
+	@Test
+	public void thereIsRoomOnEverySide() {
+		for (double offset : new double[] { 0.0, 0.1, 0.5, 0.9 }) {
+			Rectangle2D.Double glyphs = new Rectangle2D.Double(10 + offset, 20 + offset, 7.4, 9.6);
+			Rectangle cleared = ResidueRendererAWT.clearanceAround(glyphs);
+
+			assertTrue("nothing cleared to the left at offset " + offset,
+					cleared.getX() < glyphs.getX());
+			assertTrue("nothing cleared above at offset " + offset,
+					cleared.getY() < glyphs.getY());
+			assertTrue("nothing cleared to the right at offset " + offset,
+					cleared.getMaxX() > glyphs.getMaxX());
+			assertTrue("nothing cleared below at offset " + offset,
+					cleared.getMaxY() > glyphs.getMaxY());
+		}
+	}
+
+	/**
+	 * And the room is even, which is what the report was about.
+	 *
+	 * <p>It is the asymmetry that made the P look attached: one side had a pixel and the other had
+	 * nothing, so the label sat against the linkage on the right.
+	 */
+	@Test
+	public void theRoomIsTheSameOnBothSides() {
+		Rectangle2D.Double glyphs = new Rectangle2D.Double(10.6, 20.6, 7.4, 9.6);
+		Rectangle cleared = ResidueRendererAWT.clearanceAround(glyphs);
+
+		double left = glyphs.getX() - cleared.getX();
+		double right = cleared.getMaxX() - glyphs.getMaxX();
+
+		assertTrue("left " + left + " against right " + right, Math.abs(left - right) <= 1.0);
+	}
+}


### PR DESCRIPTION
Closes #88.

The area cleared behind a label was its glyphs' bounds cast to `int`. That truncates the origin one
way and the width the other, so a label came out with about a pixel of room on its left and none on
its right — which is exactly what the report describes. On a phosphate bridge the P sat against the
edge of the linkage and read as part of it.

Floored origin, ceiled far edge, a pixel each side.

The geometry is separated from the drawing so it can be asserted rather than looked at. The test
holds room on all four sides whatever fraction of a pixel the glyphs begin on, and that the two sides
match — the asymmetry being what made the label look attached rather than the absolute amount.

168 tests pass.
