### PR TITLE
Convert each structure once when exporting, not twice

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
@@ -1336,12 +1336,9 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 		try {
 			String str_encode = "";
 			GlycanParser parser = GlycanParserFactory.getParser(format);
-			str_encode = toString(a_lstGlycan, parser);
-			if (str_encode.equals("")) throw new Exception("Invalid output string");
-
 			this.lastExportFailures = new ArrayList<Glycan>();
-			for (Glycan g : a_lstGlycan)
-				if (parser.writeGlycan(g).equals("")) this.lastExportFailures.add(g);
+			str_encode = toString(a_lstGlycan, parser, null, this.lastExportFailures);
+			if (str_encode.equals("")) throw new Exception("Invalid output string");
 
 			for (String s : str_encode.split(";")) this.lst_encode.addLast(s);
 			return true;
@@ -1381,12 +1378,9 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 
 			// serialize structures
 			GlycanParser parser = GlycanParserFactory.getParser(format);
-			String str = toString(parser);
-			if (str == null) throw new Exception("Invalid output string");
-
 			this.lastExportFailures = new ArrayList<Glycan>();
-			for (Glycan g : structures)
-				if (parser.writeGlycan(g).equals("")) this.lastExportFailures.add(g);
+			String str = toString(structures, parser, null, this.lastExportFailures);
+			if (str == null) throw new Exception("Invalid output string");
 
 			// write to file
 			bw.write(str, 0, str.length());
@@ -1518,30 +1512,68 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	 */
 	static public String toString(Collection<Glycan> structures,
 								  GlycanParser parser, BBoxManager bboxManager) {
+		return toString(structures, parser, bboxManager, null);
+	}
+
+	/**
+	 * Create a string representation of the specified structures using the given parser, noting which
+	 * of them produced nothing.
+	 *
+	 * <p><b>Why the failures are collected here.</b> The callers used to write everything once for the
+	 * file and then write it all again to find out which structures had come out empty. A structure
+	 * that cannot be converted reports that on the way through - a message naming what it could not
+	 * encode, and the exception under it - so writing it twice said it all twice, and a workspace with
+	 * two bad structures produced four dialogs to dismiss (#183).
+	 *
+	 * <p>One pass, and the emptiness noticed as it happens.
+	 *
+	 * @param failures
+	 *            filled with the structures that produced no output, or {@code null} to not ask
+	 */
+	static public String toString(Collection<Glycan> structures, GlycanParser parser,
+								  BBoxManager bboxManager, Collection<Glycan> failures) {
 
 		String str = "";
 		if (parser instanceof GWSParser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
-				str += parser.writeGlycan(i.next(), bboxManager);
+				Glycan structure = i.next();
+				str += record(parser.writeGlycan(structure, bboxManager), structure, failures);
 				if (i.hasNext()) str += ";";
 			}
 		} else if (parser instanceof WURCS2Parser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
-				str += parser.writeGlycan(i.next());
+				Glycan structure = i.next();
+				str += record(parser.writeGlycan(structure), structure, failures);
 				if (i.hasNext()) str += "\n";
 			}
 		} else {
+			// These formats hold one structure, so only the first is written - and the rest are
+			// therefore absent from the file, which is what the caller warns about.
+			Glycan first = structures.isEmpty() ? null : structures.iterator().next();
 			if (bboxManager != null) { //At the moment this will force conversion to GlycoCT_XML
-				str = parser.writeGlycan(structures.isEmpty() ? null : structures
-						.iterator().next(), bboxManager);
+				str = record(parser.writeGlycan(first, bboxManager), first, failures);
 			} else {
-				str = parser.writeGlycan(structures.isEmpty() ? null : structures
-						.iterator().next());
+				str = record(parser.writeGlycan(first), first, failures);
 			}
-
+			if (failures != null)
+				for (Glycan unwritten : structures)
+					if (unwritten != first && !failures.contains(unwritten)) failures.add(unwritten);
 		}
 
 		return str;
