### PR TITLE
Record the branch-ordering convention, and what it would take

### DIFF
--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -82,10 +82,27 @@ remains, and the issue should say so rather than being closed.
 
 ## P3 — visibly wrong
 
-#29 (bisecting GlcNAc position) · #57 (repeat-unit linkage position) · #58 (G07957FT layout) ·
-#20 (bracket not symmetric about the reducing end) · #88 (no right margin on a bridge) ·
-#83 (CFG hat diamonds take orientation from the bond) · #91 (Add-structure menu misaligned) ·
-#6 (fragments carrying a bridge)
+~~#88 (no right margin on a bridge)~~ — **done**: the cleared area was the glyphs' bounds cast to
+int, which truncates the origin one way and the width the other.
+
+**#29** (bisecting GlcNAc position) — measured: the placement dictionary sends both position 4 and
+position 6 to the same side (`lp=[4-9]` → 90), so a bisecting GlcNAc and the 6-antenna compete and one
+gives way. Adding it after drawing is not the cause. Not changed: the rule that would fix it is a
+drawing convention, and picking it decides every picture the application draws — asked the reporter
+which rule they want.
+
+#58 (G07957FT layout) · #20 (bracket not symmetric about the
+reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is
+orientation-independent, and the measurements are on the issue.
+
+#91 (Add-structure menu
+misaligned) · #6 (fragments carrying a bridge)
+
+**#57** (repeat-unit linkage position) — measured: the model holds position 2 as the sequence says,
+so the 3 appears between the model and the picture, and the likely candidate is the position
+belonging to the *other* end of the repeat. Asked the reporter to confirm which label. Found
+separately while measuring: the round trip drops the repeat's own linkage position, `l1` → `l?`,
+which is a different fault in the same corner and wants its own issue.
 
 ## P4 — not there yet
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -169,9 +169,15 @@ never used, and is gone as of #201, on `develop`. That does not establish the sy
 orientation-independent; the measurements are on the issue, and the reporter was asked whether it
 looks *rotated* or merely *placed differently*.
 
-**#183** (a failed WURCS export shows every error twice) — two dialogs per failed structure, so four
-for two bad structures. #108 (a message for a partially failed export) was closed in 1.35.x and this
-is the same code path, so start by reading what that change left behind.
+~~**#183** (a failed WURCS export shows every error twice)~~ — **fixed, in PR #208, waiting to merge.**
+The export wrote every structure for the file and then wrote them all again to find which had come out
+empty, and one failure is already two windows — `LogUtils.report` shows the message and then a
+`ReportDialog` — so the second pass produced a second pair. One pass now.
+
+**The reported sequence no longer fails.** `WURCS=2.0/1,1,0/[A111h]/1/` writes back unchanged as of
+1.37.0, so those steps produce no dialogs at all and the fix changes nothing a user would see with it.
+Fixed on the mechanism rather than on anything watchable, and the reporter has been asked for a structure
+that still refuses to export.
 
 #58 (G07957FT layout) · #20 (bracket not symmetric about the reducing end) ·
 #91 (Add-structure menu misaligned) · #6 (fragments carrying a bridge)
@@ -264,11 +270,13 @@ so it was checked in all four orientations and the plain core comes out unchange
 turned up a mistake in `docs/linkage-positions-and-anomers.md`, corrected on this branch: the
 position-to-side rules in the placement dictionaries apply to substituents only, not to saccharides.
 
-**5. #183, the doubled export error — the next piece of work.** Cheap P3, and the same code path as
-#108, which is closed.
+**5. ~~#183, the doubled export error~~ — fixed, PR #208.** The mechanism was real; the reported
+sequence turned out to write back unchanged, so there was nothing to watch fail. Recorded as such rather
+than claimed as verified.
 
-**6. The waiting list, before starting anything new.** #17, #57, #58, #66, #83, #185, #16 are all
-waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
+**6. The waiting list — the next piece of work.** #17, #57, #58, #66, #83, #185, #16 are all waiting on
+somebody else and several are closable on a reply. A nudge costs a paragraph, and #183 has just joined
+them.
 
 Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
 changes and neither is small.
@@ -300,8 +308,8 @@ installers as every release before them. What is missing on all of them is the W
 is uploaded by hand and is what #180 is about.
 
 **Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope),
-#206 (#204, the repeat's position) and #207 (#29, branch order). All four are for `develop` and carry no
-version bump.
+#206 (#204, the repeat's position), #207 (#29, branch order) and #208 (#183, one message per failed
+export). All five are for `develop` and carry no version bump.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:
@@ -314,6 +322,7 @@ closable:
 | #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
 | #83 | whether the symbol looks *rotated* or merely *placed differently* |
 | #185 | a retest on Windows; all five formats write here |
+| #183 | a structure that still refuses to export — the one in the report writes fine now |
 | #16 | whether to split it per modification |
 | #189 | whether they mean GlcNS or a sulfate on an already-acetylated nitrogen — a chemistry question, and the only thing left on it |
 | #190 | the WURCS or GlycoCT for G13093, for whoever takes #181 |

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -103,7 +103,7 @@ Both were found while measuring something else and existed nowhere but this file
 | ~~#132~~ | ~~`v_stripes`/`h_stripes` never painted~~ | **Done.** Three bars, clipped to the outline. The test asserts the drawn image and, separately, that the stripes exist — Tal is green and All is blue, so comparing the pair passes on colour alone |
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
 | ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass**, 1.36.0, and closed. Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82) |
-| **#203** | An m/z pairs an average neutral mass with a monoisotopic adduct | **The top of this list.** `IonCloud` captures an adduct's mass when the ion is set rather than when the mass is computed, so the isotope choice never reaches it. `Molecule` already carries both masses — what is missing is resolving the adduct at `computeMZ` time. Test it with potassium or chloride; sodium would pass while proving nothing |
+| ~~#203~~ | ~~An m/z pairs an average neutral mass with a monoisotopic adduct~~ | **Fixed, in PR #205, waiting to merge.** `IonCloud` captured an adduct's mass when the ion was set rather than when it was computed, so the choice could not reach it. `computeMZ`/`computeMass` take the flag now and `getIonsMass(boolean)` recomputes the total; a charge given an explicit mass keeps it. The test is on potassium and chloride, with sodium as the control — one stable isotope, so a sodiated m/z was right by accident and a test on the default adduct would have passed before the fix |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
 | **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
 | ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
@@ -114,7 +114,7 @@ Both were found while measuring something else and existed nowhere but this file
 |---|---|---|
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
-| **#204** | A repeat unit's own linkage position does not survive a round trip | `l1` → `l?` on G03246MZ, measured on 1.37.0. A position the sequence states is written back as unknown, so the export says less than the import did and says it in a form that looks deliberate. Which end drops it is not known; the first move is a test that asserts the round trip keeps it |
+| ~~#204~~ | ~~A repeat unit's own linkage position does not survive a round trip~~ | **Fixed, in PR #206, waiting to merge.** It was dropped on the way in, not on the way out: `addChild` rebuilds a linkage from its bonds and ends by taking the child's anomeric carbon, and the closing marker is created fresh with none — so the `?` it was born with was written over the position that had just been worked out. `makeEdgeWithStartBracket` had always set it for the opening marker; only the closing side was missing the line, which is why one end of a repeat survived and the other did not. G03246MZ now round-trips character for character |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
 | ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
