### PR TITLE
Weigh an adduct the way the structure was weighed

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/FragmentEntry.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/FragmentEntry.java
@@ -320,8 +320,10 @@ public class FragmentEntry implements Comparable<FragmentEntry>, SAXUtils.SAXWri
 			fragment.getMassOptions().ION_CLOUD = charges;
 			fragment.getMassOptions().NEUTRAL_EXCHANGES = exchanges;
 			structure = fragment.toString();
-			if( update_mz )
-				mz_ratio = charges.computeMZ(exchanges.getIonsMass() + mass);
+			if( update_mz ) {
+				boolean average = fragment.getMassOptions().isAverage();
+				mz_ratio = charges.computeMZ(exchanges.getIonsMass(average) + mass, average);
+			}
 		}
 	}
 
@@ -331,8 +333,9 @@ public class FragmentEntry implements Comparable<FragmentEntry>, SAXUtils.SAXWri
 	public void updateMass() {
 		IonCloud charges = fragment.getMassOptions().ION_CLOUD;
 		IonCloud exchanges = fragment.getMassOptions().NEUTRAL_EXCHANGES;
+		boolean average = fragment.getMassOptions().isAverage();
 		mass = fragment.computeMass();
-		mz_ratio = charges.computeMZ(exchanges.getIonsMass() + mass);
+		mz_ratio = charges.computeMZ(exchanges.getIonsMass(average) + mass, average);
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -1283,9 +1283,10 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
        Compute the mass-to-charge ratio given the current mass settings.
 	 */
 	public double computeMZ() {
-		double mass = computeMass();		
-		return mass_options.ION_CLOUD.and(mass_options.NEUTRAL_EXCHANGES).computeMZ(mass);
-	}   
+		double mass = computeMass();
+		return mass_options.ION_CLOUD.and(mass_options.NEUTRAL_EXCHANGES)
+				.computeMZ(mass, weighedAsAverage());
+	}
 
 	/**
        Compute the chemical formula for this structure.
@@ -1367,7 +1368,7 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 	 * @return Returns whether {@code ISOTOPE} says average.
 	 */
 	private boolean weighedAsAverage() {
-		return mass_options != null && MassOptions.ISOTOPE_AVG.equals(mass_options.ISOTOPE);
+		return mass_options != null && mass_options.isAverage();
 	}
 
 	/** @return Returns a residue's mass, of the kind this structure is being weighed in. */

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/IonCloud.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/IonCloud.java
@@ -92,11 +92,31 @@ public class IonCloud {
 	 *            the mass of the glycan molecule
 	 */
 	public double computeMZ(double mass) {
+		return computeMZ(mass, false);
+	}
+
+	/**
+	 * Compute the mass/charge value of a structure with a certain mass given the charges in this
+	 * object, weighing the adducts the same way the structure was weighed.
+	 *
+	 * <p>The adducts used to be whatever they were when the ion was <em>set</em>, which is always
+	 * the monoisotopic figure - so an average neutral mass arrived carrying a monoisotopic adduct,
+	 * and the m/z was neither (#203). It matters most for potassium and chloride, +0.135 and +0.484
+	 * per adduct, and is nil for sodium, which has one stable isotope and would let a test pass
+	 * while proving nothing.
+	 *
+	 * @param mass
+	 *            the mass of the glycan molecule
+	 * @param average
+	 *            whether the adducts are to be averaged too, as {@link MassOptions#isAverage} says
+	 */
+	public double computeMZ(double mass, boolean average) {
 		if (mass <= 0.)
 			return mass;
+		double ionsMass = getIonsMass(average);
 		if (ionsNum == 0)
-			return (mass + ionsTotalMass);
-		return (mass + ionsTotalMass) / ionsNum;
+			return (mass + ionsMass);
+		return (mass + ionsMass) / ionsNum;
 	}
 
 	/**
@@ -108,12 +128,27 @@ public class IonCloud {
 	 *            associated charges
 	 */
 	public double computeMass(double mz) {
+		return computeMass(mz, false);
+	}
+
+	/**
+	 * Compute the original mass of a structure with a certain mass/charge value given the charges in
+	 * this object, taking the adducts off in the same weighing they were put on in.
+	 *
+	 * @param mz
+	 *            the mass/charge value of the glycan molecule with the associated charges
+	 * @param average
+	 *            whether the adducts were averaged, as {@link MassOptions#isAverage} says
+	 * @see #computeMZ(double, boolean)
+	 */
+	public double computeMass(double mz, boolean average) {
 		if (mz <= 0.)
 			return mz;
+		double ionsMass = getIonsMass(average);
 		if (ionsNum == 0)
-			return (mz - ionsTotalMass);
+			return (mz - ionsMass);
 
-		return (mz * ionsNum - ionsTotalMass);
+		return (mz * ionsNum - ionsMass);
 	}
 
 	/**
@@ -216,55 +251,28 @@ public class IonCloud {
 	 * has been added
 	 */
 	public IonCloud and(String charge, int quantity) {
-		if (charge.equals(MassOptions.ION_H))
-			return this.and(charge, MassUtils.h_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_LI))
-			return this.and(charge, MassUtils.li_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_NA))
-			return this.and(charge, MassUtils.na_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_K))
-			return this.and(charge, MassUtils.k_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_CL))
-			return this.and(charge, MassUtils.cl_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_H2PO4))
-			return this.and(charge, MassUtils.h2po4_ion.getMass(), quantity);
-		return this.clone();
+		Molecule adduct = moleculeFor(charge);
+		if (adduct == null)
+			return this.clone();
+		return this.and(charge, adduct.getMass(), quantity);
 	}
 
 	/**
 	 * Add a certain quantity of a new charge to this object
 	 */
 	public void add(String charge, int quantity) {
-		if (charge.equals(MassOptions.ION_H))
-			add(charge, MassUtils.h_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_LI))
-			add(charge, MassUtils.li_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_NA))
-			add(charge, MassUtils.na_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_K))
-			add(charge, MassUtils.k_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_CL))
-			add(charge, MassUtils.cl_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_H2PO4))
-			add(charge, MassUtils.h2po4_ion.getMass(), quantity);
+		Molecule adduct = moleculeFor(charge);
+		if (adduct != null)
+			add(charge, adduct.getMass(), quantity);
 	}
 
 	/**
 	 * Set the quantity of a specific charge
 	 */
 	public void set(String charge, int quantity) {
-		if (charge.equals(MassOptions.ION_H))
-			set(charge, MassUtils.h_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_LI))
-			set(charge, MassUtils.li_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_NA))
-			set(charge, MassUtils.na_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_K))
-			set(charge, MassUtils.k_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_CL))
-			set(charge, MassUtils.cl_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_H2PO4))
-			set(charge, MassUtils.h2po4_ion.getMass(), quantity);
+		Molecule adduct = moleculeFor(charge);
+		if (adduct != null)
+			set(charge, adduct.getMass(), quantity);
 	}
 
 	/**
@@ -451,6 +459,56 @@ public class IonCloud {
 	}
 
 	/**
+	 * The total mass of the charges in this object, weighed monoisotopically or on average.
+	 *
+	 * <p>Recomputed from the adducts rather than read off {@link #ionsTotalMass}, which is whatever
+	 * was passed when each ion was set and is therefore always monoisotopic for the six named
+	 * adducts (#203).
+	 *
+	 * <p>A charge added with an explicit mass - a neutral exchange, say - keeps the mass it was
+	 * given. There is no second figure to reach for, and inventing one would be worse than using the
+	 * one the caller supplied.
+	 *
+	 * @param average
+	 *            whether to take each known adduct's average mass rather than its monoisotopic one
+	 */
+	public double getIonsMass(boolean average) {
+		if (!average)
+			return ionsTotalMass;
+
+		double total = 0.;
+		for (Map.Entry<String, Integer> e : this.ions.entrySet()) {
+			Molecule adduct = moleculeFor(e.getKey());
+			double mass = (adduct != null) ? adduct.getAverageMass()
+					: ionNameToChargeMass.getOrDefault(e.getKey(), 0.);
+			total += e.getValue() * mass;
+		}
+		return total;
+	}
+
+	/**
+	 * The molecule for one of the named adducts, or <code>null</code> for a charge this class does
+	 * not know by name.
+	 *
+	 * <p>One place, because adding a seventh adduct used to mean finding six copies of this chain.
+	 */
+	private static Molecule moleculeFor(String charge_name) {
+		if (MassOptions.ION_H.equals(charge_name))
+			return MassUtils.h_ion;
+		if (MassOptions.ION_LI.equals(charge_name))
+			return MassUtils.li_ion;
+		if (MassOptions.ION_NA.equals(charge_name))
+			return MassUtils.na_ion;
+		if (MassOptions.ION_K.equals(charge_name))
+			return MassUtils.k_ion;
+		if (MassOptions.ION_CL.equals(charge_name))
+			return MassUtils.cl_ion;
+		if (MassOptions.ION_H2PO4.equals(charge_name))
+			return MassUtils.h2po4_ion;
+		return null;
+	}
+
+	/**
 	 * Return a map containing the identities and quantities of the charges in
 	 * this object
 	 */