+	}
+
+	/**
+	 * Note a structure as a failure when it encoded to nothing, and hand the encoding straight back.
+	 *
+	 * <p>Returned unchanged, null included: {@code exportTo} tells a null apart from an empty string
+	 * and refuses the export on it, and turning one into the other here would write an empty file
+	 * without saying so.
+	 */
+	static private String record(String encoded, Glycan structure, Collection<Glycan> failures) {
+		if (failures != null && structure != null && (encoded == null || encoded.isEmpty()))
+			failures.add(structure);
+		return encoded;
 	}
 
 	public void fromString(String str, String format) throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OneMessagePerFailedExportTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OneMessagePerFailedExportTest.java
@@ -1,0 +1,126 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a structure which cannot be exported is only converted once (#183).
+ *
+ * <p>The export wrote everything for the file and then wrote it all over again to find out which
+ * structures had come out empty. A structure that cannot be converted says so on the way through, and
+ * {@code LogUtils.report} answers one failure with two windows — the message, then the stack — so a
+ * second pass produced a second pair. That is the "two sets (error+exception)" per failed structure the
+ * report describes, and with two bad structures, four.
+ *
+ * <p><b>The count is what this tests.</b> Asserting on dialogs would mean driving Swing; asserting that
+ * each structure is handed to the parser exactly once says the same thing about the cause, and it was
+ * the cause that was doubled.
+ *
+ * <p><b>The sequence in the report no longer fails.</b> {@code WURCS=2.0/1,1,0/[A111h]/1/} writes back
+ * unchanged as of 1.37.0, so the skeleton-code error it was reported with is gone and those steps
+ * produce no dialogs at all. The doubling was still there to be found by reading, and would have
+ * doubled the next failure just as well — which is why it is fixed here rather than closed as
+ * not-reproducible.
+ */
+public class OneMessagePerFailedExportTest {
+
+	private static final String ORDINARY_GLYCAN =
+			"freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd";
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * Each structure is handed to the parser once, whether it converts or not.
+	 *
+	 * <p>Before the change this counted two per structure.
+	 */
+	@Test
+	public void everyStructureIsConvertedOnce() throws Exception {
+		CountingParser parser = new CountingParser();
+		GlycanDocument.toString(twoStructures(), parser, null, new ArrayList<Glycan>());
+
+		assertEquals("each structure should be converted once", 2, parser.calls);
+	}
+
+	/** The ones that produced nothing are still named, which is what the warning dialog reads. */
+	@Test
+	public void theEmptyOnesAreStillNamed() throws Exception {
+		LinkedList<Glycan> structures = twoStructures();
+		Glycan bad = structures.getLast();
+
+		CountingParser parser = new CountingParser();
+		parser.silentAbout = bad;
+		List<Glycan> failures = new ArrayList<Glycan>();
+		GlycanDocument.toString(structures, parser, null, failures);
+
+		assertEquals("the structure that produced nothing should be named once", 1, failures.size());
+		assertTrue("the wrong structure was named", failures.contains(bad));
+		assertEquals("and it should still have been converted only once", 2, parser.calls);
+	}
+
+	/**
+	 * An ordinary export is unaffected: both structures in the file, nothing reported as failed.
+	 *
+	 * <p>Through the real writer, since the point of collecting the failures during the single pass is
+	 * that it still fills in what the warning needs.
+	 */
+	@Test
+	public void anOrdinaryExportStillWritesEverything() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.importFromString(ORDINARY_GLYCAN, "gws"));
+		assertTrue(document.importFromString("WURCS=2.0/1,1,0/[A111h]/1/", "wurcs2"));
+
+		File file = File.createTempFile("glycanbuilder-183-", ".wurcs");
+		file.deleteOnExit();
+		assertTrue("the export failed outright", document.exportTo(file.getAbsolutePath(), "wurcs2"));
+
+		String written = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+		assertEquals("both structures should have been written",
+				2, written.trim().split("\\R").length);
+		assertTrue("nothing should have been reported as failed: "
+				+ document.getLastExportFailures(), document.getLastExportFailures().isEmpty());
+	}
+
+	private static LinkedList<Glycan> twoStructures() throws Exception {
+		LinkedList<Glycan> structures = new LinkedList<Glycan>();
+		structures.add(Glycan.fromString(ORDINARY_GLYCAN));
+		structures.add(Glycan.fromString(ORDINARY_GLYCAN));
+		return structures;
+	}
+
+	/**
+	 * Counts what it is asked to write, and can be told to produce nothing for one structure.
+	 *
+	 * <p>A {@link WURCS2Parser} rather than a bare {@code GlycanParser}, because the encoder picks its
+	 * loop by the parser's type and only the sequence formats write more than the first structure.
+	 */
+	private static final class CountingParser extends WURCS2Parser {
+
+		private int calls;
+		private Glycan silentAbout;
+
+		@Override
+		public String writeGlycan(Glycan structure) {
+			calls++;
+			return (structure == silentAbout) ? "" : "written";
+		}
+	}
+}