@@ -244,18 +244,16 @@ hour rather than a week, which is why they came first.
 Ten issues closed with their measurements, #203 and #204 filed, #88 left open on purpose until the fix
 is in a release, #189 answered from the dictionary and #190 pointed at #181.
 
-**2. #203, the ion adduct isotope** — now the top of P1, and the last thing in the project that hands
-someone a wrong number they cannot see is wrong: an m/z pairing an average neutral mass with a
-monoisotopic adduct. P1 by the same rule that put #127 there in the first place. **This is the next
-piece of work.**
+**2. ~~#203, the ion adduct isotope~~ — fixed, PR #205.** The last thing in the project that handed
+someone a wrong number they could not see was wrong. P1 by the same rule that put #127 there.
 
-**3. #204, the repeat unit's linkage position lost on a round trip** — a position the sequence states
-does not survive being written back, which is P2: the output cannot be used for what it was written
-for.
+**3. ~~#204, the repeat unit's linkage position lost on a round trip~~ — fixed, PR #206.** It turned out
+to be dropped on the way in rather than on the way out, and to be one line: the closing repeat marker
+was the only one of the two that was never given the position before being added.
 
-**4. #29, the bisecting GlcNAc** — the largest P3 and the one with a known next step
-(`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it wants a
-clear run at it rather than being squeezed in.
+**4. #29, the bisecting GlcNAc — the next piece of work.** The largest P3 and the one with a known next
+step (`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it
+wants a clear run at it rather than being squeezed in.
 
 **5. #183, the doubled export error** — cheap P3, and the same code path as #108, which is closed.
 
@@ -291,7 +289,8 @@ pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each c
 installers as every release before them. What is missing on all of them is the Windows `.msix`, which
 is uploaded by hand and is what #180 is about.
 
-**Open pull request**: #202, this file and the layout document. Nothing else is unmerged.
+**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope) and
+#206 (#204, the repeat's position). All three are for `develop` and carry no version bump.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -125,8 +125,7 @@ Both were found while measuring something else and existed nowhere but this file
 ~~#88 (no right margin on a bridge)~~ — **done, on `develop` and not yet released**: the cleared area
 was the glyphs' bounds cast to int, which truncates the origin one way and the width the other.
 
-**#29** (bisecting GlcNAc position) — **the rule and the expected numbers are both known; what is
-not known is where in the layout to apply them.**
+~~**#29** (bisecting GlcNAc position)~~ — **fixed, in PR #207, waiting to merge.**
 
 The convention: branches are drawn in the numeric order of their linkage positions, so a bisecting
 GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft states the same
@@ -137,17 +136,26 @@ thing as an explicit rule and gives worked numbers —
 >
 > 最終配置: α1-6 Man at y=-70, bisecting GlcNAc at y=0, α1-3 Man at y=+70
 
-Measured here, on the same structure: 6-antenna y=82, β-Man y=82, 3-antenna y=134, bisecting y=30 —
-the bisecting sits above the 6-antenna instead of between the two.
+Now measured, default orientation: 6-antenna y=30, bisecting GlcNAc y=82 level with its β-Man,
+3-antenna y=134. Was 82 / 30 / 134 — the bisecting above the 6-antenna, with the 6-antenna pushed onto
+its parent's line.
 
-**Where it is not.** Every ordinary monosaccharide gets the same placement from
-`conf/residue_placements_snfg` — the catch-all `1 → 0`, straight out — and `BookingManager` puts them
-all in one bucket for angle 0. So the branch order is not decided there. Sorting the children by
-linkage position before the booking loop in `AbstractGlycanRenderer.assignPosition` was tried and
-changed nothing; it was reverted rather than left in place looking like a fix.
+**What it turned out to be.** Every ordinary monosaccharide is placed straight out, so all of a
+residue's branches arrive in one region and are stacked in whatever order that region's list is in —
+which was the order the children were stored. Attaching one afterwards appended it, so it was stacked
+last, which is the far edge. That is why the issue is phrased as "if you add it after drawing": the
+same molecule imported from a sequence drew correctly, because the sequence listed the children
+differently.
 
-**Where to look next**: `BBoxManager`, and its `alignLeftsOnTop` / `alignLeftsOnBottom` family, which
-is what turns one bucket of children into rows.
+`AbstractGlycanRenderer.inPositionOrder` sorts that region before it is stacked, ascending, in all four
+orientations — which is what three of the four were already doing for a plain biantennary core, so a
+middle branch moves into place and nothing already right moves at all.
+
+**Two dead ends worth not repeating.** Sorting the children in `assignPosition` changed nothing: the
+region list is rebuilt from `PositionManager.getChildrenAtPosition`, which walks the residue's own
+linkages. And the first version of the test found the bisecting GlcNAc by name and position and picked
+up the chitobiose core's GlcNAc, which is also at 4 — it failed without the change, for the wrong
+reason.
 
 
 **#57** (repeat-unit linkage position) — measured: the model holds position 2 as the sequence says,
@@ -251,11 +259,13 @@ someone a wrong number they could not see was wrong. P1 by the same rule that pu
 to be dropped on the way in rather than on the way out, and to be one line: the closing repeat marker
 was the only one of the two that was never given the position before being added.
 
