### PR TITLE
Let a repeat keep the position it closes on

### DIFF
--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
@@ -178,6 +178,17 @@ public class LinkageConnector {
 		a_oEndRep.setStartResidue(this.start);
 		a_oRES.setEndRepitionResidue(a_oEndRep);
 
+		/*
+		 * The marker has to carry the position the repeat closes on before it is added as a child
+		 * (#204). addChild rebuilds the linkage from the bonds and finishes by taking the child's own
+		 * anomeric carbon, which for a freshly created marker is '?' - so the position GLINToLinkage
+		 * had just worked out was read back over, and l1-m3~n was written out as l?-m3~n.
+		 *
+		 * makeEdgeWithStartBracket has always done this for the opening marker. Only this side was
+		 * missing it.
+		 */
+		a_oEndRep.setAnomericCarbon(a_oG2L.getEndSideRepLinkage().getAnomericCarbon());
+
 		// sugar->sub->EndRep
 		if(a_oG2L.getEndSideRepLinkage().getChildResidue() != null) {
 			a_oSUB = a_oG2L.getEndSideRepLinkage().getChildResidue();

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RepeatKeepsItsLinkagePositionTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RepeatKeepsItsLinkagePositionTest.java
@@ -1,0 +1,74 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That the position a repeat closes on survives a round trip (#204).
+ *
+ * <p>It did not: {@code l1-m3~n} was read in and written back as {@code l?-m3~n}. Every other linkage
+ * in the sequence round-tripped. {@code ?} is not a rounding of {@code 1} — it is the sequence saying
+ * the position is unknown, about a position the input had stated, so the export said less than the
+ * import and said it in a form that looks deliberate.
+ *
+ * <p><b>Where it went.</b> {@code addChild} rebuilds a linkage from its bonds and finishes by taking
+ * the child residue's own anomeric carbon. The closing marker is created fresh and has none, so the
+ * position {@code GLINToLinkage} had just worked out from the donor side was read back over with
+ * {@code '?'}. The opening marker never had the problem, because
+ * {@code makeEdgeWithStartBracket} sets its anomeric carbon before adding it; only the closing side
+ * was missing that line.
+ */
+public class RepeatKeepsItsLinkagePositionTest {
+
+	/**
+	 * G03246MZ, the structure the fault was found on while measuring #57 — a repeating unit inside an
+	 * N-glycan antenna.
+	 */
+	private static final String G03246MZ = "WURCS=2.0/7,15,15/[h2122h_2*NCC/3=O]"
+			+ "[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5]"
+			+ "[Aad21122h-2a_2-6_5*NCC/3=O][a1221m-1a_1-5]/1-2-3-4-2-5-6-2-5-6-4-2-5-6-7/"
+			+ "a4-b1_a6-o1_b4-c1_c3-d1_c6-k1_d2-e1_d4-h1_e4-f1_f3-g2_h4-i1_i3-j2_k2-l1_l4-m1_m3-n2"
+			+ "_l1-m3~n";
+
+	/**
+	 * A repeat and nothing else, so a failure here cannot be blamed on anything around it: GlcNAc
+	 * and GlcA repeating through {@code a1-b3}.
+	 */
+	private static final String REPEAT_ALONE =
+			"WURCS=2.0/2,2,2/[a2122h-1b_1-5_2*NCC/3=O][a2122A-1b_1-5]/1-2/a4-b1_a1-b3~n";
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * The smallest case: the repeat's own position comes back as it went in.
+	 *
+	 * <p>Without the fix this reads {@code a?-b3~n}.
+	 */
+	@Test
+	public void aRepeatAloneKeepsItsPosition() throws Exception {
+		assertRoundTrip(REPEAT_ALONE);
+	}
+
+	/** And in the structure it was reported on, where the repeat sits inside an antenna. */
+	@Test
+	public void aRepeatInsideAnAntennaKeepsItsPosition() throws Exception {
+		assertRoundTrip(G03246MZ);
+	}
+
+	private void assertRoundTrip(String wurcs) throws Exception {
+		WURCS2Parser parser = new WURCS2Parser();
+		Glycan glycan = parser.readGlycan(wurcs, new MassOptions());
+		assertEquals("the position the repeat closes on did not survive", wurcs,
+				parser.writeGlycan(glycan));
+	}
+}


### PR DESCRIPTION
Closes #204.

`l1-m3~n` was read in and written back as `l?-m3~n`. Every other linkage in the sequence round-tripped.

```
in    ..._k2-l1_l4-m1_m3-n2_l1-m3~n
out   ..._k2-l1_l4-m1_m3-n2_l?-m3~n
```

`?` is not a rounding of `1` — it is the sequence saying the position is unknown, about a position the
input had stated. Anything reading the export is told less than the import said, in a form that looks
deliberate.

## Where it went

`addChild` rebuilds a linkage from its bonds and finishes by taking the child residue's own anomeric
carbon:

```java
public void setLinkagePositions(Collection<Bond> _bonds) {
    ...
    if( child!=null ) setAnomericCarbon(child.getAnomericCarbon());
}
```

The closing marker is created fresh by `ResidueDictionary.createEndRepetition` and has no anomeric
carbon, so the `'?'` it was born with was written straight over the position `GLINToLinkage` had just
worked out from the donor side.

**The opening marker never had this problem**, because `makeEdgeWithStartBracket` sets its anomeric
carbon before adding it:

```java
a_oStartRep.setAnomericCarbon(a_oRES.getAnomericCarbon());
a_oStartRep.addChild(a_oRES, ...);
```

Only the closing side was missing that line — which is why one end of a repeat survived and the other
did not.

## Measured

G03246MZ, the structure it was found on while measuring #57: the export now equals the import,
character for character.

`RepeatKeepsItsLinkagePositionTest` asserts that, and also a repeat with nothing else around it
(`a4-b1_a1-b3~n`) so that a failure cannot be blamed on the antenna it sits in. Without the change both
read `l?` / `a?`.

174 tests pass. No version bump: this is a sub-branch for `develop`.

**Note for #57**, which is where this was found and is still open: this is not that bug. #57 reports a
3 shown where the model holds 2, which is between the model and the picture. This was information
dropped on the way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