### PR DESCRIPTION
For #183. Please read the last section before merging — the reported symptom does not reproduce, and I
have fixed the mechanism rather than the report.

## The doubling

`exportTo` and `exportFromStructure` wrote every structure for the file, then wrote them **all again**
purely to find out which had come out empty:

```java
String str = toString(parser);                    // writes every structure
...
for (Glycan g : structures)
    if (parser.writeGlycan(g).equals("")) ...     // and writes every structure again
```

A structure that cannot be converted says so on the way through, and one `LogUtils.report` answers a
single failure with **two** windows — the message, then a `ReportDialog` with the stack:

```java
JOptionPane.showMessageDialog(null, e.getMessage(), "Error in GlycanBuilder2", ERROR_MESSAGE);
new ReportDialog(..., getLastStackError()).setVisible(true);
```

So one failure is one "set (error+exception)", and the second pass produced a second set. Two bad
structures, four sets — exactly the arithmetic in the report.

## The change

`toString` collects the failures as it encodes, so there is one pass. Callers pass a collection to fill
and drop their second loop.

Two things kept deliberately:

- **The encoding is handed back untouched, null included.** `exportTo` tells a null apart from an empty
  string and refuses the export on it; smoothing that over would write an empty file without saying so,
  which is the fault #185 was about.
- **The single-structure formats keep the warning they had.** Only the first structure is written in
  that branch, so the others are genuinely absent from the file and are recorded as such — without
  being handed to the parser to find that out, which is what the old loop did.

## The tests

`OneMessagePerFailedExportTest` pins the new contract: each structure is handed to the parser once, the
ones that produced nothing are still named, and an ordinary export still writes everything with nothing
reported as failed.

**These do not fail before the change** — they cannot. The doubling was in the callers, and the callers
build their own parser from `GlycanParserFactory`, so a counting parser cannot observe them without
dependency injection I would not add for this. The deleted second loop is the evidence, and it is plain
in the diff. The tests are here to hold the single-pass contract from now on.

## What does not reproduce

**`WURCS=2.0/1,1,0/[A111h]/1/` writes back unchanged as of 1.37.0.** Measured:

```
WURCS=2.0/1,1,0/[A111h]/1/   →   WURCS=2.0/1,1,0/[A111h]/1/
```

The skeleton-code error @ReneRanzinger saw is gone, so those exact steps produce no dialogs at all now,
and the fix above changes nothing a user can see with that sequence. I have kept it because the
mechanism is real and would double the next failure just as well.

I will ask on the issue for a structure that still fails to export, so the count can be confirmed
against something rather than argued from the code.

171 tests pass. No version bump: this is a sub-branch for `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