-**4. #29, the bisecting GlcNAc — the next piece of work.** The largest P3 and the one with a known next
-step (`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it
-wants a clear run at it rather than being squeezed in.
+**4. ~~#29, the bisecting GlcNAc~~ — fixed, PR #207.** It reached every picture the application draws,
+so it was checked in all four orientations and the plain core comes out unchanged in each. It also
+turned up a mistake in `docs/linkage-positions-and-anomers.md`, corrected on this branch: the
+position-to-side rules in the placement dictionaries apply to substituents only, not to saccharides.
 
-**5. #183, the doubled export error** — cheap P3, and the same code path as #108, which is closed.
+**5. #183, the doubled export error — the next piece of work.** Cheap P3, and the same code path as
+#108, which is closed.
 
 **6. The waiting list, before starting anything new.** #17, #57, #58, #66, #83, #185, #16 are all
 waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
@@ -289,8 +299,9 @@ pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each c
 installers as every release before them. What is missing on all of them is the Windows `.msix`, which
 is uploaded by hand and is what #180 is about.
 
-**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope) and
-#206 (#204, the repeat's position). All three are for `develop` and carry no version bump.
+**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope),
+#206 (#204, the repeat's position) and #207 (#29, branch order). All four are for `develop` and carry no
+version bump.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -41,20 +41,60 @@ and it is what lets the next person trust this file.
 
 ---
 
-## Verified, and can be closed
+## Verified, and closed
 
-Measured on 1.35.2. Each needs a comment carrying the measurement, not a bare close.
+Measured on 1.35.2, commented with the measurement, and closed on 2026-08-14.
 
 | # | Title | What was measured |
 |---|---|---|
 | #67 | Composition m/z is incorrect | Hex₃HexNAc₂ as a composition weighs 910.3278, as does the same glycan linked. Fixed by the 1.34.1–1.34.3 composition work |
 | #150 | Ambiguous linkage read as the parent's position | Fixed in 1.34.0, `AmbiguousLinkageKeepsUnknownPositionsTest` holds it |
 | #158 | org.jdom has no fixed version | Duplicate of #175, which carries the fuller investigation |
-| #17 | AUdxxxxxh no longer supported | G00771KP reads and draws. Ask the reporter to confirm before closing — it is their report |
+| #125 | Redrawing G11127BT | Half done, and split: the structure no longer takes the JVM down, it is refused with a sentence. Being unable to draw it carried on as **#200** under the title it should have had |
 
-**#125** (redrawing G11127BT) is half done: the structure no longer takes the JVM down, it is refused
-with a sentence saying a ring through a bridge cannot be represented. Being unable to draw it is what
-remains, and the issue should say so rather than being closed.
+**#17** (AUdxxxxxh no longer supported) is still open and still wants the same thing: G00771KP reads
+and draws, so ask the reporter to confirm the import is what they meant before closing — it is their
+report.
+
+---
+
+## Fixed, and still open on the tracker
+
+**The largest gap between this file and the tracker.** Nine issues are marked done below — eight of
+them in a version a user can already install — and every one of them is still open on GitHub. Somebody
+reading the tracker sees a backlog that is not there, and none of the reporters has been told.
+
+Each wants a comment carrying what was measured and the version it went out in, then a close — not a
+bare close.
+
+| # | What it was | Released in |
+|---|---|---|
+| #132 | `v_stripes`/`h_stripes` never painted | 1.36.0 |
+| #107 | Composition export to WURCS fails | 1.36.0 |
+| #34 | Duplicated linkage position in a branched glycan | 1.37.0 |
+| #186 | PNG background not transparent | 1.37.0 |
+| #188 | SVG gives every character a white background | 1.37.0 |
+| #106 | Saving on close offers Save As for an already-saved file | 1.37.0 |
+| #178 | "Open additional document" leaves the document counted as unchanged | 1.37.0 |
+| #179 | "Remember files after restarting" carries a reducing end into new imports | 1.37.0 |
+| #88 | No right margin on a bridge label | **`develop`, unreleased** — merged as #199, no version carries it yet |
+
+**#127** is a different case and should stay open with its scope narrowed rather than closed: the
+neutral mass follows `MassOptions.ISOTOPE` as of 1.36.0, the ion adducts still do not. See the
+unfiled follow-ups below.
+
+**#83** is on `develop` too (merged as #201) but is not fixed by it — removing an angle that was never
+used does not answer whether the symbol looks wrong, which is what the reporter was asked.
+
+### Two things measured but never filed
+
+Both were found while measuring something else, both are real, and neither exists as an issue — so
+they are invisible to anyone who does not read this file.
+
+- **`IonCloud` captures an ion's mass when the ion is set, not when the mass is computed**, so an m/z
+  can pair an average neutral mass with a monoisotopic adduct. This is the remainder of #127.
+- **A repeat unit's own linkage position does not survive a round trip**, `l1` → `l?`. Found while
+  measuring #57, and a different fault from the one that issue reports.
 
 ---
 
@@ -82,8 +122,8 @@ remains, and the issue should say so rather than being closed.
 
 ## P3 — visibly wrong
 
-~~#88 (no right margin on a bridge)~~ — **done**: the cleared area was the glyphs' bounds cast to
-int, which truncates the origin one way and the width the other.
+~~#88 (no right margin on a bridge)~~ — **done, on `develop` and not yet released**: the cleared area
+was the glyphs' bounds cast to int, which truncates the origin one way and the width the other.
 
 **#29** (bisecting GlcNAc position) — **the rule and the expected numbers are both known; what is
 not known is where in the layout to apply them.**
@@ -110,18 +150,23 @@ changed nothing; it was reverted rather than left in place looking like a fix.
 is what turns one bucket of children into rows.
 
 
-#58 (G07957FT layout) · #20 (bracket not symmetric about the
-reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is
-orientation-independent, and the measurements are on the issue.
-
-#91 (Add-structure menu
-misaligned) · #6 (fragments carrying a bridge)
-
 **#57** (repeat-unit linkage position) — measured: the model holds position 2 as the sequence says,
 so the 3 appears between the model and the picture, and the likely candidate is the position
 belonging to the *other* end of the repeat. Asked the reporter to confirm which label. Found
 separately while measuring: the round trip drops the repeat's own linkage position, `l1` → `l?`,
-which is a different fault in the same corner and wants its own issue.
+which is a different fault in the same corner and is not filed.
+
+**#83** (CFG hat diamonds take orientation from the bond) — the angle those two symbols took was
+never used, and is gone as of #201, on `develop`. That does not establish the symbol is
+orientation-independent; the measurements are on the issue, and the reporter was asked whether it
+looks *rotated* or merely *placed differently*.
+
+**#183** (a failed WURCS export shows every error twice) — two dialogs per failed structure, so four
+for two bad structures. #108 (a message for a partially failed export) was closed in 1.35.x and this
+is the same code path, so start by reading what that change left behind.
+
+#58 (G07957FT layout) · #20 (bracket not symmetric about the reducing end) ·
+#91 (Add-structure menu misaligned) · #6 (fragments carrying a bridge)
 
 ## P4 — not there yet
 
@@ -129,7 +174,8 @@ which is a different fault in the same corner and wants its own issue.
 |---|---|---|
 | #95 | Validate a drawn structure | Before submitting to GlyTouCan. Validation code exists elsewhere and could be called |
 | #100 | Substituents and defined residues in the composition builder | Overlaps #7 (which monosaccharides the list should offer); decide them together |
-| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench |
+| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench. #189 and #190 are both instances of it, per R. Ranzinger on #190 — a modified residue can be imported from a sequence but not drawn |
+| #200 | A ring closed through a bridge cannot be represented | The bridge plus the direct bond make a genuine cycle where everything downstream assumes a tree, so it is a change to the structure model, not the renderer. Carried on from #125, which is closed |
 | #184 | Multi-format clipboard (bitmap + text + SVG) | |
 | #177 | Open a .gws by double-clicking it | Needs file association *and* accepting a path at startup |
 | #41 | SNFG with linkage placement notation | CFG has it; SNFG does not |
@@ -137,6 +183,7 @@ which is a different fault in the same corner and wants its own issue.
 | #172 | Check for updates at startup | Waiting on the Microsoft Store question |
 | #109 | Compositions with linkage (lactonised sialic acid) | A WURCS question more than a GB2 one |
 | #7 | Review the Add-composition monosaccharide list | |
+| #16 | A standing list of modifications that were not handled | Fourteen WURCS collected since 2021, almost certainly not one fault — `*OSO`, `*=NO` and the rest fail at different points and some read now. Asked the reporter whether to re-measure each on 1.35.2, close this, and file one issue per modification that still fails. Overlaps #181 |
 
 ## P5 — plumbing
 
@@ -151,28 +198,90 @@ which is a different fault in the same corner and wants its own issue.
 #182 ("Unknown" is a misleading group name) · #189 (sulfate on a GlcNAc nitrogen) ·
 #190 (a KEGG structure with ribitol)
 
-#189 and #190 are asked as "how do I input this?" and may each turn out to be a missing capability
-rather than a missing instruction. Answer them by trying it, and re-file what does not work.
+#189 and #190 are asked as "how do I input this?" and both look like the missing capability #181
+describes rather than a missing instruction — R. Ranzinger said so on #190. Confirm it by trying, then
+say so on each and let #181 carry the work.
+
+**#90** (no second window on macOS) — Swing runs one instance per application on macOS, and it is not
+ours to change. Two workarounds are already in the thread, `open -n /Applications/GlycanBuilder2.app`
+and the same line wrapped as a Script Editor app. The answer is to put one of them somewhere a user
+will find it and close the issue, not to keep it open against an approach nobody has.
 
 ---
 
 ## Not a priority band, but do it first
 
 **#123** is someone outside the project offering patches — NPEs turned into exceptions that say what
-failed in WURCS terms — and asking how to submit them. The last word is theirs: they will be back in
-about a week. Replying with how to send it costs a paragraph, and not replying costs the patches.
+failed in WURCS terms. **Answered on 2026-08-14** with how to send them, what shape a test wants, and
+two recent refusals to imitate. They said about a week, so nothing is owed here until roughly the 21st;
+the next move is theirs.
 
 Contribution questions are answered ahead of the queue, whatever band the code would fall in.
 
 ---
 
+## The order to take them in
+
+The bands say what a thing costs. This says what to pick up, and it is the bands applied twice: once
+for cost, once for what it costs to leave the tracker saying something untrue.
+
+**1. One sitting of tracker work — about an hour, and it outranks every open defect.** Nine fixed
+issues are still open and two measured faults are not filed at all. Both are the same failure and it
+is the one this file is most emphatic about: *silence outranks severity*. An issue that says a fixed
+bug is live, and a real fault that exists in nobody's tracker, are both quietly wrong to everyone
+outside this repository — and unlike the defects below, they cost an hour rather than a week.
+
+- Close the nine with the measurement and the version, from the table above
+- File the `IonCloud` m/z fault, and narrow #127 to it
+- File the repeat unit's `l1` → `l?` round trip
+- Close #90 with the `open -n` workaround, and say on #189 and #190 that #181 is the work
+
+**2. The ion adduct isotope** — the new #127 issue. The last thing left in the project that hands
+someone a wrong number they cannot see is wrong: an m/z pairing an average neutral mass with a
+monoisotopic adduct. P1 by the same rule that put #127 there in the first place.
+
+**3. The repeat unit's linkage position, lost on a round trip** — the other new issue. A position the
+sequence states does not survive being written back, which is P2: the output cannot be used for what
+it was written for.
+
+**4. #29, the bisecting GlcNAc** — the largest P3 and the one with a known next step
+(`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it wants a
+clear run at it rather than being squeezed in.
+
+**5. #183, the doubled export error** — cheap P3, and the same code path as #108, which is closed.
+
+**6. The waiting list, before starting anything new.** #17, #57, #58, #66, #83, #185, #16 are all
+waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
+
+Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
+changes and neither is small.
+
+**When the next release goes out**, it already has two fixes waiting on `develop` (#199, #201) and the
+version bump belongs immediately before the merge to `master`, not before that.
+
+---
+
 ## Where this stands, for whoever picks it up next
 
-As of 2026-08-14, after 1.37.0.
+Re-checked against the tracker on 2026-08-15.
 
-**Released**: P1 and P2 are done. 1.36.0 carried the composition WURCS export, the average mass and
-the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
+**Released**: P1 and P2 are done in the code. 1.36.0 carried the composition WURCS export, the average
+mass and the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
 document-loses-your-work bugs.
+
+**The code is ahead of the tracker, and the tracker is what other people read.** Nine fixed issues are
+still open — the table under "Fixed, and still open on the tracker" is the shortest piece of work on
+this page and the one that changes what the project looks like from outside. Two measured faults are
+not filed at all.
+
+**On `develop`, waiting for the next release**: #199 (#88, the bridge label's margin) and #201 (#83's
+unused angle). `pom.xml` still reads 1.37.0 on both branches, correctly — the bump belongs immediately
+before the merge to `master`.
+
+**Releases are in order**, checked against the API rather than the release page: nothing is a
+pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each carry the same five
+installers as every release before them. What is missing on all of them is the Windows `.msix`, which
+is uploaded by hand and is what #180 is about.
 
 **Open pull request**: #202, this file and the layout document. Nothing else is unmerged.
 
@@ -182,7 +291,7 @@ closable:
 | # | Waiting for |
 |---|---|
 | #17 | the reporter to confirm the import is what they meant, or close it |
-| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` wants its own issue |
+| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` is still not filed |
 | #58 | which part of the layout is wrong |
 | #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
 | #83 | whether the symbol looks *rotated* or merely *placed differently* |

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -58,43 +58,41 @@ report.
 
 ---
 
-## Fixed, and still open on the tracker
+## Fixed and closed, on 2026-08-15
 
-**The largest gap between this file and the tracker.** Nine issues are marked done below — eight of
-them in a version a user can already install — and every one of them is still open on GitHub. Somebody
-reading the tracker sees a backlog that is not there, and none of the reporters has been told.
-
-Each wants a comment carrying what was measured and the version it went out in, then a close — not a
-bare close.
+For a day these were all marked done here and open on GitHub — the tracker showed a backlog that did
+not exist, and no reporter had been told. Each is now closed with a comment carrying what was measured
+and the version it went out in.
 
 | # | What it was | Released in |
 |---|---|---|
 | #132 | `v_stripes`/`h_stripes` never painted | 1.36.0 |
 | #107 | Composition export to WURCS fails | 1.36.0 |
+| #127 | `MassOptions.ISOTOPE` has no effect | 1.36.0, for the neutral mass — the adducts became **#203** |
 | #34 | Duplicated linkage position in a branched glycan | 1.37.0 |
 | #186 | PNG background not transparent | 1.37.0 |
 | #188 | SVG gives every character a white background | 1.37.0 |
 | #106 | Saving on close offers Save As for an already-saved file | 1.37.0 |
 | #178 | "Open additional document" leaves the document counted as unchanged | 1.37.0 |
 | #179 | "Remember files after restarting" carries a reducing end into new imports | 1.37.0 |
-| #88 | No right margin on a bridge label | **`develop`, unreleased** — merged as #199, no version carries it yet |
+| #90 | No second window on macOS | Not a code change — closed with the `open -n` workaround |
 
-**#127** is a different case and should stay open with its scope narrowed rather than closed: the
-neutral mass follows `MassOptions.ISOTOPE` as of 1.36.0, the ion adducts still do not. See the
-unfiled follow-ups below.
+**#88 is fixed and deliberately still open.** The fix is on `develop` (merged as #199) and no version
+a user can install carries it, so closing it would read as done to somebody whose build still shows
+the problem. It is commented to that effect and closes with the next release.
 
 **#83** is on `develop` too (merged as #201) but is not fixed by it — removing an angle that was never
 used does not answer whether the symbol looks wrong, which is what the reporter was asked.
 
-### Two things measured but never filed
+### Two things measured, now filed
 
-Both were found while measuring something else, both are real, and neither exists as an issue — so
-they are invisible to anyone who does not read this file.
+Both were found while measuring something else and existed nowhere but this file until 2026-08-15.
 
-- **`IonCloud` captures an ion's mass when the ion is set, not when the mass is computed**, so an m/z
-  can pair an average neutral mass with a monoisotopic adduct. This is the remainder of #127.
-- **A repeat unit's own linkage position does not survive a round trip**, `l1` → `l?`. Found while
-  measuring #57, and a different fault from the one that issue reports.
+- **#203** — `IonCloud` captures an adduct's mass when the ion is set rather than when the mass is
+  computed, so an m/z can pair an average neutral mass with a monoisotopic adduct. Nil for sodium,
+  +0.135 per potassium, +0.484 per chloride, and *negative* for lithium. The remainder of #127.
+- **#204** — a repeat unit's own linkage position does not survive a round trip, `l1` → `l?`. Found
+  while measuring #57, and a different fault from the one that issue reports.
 
 ---
 
@@ -104,7 +102,8 @@ they are invisible to anyone who does not read this file.
 |---|---|---|
 | ~~#132~~ | ~~`v_stripes`/`h_stripes` never painted~~ | **Done.** Three bars, clipped to the outline. The test asserts the drawn image and, separately, that the stripes exist — Tal is green and All is blue, so comparing the pair passes on colour alone |
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
-| ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass.** Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82). **Still monoisotopic: the ion adducts.** `IonCloud` captures an ion's mass when the ion is set, not when the mass is computed, so an m/z carries an average neutral mass and a monoisotopic adduct. Worth its own issue |
+| ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass**, 1.36.0, and closed. Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82) |
+| **#203** | An m/z pairs an average neutral mass with a monoisotopic adduct | **The top of this list.** `IonCloud` captures an adduct's mass when the ion is set rather than when the mass is computed, so the isotope choice never reaches it. `Molecule` already carries both masses — what is missing is resolving the adduct at `computeMZ` time. Test it with potassium or chloride; sodium would pass while proving nothing |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
 | **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
 | ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
