### PR TITLE
Draw branches in the numeric order of their linkage positions

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
@@ -15,6 +15,7 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.text.DecimalFormat;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -692,6 +693,61 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		return text.toString();
 	}
 
+	/**
+	 * The children of one region, in the numeric order of the positions they attach at.
+	 *
+	 * <p><b>Why the order matters.</b> Every ordinary monosaccharide is placed straight out by
+	 * {@code residue_placements_snfg} and {@code residue_placements_cfg} — the rules that pick a side
+	 * from the linkage position apply to substituents, and a saccharide child falls through to the
+	 * catch-all {@code 1 → 0}. So all the branches of one residue arrive in a single region and are
+	 * stacked in the order this list happens to be in, which until now was the order the children were
+	 * stored: whatever the sequence said, or the order somebody drew them in.
+	 *
+	 * <p>That is what #29 is. Drawing a biantennary core and then attaching a GlcNAc to the β-Man's 4
+	 * appended it to the list, so it was stacked last and came out at the far edge — above the
+	 * 6-antenna rather than between the two antennae. Measured on 1.37.0, default orientation: the
+	 * 6-antenna fell from y=30 to y=82 and the new GlcNAc took y=30.
+	 *
+	 * <p><b>The convention.</b> Branches are drawn in the numeric order of their linkage positions, so
+	 * a bisecting GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft's
+	 * {@code LAYOUT_ALGORITHM.md} states the same rule and gives worked coordinates: α1-6 Man above,
+	 * the bisecting GlcNAc level with its parent, α1-3 Man below.
+	 *
+	 * <p><b>Ascending, in every orientation.</b> The four orientations stack a region from opposite
+	 * ends — LR downwards, RL upwards, TB leftwards, BT rightwards — so the same ascending list lands
+	 * differently in each. Ascending is what each of them was already doing correctly for a plain
+	 * biantennary core, in the three orientations that had it right, so ordering by position fixes
+	 * where a middle branch goes without moving anything that was already where it belonged.
+	 *
+	 * <p>An unknown position sorts last and keeps the order it came in: there is nothing to compare it
+	 * with, and moving it would be a guess dressed as a rule.
+	 */
+	private LinkedList<Residue> inPositionOrder(LinkedList<Residue> children) {
+		if (children.size() < 2) return children;
+
+		// A stable sort, so children that cannot be compared stay as they were.
+		children.sort(Comparator.comparingInt(AbstractGlycanRenderer::linkagePositionOf));
+		return children;
+	}
+
+	/**
+	 * The position a residue attaches to its parent at, for ordering.
+	 *
+	 * @return Returns the position as a number, or {@link Integer#MAX_VALUE} when there is no single
+	 *         known position — no parent, an unknown position, or several candidates, none of which
+	 *         says where the branch belongs.
+	 */
+	private static int linkagePositionOf(Residue residue) {
+		Linkage link = residue.getParentLinkage();
+		if (link == null) return Integer.MAX_VALUE;
+
+		Collection<Character> positions = link.getParentPositions();
+		if (positions == null || positions.size() != 1) return Integer.MAX_VALUE;
+
+		char position = positions.iterator().next();
+		return Character.isDigit(position) ? Character.getNumericValue(position) : Integer.MAX_VALUE;
+	}
+
 	private void computeBoundingBoxes(Residue node, PositionManager posManager,
 									  BBoxManager bboxManager, boolean _isComposition) throws Exception {
 		if (node == null) return;
@@ -762,7 +818,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (right)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0));
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0)));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager, _isComposition);
 			if (i > 0)
@@ -887,7 +943,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (left)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0), false);
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0), false));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager ,_isComposition);
 			if (i > 0)
@@ -1019,7 +1075,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (bottom)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0));
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0)));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager, _isComposition);
 			if (i > 0)
