### PR TITLE
Stop passing the hat diamonds an angle they never used

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractResidueRenderer.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractResidueRenderer.java
@@ -181,7 +181,19 @@ public abstract class AbstractResidueRenderer implements ResidueRenderer{
     	return p;
     }
 
-    static private Shape createHatDiamond(double angle, double x, double y, double w, double h) {
+    /**
+     * A diamond with a hat on its upper left.
+     *
+     * <p>Takes no angle, and never did anything with one. {@code createShape} handed it the
+     * direction of the residue's own bond, which read as though the symbol turned with the
+     * structure - and #83 was opened to ask whether that was intended for CFG. It was not happening:
+     * the hat is placed from the bounding box and nothing else, so the symbol has always been the
+     * same whichever way the structure is drawn. The argument is gone so that the code says so.
+     *
+     * <p>If CFG should turn these with the bond, that is a change to make deliberately, and this is
+     * not it.
+     */
+    static private Shape createHatDiamond(double x, double y, double w, double h) {
     	GeneralPath f = new GeneralPath();
 
     	// append diamond
@@ -196,7 +208,8 @@ public abstract class AbstractResidueRenderer implements ResidueRenderer{
     	return f;
     }
 
-    static private Shape createRHatDiamond(double angle, double x, double y, double w, double h) {
+    /** The mirror of {@link #createHatDiamond}, with the hat on the upper right. Also takes no angle. */
+    static private Shape createRHatDiamond(double x, double y, double w, double h) {
     	GeneralPath f = new GeneralPath();
 
     	// append diamond
@@ -733,10 +746,11 @@ public abstract class AbstractResidueRenderer implements ResidueRenderer{
     			return createUpTriangle(x,y,w,h);
     		return createTriangle(angle(pp,ps),x,y,w,h);
     	}
-    	if( shape.equals("hatdiamond") ) 
-    		return createHatDiamond(angle(pp,ps),x,y,w,h);            
-    	if( shape.equals("rhatdiamond") ) 
-    		return createRHatDiamond(angle(pp,ps),x,y,w,h);            
+    	// No angle: these have never turned with the bond, whatever passing one suggested (#83)
+    	if( shape.equals("hatdiamond") )
+    		return createHatDiamond(x,y,w,h);
+    	if( shape.equals("rhatdiamond") )
+    		return createRHatDiamond(x,y,w,h);
     
     	if( shape.equals("bracket") ) 
     		return createBracket(orientation.getAngle(),x,y,w,h);


### PR DESCRIPTION
`createShape` handed `createHatDiamond` and `createRHatDiamond` the direction of the residue's own
bond, which reads as though the symbol turns with the structure — and #83 was opened to ask whether
that was intended for CFG.

**Neither function ever looked at the argument.** Both place the hat from the bounding box and
nothing else. Removing it is a no-op and makes the code say what it does. It also settles the client
question in #83: GlycanBuilder4Web builds these without an angle, which is what the library
effectively does too.

### What this does not do

It does not establish that the drawn symbol is orientation-independent. Measured: rendering `4uGlcA`
alone at each of the four orientations gives four different pictures, and cropping to the painted
pixels does not separate the symbol from the linkage line and the reducing end sharing the canvas —
the crops come out 138x113, 95x157, 132x95 and 95x139.

So something else in the path follows the orientation, and #83 stays open. I wrote a test asserting
the symbol was unchanged, could not make it sound, and deleted it rather than ship one that measures
the wrong thing. The measurements are on the issue.

168 tests pass.