@@ -465,21 +523,9 @@ public class IonCloud {
 	public Molecule getMolecule() throws Exception {
 		Molecule ret = new Molecule();
 		for (Map.Entry<String, Integer> e : this.ions.entrySet()) {
-			String charge = e.getKey();
-			int num = e.getValue();
-
-			if (charge.equals(MassOptions.ION_H))
-				ret.add(MassUtils.h_ion, num);
-			else if (charge.equals(MassOptions.ION_LI))
-				ret.add(MassUtils.li_ion, num);
-			else if (charge.equals(MassOptions.ION_NA))
-				ret.add(MassUtils.na_ion, num);
-			else if (charge.equals(MassOptions.ION_K))
-				ret.add(MassUtils.k_ion, num);
-			else if (charge.equals(MassOptions.ION_CL))
-				ret.add(MassUtils.cl_ion, num);
-			else if (charge.equals(MassOptions.ION_H2PO4))
-				ret.add(MassUtils.h2po4_ion, num);
+			Molecule adduct = moleculeFor(e.getKey());
+			if (adduct != null)
+				ret.add(adduct, e.getValue());
 		}
 		return ret;
 	}

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/MassOptions.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/MassOptions.java
@@ -120,6 +120,19 @@ public class MassOptions {
 	}
 
 	/**
+	 * Whether masses are to be averaged rather than taken monoisotopically.
+	 *
+	 * <p>Asked here rather than compared to {@link #ISOTOPE_AVG} at each site that needs to know,
+	 * because there are several and they must agree: a neutral mass from the average table with an
+	 * adduct from the monoisotopic one gives a figure that is neither (#127, #203).
+	 *
+	 * @return Returns whether {@code ISOTOPE} says average.
+	 */
+	public boolean isAverage() {
+		return ISOTOPE_AVG.equals(ISOTOPE);
+	}
+
+	/**
 	 * Return the type of persubstitution applied to the structure.
 	 */
 	public String getDerivatization() {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AdductIsWeighedLikeTheStructureTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AdductIsWeighedLikeTheStructureTest.java
@@ -1,0 +1,123 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an m/z weighs its adduct the same way it weighed the structure (#203).
+ *
+ * <p>#127 brought the neutral mass under {@code MassOptions.ISOTOPE}. It did not reach the adducts:
+ * {@code IonCloud} captured an ion's mass when the ion was <em>set</em>, which is always the
+ * monoisotopic figure, so an average neutral mass arrived carrying a monoisotopic adduct and the m/z
+ * was neither.
+ *
+ * <p><b>The test is written on potassium and chloride on purpose.</b> Sodium has one stable isotope,
+ * so its average and monoisotopic masses are the same number and a sodiated m/z was right by accident
+ * throughout - a test written on the default adduct would have passed before the fix. Sodium appears
+ * here as the control that says so.
+ *
+ * <p>The expected differences are the atomic ones, from the periodic table rather than from this
+ * code: K 39.0983 against 38.96371, Cl 35.4525 against 34.96885. The electron taken off for the
+ * charge is a constant and cancels.
+ */
+public class AdductIsWeighedLikeTheStructureTest {
+
+	/** Man₃GlcNAc₂, the N-glycan core: 910.3278 monoisotopic, 910.82 average. */
+	private static final String CORE =
+			"freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p--4b1D-Man,p--3b1D-Man,p--?b1D-Man,p";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * A potassiated m/z gains the adduct's average-minus-monoisotopic difference on top of the
+	 * structure's own.
+	 *
+	 * <p>This is the assertion that fails without the fix, by 0.1346 - small, never zero, and
+	 * plausible at every digit somebody would think to check.
+	 */
+	@Test
+	public void potassiumIsAveragedToo() {
+		assertEquals("the potassium adduct is still monoisotopic in an average m/z",
+				0.134594, adductContributionToTheAverage(MassOptions.ION_K), 0.001);
+	}
+
+	/** Chloride is the same fault at four times the size. */
+	@Test
+	public void chlorideIsAveragedToo() {
+		assertEquals("the chloride adduct is still monoisotopic in an average m/z",
+				0.483685, adductContributionToTheAverage(MassOptions.ION_CL), 0.001);
+	}
+
+	/**
+	 * Sodium contributes nothing, having one stable isotope — the control.
+	 *
+	 * <p>If this ever fails, the adduct is being averaged against something that is not the atom.
+	 */
+	@Test
+	public void sodiumHasNothingToAverage() {
+		assertEquals("sodium has one stable isotope and cannot differ",
+				0., adductContributionToTheAverage(MassOptions.ION_NA), 0.0001);
+	}
+
+	/**
+	 * And the monoisotopic m/z is unchanged, which is the half that matters more.
+	 *
+	 * <p>Man₃GlcNAc₂ 910.3278 plus a sodium ion, 22.98977 less the electron.
+	 */
+	@Test
+	public void theMonoisotopicMZIsUnchanged() {
+		assertEquals(933.3170, mz(MassOptions.ISOTOPE_MONO, MassOptions.ION_NA), 0.001);
+		assertEquals(949.2911, mz(MassOptions.ISOTOPE_MONO, MassOptions.ION_K), 0.001);
+	}
+
+	/**
+	 * How much of the m/z's average-minus-monoisotopic gap the adduct is responsible for.
+	 *
+	 * <p>The structure's own gap is subtracted, so what is left is the adduct's alone and can be
+	 * compared against the periodic table.
+	 */
+	private static double adductContributionToTheAverage(String ion) {
+		double mzGap = mz(MassOptions.ISOTOPE_AVG, ion) - mz(MassOptions.ISOTOPE_MONO, ion);
+		double massGap = mass(MassOptions.ISOTOPE_AVG) - mass(MassOptions.ISOTOPE_MONO);
+		return mzGap - massGap;
+	}
+
+	private static double mz(String isotope, String ion) {
+		return weigh(isotope, ion).computeMZ();
+	}
+
+	private static double mass(String isotope) {
+		return weigh(isotope, null).computeMass();
+	}
+
+	private static Glycan weigh(String isotope, String ion) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		try {
+			document.importFromString(CORE, "gws");
+		} catch (Exception cannotRead) {
+			throw new IllegalStateException(CORE, cannotRead);
+		}
+
+		Glycan glycan = document.getStructures().get(0);
+		MassOptions options = glycan.getMassOptions();
+		options.DERIVATIZATION = MassOptions.NO_DERIVATIZATION;
+		options.ISOTOPE = isotope;
+		options.ION_CLOUD = new IonCloud();
+		if (ion != null)
+			options.ION_CLOUD.set(ion, 1);
+		glycan.setMassOptions(options);
+
+		return glycan;
+	}
+}


### PR DESCRIPTION
Closes #203.

`MassOptions.ISOTOPE` reached the residues, the water taken off per bond, an alditol's hydrogens and the
derivatization in 1.36.0 (#127). It did not reach the ion adducts, so an m/z could pair an average
neutral mass with a monoisotopic adduct — a figure that is neither.

## Why it could not reach them

`IonCloud` captured an adduct's mass when the ion was **set** rather than when the mass was
**computed**:

```java
if (charge.equals(MassOptions.ION_H))
    add(charge, MassUtils.h_ion.getMass(), quantity);   // always monoisotopic
```

`computeMZ` then only added the total it had been handed. The adduct was decided before anything knew
which isotope table the answer was supposed to come from.

## What changed

- `computeMZ` and `computeMass` take the same *average?* flag the rest of the mass path takes, and
  `getIonsMass(boolean)` recomputes the total from the adducts instead of reading the captured figure.
- A charge added with an explicit mass — a neutral exchange — keeps the mass it was given. There is no
  second figure for it, and inventing one would be worse than using the caller's.
- The *are we averaging* question moved onto `MassOptions.isAverage()`, because the several sites that
  ask it have to agree; a neutral mass from one table with an adduct from the other is the mixture #127
  rejected.
- `Glycan.computeMZ` and both `FragmentEntry` m/z sites pass it through.

## The test, and why it is written on potassium

`AdductIsWeighedLikeTheStructureTest` asserts how much of the m/z's average-minus-monoisotopic gap the
adduct is responsible for, against the periodic table rather than against this code:

| Adduct | Difference |
|---|---|
| K | +0.134594 |
| Cl | +0.483685 |
| Na | 0 — one stable isotope |

**Sodium is the control.** It has a single stable isotope, so a sodiated m/z — the default — was right
by accident throughout, and a test written on it would have passed before this change. Without the fix
the potassium assertion reads `0.0` where it should read `0.134594`.

The monoisotopic m/z is pinned unchanged, which is the half that matters more.

## Also

The six-way `if` chain over adduct names existed four times over — `and`, `add`, `set`, `getMolecule` —
which is a fair part of why the isotope reached none of them. One `moleculeFor(name)` now.

172 tests pass. No version bump: this is a sub-branch for `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)