@@ -115,6 +114,7 @@ they are invisible to anyone who does not read this file.
 |---|---|---|
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
+| **#204** | A repeat unit's own linkage position does not survive a round trip | `l1` → `l?` on G03246MZ, measured on 1.37.0. A position the sequence states is written back as unknown, so the export says less than the import did and says it in a form that looks deliberate. Which end drops it is not known; the first move is a test that asserts the round trip keeps it |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
 | ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
@@ -174,7 +174,7 @@ is the same code path, so start by reading what that change left behind.
 |---|---|---|
 | #95 | Validate a drawn structure | Before submitting to GlyTouCan. Validation code exists elsewhere and could be called |
 | #100 | Substituents and defined residues in the composition builder | Overlaps #7 (which monosaccharides the list should offer); decide them together |
-| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench. #189 and #190 are both instances of it, per R. Ranzinger on #190 — a modified residue can be imported from a sequence but not drawn |
+| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench: a modified residue can be imported from a sequence but not drawn, per R. Ranzinger. #190 (ribitol) is the concrete case to satisfy. #189 is **not** one of these — see P6 |
 | #200 | A ring closed through a bridge cannot be represented | The bridge plus the direct bond make a genuine cycle where everything downstream assumes a tree, so it is a change to the structure model, not the renderer. Carried on from #125, which is closed |
 | #184 | Multi-format clipboard (bitmap + text + SVG) | |
 | #177 | Open a .gws by double-clicking it | Needs file association *and* accepting a path at startup |