@@ -1145,7 +1201,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (top)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0));
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0)));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager, _isComposition);
 			if (i > 0)

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/BranchesAreDrawnInPositionOrderTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/BranchesAreDrawnInPositionOrderTest.java
@@ -1,0 +1,202 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.linkage.Linkage;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a branch goes where its linkage position says, not where the drawing order left it (#29).
+ *
+ * <p>Every ordinary monosaccharide is placed straight out — the placement rules that pick a side from
+ * the linkage position apply to substituents, and a saccharide child falls through to the catch-all.
+ * So all of a residue's branches arrive in one region and are stacked in the order the children are
+ * stored, which was the order the sequence listed them or the order somebody drew them in.
+ *
+ * <p>Attaching a GlcNAc to the β-Man's 4 of a finished biantennary core therefore appended it, and it
+ * was stacked last: at the far edge, above the 6-antenna, rather than between the two antennae. The
+ * convention is that branches are drawn in the numeric order of their positions, so a bisecting
+ * GlcNAc at 4 belongs between the 3- and 6-antennae (I. Yamada, 2026-08-14), which is also what
+ * GlycoCraft's layout document states.
+ *
+ * <p>These assertions are about order along the axis the branches stack on, not about coordinates. A
+ * test pinned to y=30 and y=82 would fail on any change to spacing and would say nothing about what
+ * had gone wrong.
+ */
+public class BranchesAreDrawnInPositionOrderTest {
+
+	private static final String RESIDUES =
+			"[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]";
+
+	/** A biantennary N-glycan core: antennae at the β-Man's 3 and 6. */
+	private static final String CORE =
+			"WURCS=2.0/3,5,4/" + RESIDUES + "/1-1-2-3-3/a4-b1_b4-c1_c3-d1_c6-e1";
+
+	/** The same with a bisecting GlcNAc at 4, stated in the sequence. */
+	private static final String BISECTED =
+			"WURCS=2.0/3,6,5/" + RESIDUES + "/1-1-2-3-1-3/a4-b1_b4-c1_c3-d1_c4-e1_c6-f1";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * The bisecting GlcNAc sits between the two antennae, in the default orientation.
+	 *
+	 * <p>Without the fix it is above both of them: measured on 1.37.0, the 6-antenna fell from y=30 to
+	 * y=82 and the new GlcNAc took y=30.
+	 */
+	@Test
+	public void aBisectingGlcNAcSitsBetweenTheAntennae() throws Exception {
+		Glycan structure = coreWithGlcNAcAddedAfterwards();
+
+		int sixAntenna = topOf(structure, branchAt(structure, '6'));
+		int bisecting = topOf(structure, branchAt(structure, '4'));
+		int threeAntenna = topOf(structure, branchAt(structure, '3'));
+
+		assertTrue("the 6-antenna should be above the bisecting GlcNAc, and is at " + sixAntenna
+				+ " against " + bisecting, sixAntenna < bisecting);
+		assertTrue("the bisecting GlcNAc should be above the 3-antenna, and is at " + bisecting
+				+ " against " + threeAntenna, bisecting < threeAntenna);
+	}
+
+	/**
+	 * It is drawn level with the residue it hangs off, which is what "straight out" means.
+	 *
+	 * <p>GlycoCraft states this as the rule for position 4 and gives the coordinate: the bisecting
+	 * GlcNAc on the parent's own line, an antenna above and an antenna below.
+	 */
+	@Test
+	public void aBisectingGlcNAcIsLevelWithItsParent() throws Exception {
+		Glycan structure = coreWithGlcNAcAddedAfterwards();
+
+		assertEquals("the bisecting GlcNAc should be on the β-Man's own line",
+				topOf(structure, betaMan(structure)), topOf(structure, branchAt(structure, '4')));
+	}
+
+	/**
+	 * Adding it afterwards gives the same picture as stating it in the sequence.
+	 *
+	 * <p>This is what the issue reports — that it depends on when you attach it — and it is the whole
+	 * of the rule: the picture follows the molecule, not the order it was assembled in.
+	 */
+	@Test
+	public void whenItWasAddedMakesNoDifference() throws Exception {
+		Glycan added = coreWithGlcNAcAddedAfterwards();
+		Glycan stated = wurcs(BISECTED);
+
+		assertEquals("stating the GlcNAc in the sequence and adding it afterwards draw differently",
+				rowsOf(stated), rowsOf(added));
+	}
+
+	/**
+	 * And a plain biantennary core is where it always was: 6-antenna above, 3-antenna below.
+	 *
+	 * <p>The way to make the assertions above pass wrongly is to reverse the stacking, which would move
+	 * every branch in every structure. This is the half that says nothing else moved.
+	 */
+	@Test
+	public void aPlainCoreIsUnchanged() throws Exception {
+		Glycan structure = wurcs(CORE);
+
+		assertTrue("the 6-antenna should be above the 3-antenna",
+				topOf(structure, branchAt(structure, '6')) < topOf(structure, branchAt(structure, '3')));
+	}
+
+	/** The core as imported, with a GlcNAc then attached to the β-Man's 4 — the path #29 describes. */
+	private static Glycan coreWithGlcNAcAddedAfterwards() throws Exception {
+		Glycan structure = wurcs(CORE);
+
+		assertTrue("the GlcNAc was refused at the β-Man's 4",
+				betaMan(structure).addChild(ResidueDictionary.newResidue("GlcNAc"), '4'));
+
+		return structure;
+	}
+
+	/**
+	 * Which residue is drawn on which row, so two layouts can be compared as a whole.
+	 *
+	 * <p>Sorted, because the two structures are walked in different orders — the same picture described
+	 * from two directions is the same picture, and comparing the walk would be comparing the wrong
+	 * thing.
+	 */
+	private static List<String> rowsOf(Glycan structure) throws Exception {
+		BBoxManager boxes = boxes(structure);
+
+		List<String> rows = new ArrayList<String>();
+		for (Residue residue : structure.getAllResidues()) {
+			Rectangle box = boxes.getCurrent(residue);
+			if (box == null || residue.getParentLinkage() == null) continue;
+			rows.add(residue.getTypeName() + "@" + positionOf(residue) + ":" + box.y);
+		}
+		Collections.sort(rows);
+
+		return rows;
+	}
+
+	/** Where the top edge of a residue ends up. */
+	private static int topOf(Glycan structure, Residue residue) throws Exception {
+		Rectangle box = boxes(structure).getCurrent(residue);
+		assertTrue(residue.getTypeName() + " was not laid out", box != null);
+		return box.y;
+	}
+
+	/**
+	 * The branch point: the Man carrying more than one child.
+	 *
+	 * <p>Found by its children rather than by name and position. The chitobiose core has a GlcNAc at
+	 * position 4 as well, and an earlier version of this test picked that one up and compared the wrong
+	 * pair of residues — it failed without the change, but for the wrong reason.
+	 */
+	private static Residue betaMan(Glycan structure) {
+		for (Residue residue : structure.getAllResidues())
+			if ("Man".equals(residue.getTypeName()) && residue.getNoChildren() >= 2)
+				return residue;
+		throw new IllegalStateException("no branch point");
+	}
+
+	/** The β-Man's child at one of its positions — an antenna, or the bisecting GlcNAc. */
+	private static Residue branchAt(Glycan structure, char position) {
+		for (Linkage link : betaMan(structure).getChildrenLinkages())
+			if (positionOf(link.getChildResidue()) == position)
+				return link.getChildResidue();
+		throw new IllegalStateException("the branch point has nothing at " + position);
+	}
+
+	private static char positionOf(Residue residue) {
+		Linkage link = residue.getParentLinkage();
+		if (link == null || link.getParentPositions().size() != 1) return '?';
+		return link.getParentPositions().iterator().next();
+	}
+
+	private static BBoxManager boxes(Glycan structure) throws Exception {
+		GlycanRendererAWT renderer = new GlycanRendererAWT();
+		BBoxManager boxes = new BBoxManager();
+		renderer.computeBoundingBoxes(Collections.singletonList(structure), false, false,
+				new PositionManager(), boxes);
+		return boxes;
+	}
+
+	private static Glycan wurcs(String sequence) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS would not import", document.importFromString(sequence, "wurcs2"));
+
+		return document.getStructures().get(0);
+	}
+}