@@ -198,14 +198,24 @@ is the same code path, so start by reading what that change left behind.
 #182 ("Unknown" is a misleading group name) · #189 (sulfate on a GlcNAc nitrogen) ·
 #190 (a KEGG structure with ribitol)
 
-#189 and #190 are asked as "how do I input this?" and both look like the missing capability #181
-describes rather than a missing instruction — R. Ranzinger said so on #190. Confirm it by trying, then
-say so on each and let #181 carry the work.
+**#190** (a KEGG structure with ribitol) is an instance of #181 — a modified residue can be imported
+from a sequence but not drawn, per R. Ranzinger on the issue. Left open as the concrete case #181 has
+to satisfy, and the reporter asked for the sequence, which is worth more to whoever takes #181 than a
+description of alditols.
 
-**#90** (no second window on macOS) — Swing runs one instance per application on macOS, and it is not
-ours to change. Two workarounds are already in the thread, `open -n /Applications/GlycanBuilder2.app`
-and the same line wrapped as a Script Editor app. The answer is to put one of them somewhere a user
-will find it and close the issue, not to keep it open against an approach nobody has.
+**#189** (sulfate on a GlcNAc nitrogen) **is not an instance of #181, and this file said it was for a
+day.** The dictionary answers it. `NS` — N-sulfate, `*NSO/3=O/3=O` — is an N-type substituent sitting
+right beside `NAc`, and `GlcN` declares `3,4,5,6,N` as its positions while `GlcNAc` declares `3,4,5,6`:
+
+- GlcN with `NS` at N is GlcNS, and it can be drawn today
+- GlcNAc has no free nitrogen, and 1.37.0's position rules refuse a second substituent there **on
+  purpose** — that is the rule working, not a gap
+
+What is left is the one chemistry question, which is the reporter's: whether they mean GlcNS or a
+sulfate on top of an acetylated nitrogen. Asked on the issue.
+
+*The lesson worth keeping: "these two look like the same missing capability" was written from the
+titles. Two greps at the dictionary said one of them had an answer already.*
 
 ---
 
@@ -225,24 +235,23 @@ Contribution questions are answered ahead of the queue, whatever band the code w
 The bands say what a thing costs. This says what to pick up, and it is the bands applied twice: once
 for cost, once for what it costs to leave the tracker saying something untrue.
 
-**1. One sitting of tracker work — about an hour, and it outranks every open defect.** Nine fixed
-issues are still open and two measured faults are not filed at all. Both are the same failure and it
-is the one this file is most emphatic about: *silence outranks severity*. An issue that says a fixed
-bug is live, and a real fault that exists in nobody's tracker, are both quietly wrong to everyone
-outside this repository — and unlike the defects below, they cost an hour rather than a week.
+**1. ~~One sitting of tracker work~~ — done on 2026-08-15.** Nine fixed issues were still open and two
+measured faults were filed nowhere. Both are the same failure, and it is the one this file is most
+emphatic about: *silence outranks severity*. An issue saying a fixed bug is live, and a real fault that
+exists in nobody's tracker, are equally wrong to everyone outside this repository — and they cost an
+hour rather than a week, which is why they came first.
 
-- Close the nine with the measurement and the version, from the table above
-- File the `IonCloud` m/z fault, and narrow #127 to it
-- File the repeat unit's `l1` → `l?` round trip
-- Close #90 with the `open -n` workaround, and say on #189 and #190 that #181 is the work
+Ten issues closed with their measurements, #203 and #204 filed, #88 left open on purpose until the fix
+is in a release, #189 answered from the dictionary and #190 pointed at #181.
 
-**2. The ion adduct isotope** — the new #127 issue. The last thing left in the project that hands
+**2. #203, the ion adduct isotope** — now the top of P1, and the last thing in the project that hands
 someone a wrong number they cannot see is wrong: an m/z pairing an average neutral mass with a
-monoisotopic adduct. P1 by the same rule that put #127 there in the first place.
+monoisotopic adduct. P1 by the same rule that put #127 there in the first place. **This is the next
+piece of work.**
 