### PR DESCRIPTION
Closes #29.

Attaching a GlcNAc to the β-Man's 4 of a finished biantennary core put it **above** the 6-antenna
instead of between the two antennae, and pushed the 6-antenna down onto its parent's line.

Measured on 1.37.0, default orientation:

| | before | after |
|---|---|---|
| 6-antenna Man | y=82 | **y=30** |
| bisecting GlcNAc | y=30 | **y=82** — level with its β-Man |
| 3-antenna Man | y=134 | y=134 |

which is the arrangement GlycoCraft's `LAYOUT_ALGORITHM.md` gives: α1-6 Man above, the bisecting GlcNAc
straight out, α1-3 Man below.

## Why it happened

Every ordinary monosaccharide is placed straight out. The placement rules that pick a side from the
linkage position apply to **substituents** — `(!cs)` reads "child is not a monosaccharide" — so a
saccharide child falls through to the catch-all `1 → 0`, in `residue_placements_snfg` and
`residue_placements_cfg` alike.

All of a residue's branches therefore arrive in one region and are stacked in the order that list
happens to be in, which was the order the children were stored: whatever the sequence said, or the
order somebody drew them in. Adding one afterwards appended it, so it was stacked last — the far edge.
That is why the issue is phrased as *"if you add bisecting GlcNAc after drawing"*: importing the same
molecule from a sequence drew it correctly, because the sequence happened to list the children in a
different order.

## The rule

Branches are drawn in the numeric order of their linkage positions, so a bisecting GlcNAc at 4 belongs
between the 3- and 6-antennae — I. Yamada, on the issue, 2026-08-14.

**Ascending, in every orientation.** The four stack a region from opposite ends — LR downwards, RL
upwards, TB leftwards, BT rightwards — so a single ascending list lands differently in each. Ascending
is what three of the four were *already* doing correctly for a plain biantennary core, so ordering by
position moves a middle branch into place without moving anything that was already where it belonged.
Verified in all four: the plain core is byte-identical before and after, and the bisecting GlcNAc sits
between the antennae in each.

An unknown position sorts last and keeps the order it came in. There is nothing to compare it with, and
moving it would be a guess dressed as a rule.

## The test

`BranchesAreDrawnInPositionOrderTest` asserts order along the stacking axis rather than coordinates — a
test pinned to y=30 would fail on any spacing change and say nothing about what broke. Four
assertions, three of which fail without the change:

- the bisecting GlcNAc is between the two antennae;
- it is level with its β-Man, which is what "straight out" means;
- **adding it afterwards draws the same picture as stating it in the sequence** — the whole of the rule;
- a plain biantennary core is unchanged, which is the half that says nothing else moved.

An earlier version of that test identified the bisecting GlcNAc by name and position and picked up the
chitobiose core's GlcNAc, which is also at 4. It failed without the change, for the wrong reason. It
finds the branch point by its children now.

## A correction this carries

My earlier comment on #29 said 4 and 6 both match `lp=[4-9]` and are sent to the same side. That was
read off the rule without checking that it applies to substituents only, and it is wrong.
`docs/linkage-positions-and-anomers.md` still carries that version on the branch of #202 and wants
correcting there.

172 tests pass. No version bump: this is a sub-branch for `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