-**3. The repeat unit's linkage position, lost on a round trip** — the other new issue. A position the
-sequence states does not survive being written back, which is P2: the output cannot be used for what
-it was written for.
+**3. #204, the repeat unit's linkage position lost on a round trip** — a position the sequence states
+does not survive being written back, which is P2: the output cannot be used for what it was written
+for.
 
 **4. #29, the bisecting GlcNAc** — the largest P3 and the one with a known next step
 (`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it wants a
@@ -269,10 +278,9 @@ Re-checked against the tracker on 2026-08-15.
 mass and the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
 document-loses-your-work bugs.
 
-**The code is ahead of the tracker, and the tracker is what other people read.** Nine fixed issues are
-still open — the table under "Fixed, and still open on the tracker" is the shortest piece of work on
-this page and the one that changes what the project looks like from outside. Two measured faults are
-not filed at all.
+**The tracker matches the code again**, as of 2026-08-15. Ten issues closed with their measurements,
+#203 and #204 filed for the two faults that had been measured and never written down anywhere but here.
+The next piece of work is #203.
 
 **On `develop`, waiting for the next release**: #199 (#88, the bridge label's margin) and #201 (#83's
 unused angle). `pom.xml` still reads 1.37.0 on both branches, correctly — the bump belongs immediately
@@ -291,13 +299,15 @@ closable:
 | # | Waiting for |
 |---|---|
 | #17 | the reporter to confirm the import is what they meant, or close it |
-| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` is still not filed |
+| #57 | which label shows 3 — the round trip dropping `l1` → `l?` is #204 now |
 | #58 | which part of the layout is wrong |
 | #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
 | #83 | whether the symbol looks *rotated* or merely *placed differently* |
 | #185 | a retest on Windows; all five formats write here |
 | #16 | whether to split it per modification |
-| #189, #190 | the structure, as WURCS or GlycoCT |
+| #189 | whether they mean GlcNS or a sulfate on an already-acetylated nitrogen — a chemistry question, and the only thing left on it |
+| #190 | the WURCS or GlycoCT for G13093, for whoever takes #181 |
+| #88 | nothing — it is fixed, and waits only for a release to close against |
 | #123 | the contributor said about a week, from 2026-08-14 |
 
 **Deliberately not started**: #175 (jdom2) and taking glycanbuilder2web to 1.37.0 are both on hold at

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -87,9 +87,12 @@ int, which truncates the origin one way and the width the other.
 
 **#29** (bisecting GlcNAc position) — measured: the placement dictionary sends both position 4 and
 position 6 to the same side (`lp=[4-9]` → 90), so a bisecting GlcNAc and the 6-antenna compete and one
-gives way. Adding it after drawing is not the cause. Not changed: the rule that would fix it is a
-drawing convention, and picking it decides every picture the application draws — asked the reporter
-which rule they want.
+gives way. Adding it after drawing is not the cause. **The convention is settled**: branches are ordered by their linkage
+position, so 3 below, 4 between, 6 above (I. Yamada, 2026-08-14; recorded in
+`docs/linkage-positions-and-anomers.md`). Implementing it is wider than the dictionary, which matches
+one linkage at a time and cannot see its siblings — it needs candidate positions that admit a middle
+branch *and* `BookingManager` allocating in position order. Not attempted yet: it reaches every
+picture the application draws.
 
 #58 (G07957FT layout) · #20 (bracket not symmetric about the
 reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -85,14 +85,30 @@ remains, and the issue should say so rather than being closed.
 ~~#88 (no right margin on a bridge)~~ — **done**: the cleared area was the glyphs' bounds cast to
 int, which truncates the origin one way and the width the other.
 
-**#29** (bisecting GlcNAc position) — measured: the placement dictionary sends both position 4 and
-position 6 to the same side (`lp=[4-9]` → 90), so a bisecting GlcNAc and the 6-antenna compete and one
-gives way. Adding it after drawing is not the cause. **The convention is settled**: branches are ordered by their linkage
-position, so 3 below, 4 between, 6 above (I. Yamada, 2026-08-14; recorded in
-`docs/linkage-positions-and-anomers.md`). Implementing it is wider than the dictionary, which matches
-one linkage at a time and cannot see its siblings — it needs candidate positions that admit a middle
-branch *and* `BookingManager` allocating in position order. Not attempted yet: it reaches every
-picture the application draws.
+**#29** (bisecting GlcNAc position) — **the rule and the expected numbers are both known; what is
+not known is where in the layout to apply them.**
+
+The convention: branches are drawn in the numeric order of their linkage positions, so a bisecting
+GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft states the same
+thing as an explicit rule and gives worked numbers —
+`/Users/yamada/git/gitlab/glycoinfo-dev/glycocraft/LAYOUT_ALGORITHM.md`, §4.5 Step 3 and §5:
+
+> DrawGlycan-SNFG ルール: acceptorPos=4 (例: bisecting GlcNAc) は y=0 に固定
+>
+> 最終配置: α1-6 Man at y=-70, bisecting GlcNAc at y=0, α1-3 Man at y=+70
+
+Measured here, on the same structure: 6-antenna y=82, β-Man y=82, 3-antenna y=134, bisecting y=30 —
+the bisecting sits above the 6-antenna instead of between the two.
+
+**Where it is not.** Every ordinary monosaccharide gets the same placement from
+`conf/residue_placements_snfg` — the catch-all `1 → 0`, straight out — and `BookingManager` puts them
+all in one bucket for angle 0. So the branch order is not decided there. Sorting the children by
+linkage position before the booking loop in `AbstractGlycanRenderer.assignPosition` was tried and
+changed nothing; it was reverted rather than left in place looking like a fix.
+
+**Where to look next**: `BBoxManager`, and its `alignLeftsOnTop` / `alignLeftsOnBottom` family, which
+is what turns one bucket of children into rows.
+
 
 #58 (G07957FT layout) · #20 (bracket not symmetric about the
 reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is
@@ -147,3 +163,36 @@ failed in WURCS terms — and asking how to submit them. The last word is theirs
 about a week. Replying with how to send it costs a paragraph, and not replying costs the patches.
 
 Contribution questions are answered ahead of the queue, whatever band the code would fall in.
+
+---
+
+## Where this stands, for whoever picks it up next
+
+As of 2026-08-14, after 1.37.0.
+
+**Released**: P1 and P2 are done. 1.36.0 carried the composition WURCS export, the average mass and
+the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
+document-loses-your-work bugs.
+
+**Open pull request**: #202, this file and the layout document. Nothing else is unmerged.
+
+**Waiting on somebody else**, and worth a look before starting anything new — several of these may be
+closable:
+
+| # | Waiting for |
+|---|---|
+| #17 | the reporter to confirm the import is what they meant, or close it |
+| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` wants its own issue |
+| #58 | which part of the layout is wrong |
+| #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
+| #83 | whether the symbol looks *rotated* or merely *placed differently* |
+| #185 | a retest on Windows; all five formats write here |
+| #16 | whether to split it per modification |
+| #189, #190 | the structure, as WURCS or GlycoCT |
+| #123 | the contributor said about a week, from 2026-08-14 |
+
+**Deliberately not started**: #175 (jdom2) and taking glycanbuilder2web to 1.37.0 are both on hold at
+the maintainer's request.
+
+**The reducing-end note in "Before ranking anything, verify it" is the trap most likely to waste your
+first hour.** It has caught two measurements so far.

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -103,7 +103,7 @@ Both were found while measuring something else and existed nowhere but this file
 | ~~#132~~ | ~~`v_stripes`/`h_stripes` never painted~~ | **Done.** Three bars, clipped to the outline. The test asserts the drawn image and, separately, that the stripes exist — Tal is green and All is blue, so comparing the pair passes on colour alone |
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
 | ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass**, 1.36.0, and closed. Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82) |
-| ~~#203~~ | ~~An m/z pairs an average neutral mass with a monoisotopic adduct~~ | **Fixed, in PR #205, waiting to merge.** `IonCloud` captured an adduct's mass when the ion was set rather than when it was computed, so the choice could not reach it. `computeMZ`/`computeMass` take the flag now and `getIonsMass(boolean)` recomputes the total; a charge given an explicit mass keeps it. The test is on potassium and chloride, with sodium as the control — one stable isotope, so a sodiated m/z was right by accident and a test on the default adduct would have passed before the fix |
+| ~~#203~~ | ~~An m/z pairs an average neutral mass with a monoisotopic adduct~~ | **Fixed in PR #205, merged to `develop` on 2026-08-15.** `IonCloud` captured an adduct's mass when the ion was set rather than when it was computed, so the choice could not reach it. `computeMZ`/`computeMass` take the flag now and `getIonsMass(boolean)` recomputes the total; a charge given an explicit mass keeps it. The test is on potassium and chloride, with sodium as the control — one stable isotope, so a sodiated m/z was right by accident and a test on the default adduct would have passed before the fix |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
 | **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
 | ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
@@ -114,7 +114,7 @@ Both were found while measuring something else and existed nowhere but this file
 |---|---|---|
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
-| ~~#204~~ | ~~A repeat unit's own linkage position does not survive a round trip~~ | **Fixed, in PR #206, waiting to merge.** It was dropped on the way in, not on the way out: `addChild` rebuilds a linkage from its bonds and ends by taking the child's anomeric carbon, and the closing marker is created fresh with none — so the `?` it was born with was written over the position that had just been worked out. `makeEdgeWithStartBracket` had always set it for the opening marker; only the closing side was missing the line, which is why one end of a repeat survived and the other did not. G03246MZ now round-trips character for character |
+| ~~#204~~ | ~~A repeat unit's own linkage position does not survive a round trip~~ | **Fixed in PR #206, merged to `develop` on 2026-08-15.** It was dropped on the way in, not on the way out: `addChild` rebuilds a linkage from its bonds and ends by taking the child's anomeric carbon, and the closing marker is created fresh with none — so the `?` it was born with was written over the position that had just been worked out. `makeEdgeWithStartBracket` had always set it for the opening marker; only the closing side was missing the line, which is why one end of a repeat survived and the other did not. G03246MZ now round-trips character for character |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
 | ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
@@ -125,7 +125,7 @@ Both were found while measuring something else and existed nowhere but this file
 ~~#88 (no right margin on a bridge)~~ — **done, on `develop` and not yet released**: the cleared area
 was the glyphs' bounds cast to int, which truncates the origin one way and the width the other.
 
-~~**#29** (bisecting GlcNAc position)~~ — **fixed, in PR #207, waiting to merge.**
+~~**#29** (bisecting GlcNAc position)~~ — **fixed in PR #207, merged to `develop` on 2026-08-15.**
 
 The convention: branches are drawn in the numeric order of their linkage positions, so a bisecting
 GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft states the same
@@ -169,7 +169,7 @@ never used, and is gone as of #201, on `develop`. That does not establish the sy
 orientation-independent; the measurements are on the issue, and the reporter was asked whether it
 looks *rotated* or merely *placed differently*.
 
-~~**#183** (a failed WURCS export shows every error twice)~~ — **fixed, in PR #208, waiting to merge.**
+~~**#183** (a failed WURCS export shows every error twice)~~ — **fixed in PR #208, merged to `develop` on 2026-08-15.**
 The export wrote every structure for the file and then wrote them all again to find which had come out
 empty, and one failure is already two windows — `LogUtils.report` shows the message and then a
 `ReportDialog` — so the second pass produced a second pair. One pass now.
@@ -278,6 +278,10 @@ than claimed as verified.
 somebody else and several are closable on a reply. A nudge costs a paragraph, and #183 has just joined
 them.
 
+**Then a release.** Six fixes are on `develop` and none of them has reached anybody: #88, #83's dead
+angle, and the four from 2026-08-15. That is the whole of P1 and P2 sitting where no user can install
+it, which by this file's own ranking is worth more than the next defect on the list.
+
 Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
 changes and neither is small.
 
@@ -307,9 +311,16 @@ pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each c
 installers as every release before them. What is missing on all of them is the Windows `.msix`, which
 is uploaded by hand and is what #180 is about.
 
-**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope),
-#206 (#204, the repeat's position), #207 (#29, branch order) and #208 (#183, one message per failed
-export). All five are for `develop` and carry no version bump.
+**On `develop`, waiting only for a release**: #199 (#88's bridge margin), #201 (#83's unused angle),
+#205 (#203), #206 (#204), #207 (#29) and #208 (#183). 181 tests pass with all of them together.
+`pom.xml` still reads 1.37.0, correctly — the bump belongs immediately before the merge to `master`.
+
+**Four issues are fixed and still open on purpose**: #203, #204, #29 and #183. `develop` is not the
+default branch, so "Closes #N" did not fire on merge, and closing them by hand would tell each reporter
+it is done while no version they can install has it. They close with the release, alongside #88. This is
+the same judgement as #88's, applied consistently rather than issue by issue.
+
+**Open pull request**: #202, this file and the layout document.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:

--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -76,6 +76,33 @@ of them.
 
 ## What is drawn
 
+### Which way a branch goes
+
+**Branches are ordered by their linkage position.** A residue's children are drawn in the numeric
+order of the positions they attach at, so on a β-Man carrying 3, 4 and 6 the 3-antenna is on one
+side, the 6-antenna on the other, and the bisecting GlcNAc at 4 sits between them.
+
+*Confirmed by I. Yamada, 2026-08-14: "単糖の結合方向は数字の順番になるようにするのが慣例であるので、
+4位の単糖は、3と６の間の位置に配置される".*
+
+**This is not what the code does.** `conf/residue_placements_snfg` assigns a side from the position
+alone, in two ranges:
+
+```
+(!cs)&(!cx)&(lp=[1-3[N]])   -90
+(!cs)&(!cx)&(lp=[4-9])       90
+```
+
+4 and 6 both fall in `[4-9]`, so a bisecting GlcNAc and a 6-antenna are sent to the same side and one
+of them gives way — measured, the bisecting GlcNAc ends up above the 6-antenna and the 6-antenna
+drops to the β-Man's own line (#29).
+
+Ordering by position cannot be expressed in that dictionary, which matches one linkage at a time and
+cannot see its siblings. Making the drawing follow the convention needs both halves: candidate
+positions wide enough for a middle branch to exist, and `BookingManager` allocating them in position
+order rather than in the order the children happen to be stored. That reaches every picture the
+application draws, which is why it is written down here before it is attempted.
+
 ### The anomeric configuration
 
 α and β describe the configuration at the anomeric centre. **Where there is no anomeric centre there

--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -85,23 +85,36 @@ side, the 6-antenna on the other, and the bisecting GlcNAc at 4 sits between the
 *Confirmed by I. Yamada, 2026-08-14: "単糖の結合方向は数字の順番になるようにするのが慣例であるので、
 4位の単糖は、3と６の間の位置に配置される".*
 
-**This is not what the code does.** `conf/residue_placements_snfg` assigns a side from the position
-alone, in two ranges:
+**Where it is decided, and where it is not.** `conf/residue_placements_snfg` does have rules that pick
+a side from the position:
 
 ```
 (!cs)&(!cx)&(lp=[1-3[N]])   -90
 (!cs)&(!cx)&(lp=[4-9])       90
 ```
 
-4 and 6 both fall in `[4-9]`, so a bisecting GlcNAc and a 6-antenna are sent to the same side and one
-of them gives way — measured, the bisecting GlcNAc ends up above the 6-antenna and the 6-antenna
-drops to the β-Man's own line (#29).
+**They are not about saccharides.** `cs` reads "child is a monosaccharide", so `(!cs)&(!cx)` restricts
+both rules to substituents. Every ordinary monosaccharide falls through to the catch-all `1 → 0` and is
+placed straight out — in `residue_placements_cfg` too, which has the same shape.
 
-Ordering by position cannot be expressed in that dictionary, which matches one linkage at a time and
-cannot see its siblings. Making the drawing follow the convention needs both halves: candidate
-positions wide enough for a middle branch to exist, and `BookingManager` allocating them in position
-order rather than in the order the children happen to be stored. That reaches every picture the
-application draws, which is why it is written down here before it is attempted.
+*An earlier version of this section said 4 and 6 both match `lp=[4-9]` and are therefore sent to the
+same side. That was read off the rule without checking which children it applies to, and it was wrong.
+It is recorded here rather than quietly removed, because it is the kind of mistake this document exists
+to stop: the dictionary is easy to read as saying more than it does.*
+
+So all of a residue's branches arrive in one region, and the picture is decided by the order that
+region's list is in. That was the order the children happened to be stored — what the sequence said, or
+what somebody drew first. Attaching a bisecting GlcNAc to a finished core appended it and it was
+stacked last, which is the far edge: above the 6-antenna, with the 6-antenna pushed down onto the
+β-Man's own line (#29).
+
+**The fix is in the renderer, not the dictionary.** Ordering by position cannot be expressed in a
+dictionary that matches one linkage at a time and cannot see its siblings.
+`AbstractGlycanRenderer.inPositionOrder` sorts the straight-out region before it is stacked, ascending,
+in all four orientations — which is what three of the four were already doing correctly for a plain
+biantennary core, so a middle branch moves into place and nothing that was already right moves at all.
+
+An unknown position sorts last and keeps the order it came in: there is nothing to compare it with.
 
 ### The anomeric configuration
 


### PR DESCRIPTION
Documentation only. Records where P3 stands and, more usefully, the convention behind #29.

**Branches are ordered by their linkage position** — 3 below, 4 between, 6 above — which is why a
bisecting GlcNAc belongs between the two antennae rather than above them. Confirmed and attributed in
`docs/linkage-positions-and-anomers.md`.

**The placement dictionary cannot express that.** It matches one linkage at a time and cannot see its
siblings, and it sends everything from 4 to 9 to the same side:

```
(!cs)&(!cx)&(lp=[1-3[N]])   -90
(!cs)&(!cx)&(lp=[4-9])       90
```

So the bisecting GlcNAc and the 6-antenna compete for one side and one gives way — measured, the
bisecting ends up above the 6-antenna and the 6-antenna drops to the β-Man's own line.

Following the convention needs two things: candidate positions wide enough for a middle branch to
exist, and `BookingManager` allocating them in position order rather than in the order the children
happen to be stored. That reaches every picture the application draws, so it is written down before
it is attempted rather than after.

Also records #83's outcome: the angle those two shapes took was never used and is gone, which does
not establish that the symbol is orientation-independent — something else in the path still follows
the orientation, and the measurements are on the issue.

No code changes.
