### PR TITLE
Version 1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,62 @@
 ## Change log
+### 1.38.0  (20260815)
+The tracker was re-checked against the code first, and the gap between them turned out to be the largest
+thing on the list: nine issues were marked fixed and still open, and two faults that had been measured
+were filed nowhere. Those were dealt with before any code was written, and the release is what came out
+of the reordering.
+* **An m/z weighs its adduct the way it weighed the structure** (#203). 1.36.0 brought the neutral mass
+  under `MassOptions.ISOTOPE` and stopped at the ions, so an average neutral mass could arrive carrying a
+  monoisotopic adduct - a figure that is neither, and plausible at every digit anyone would check
+  * `IonCloud` captured an adduct's mass when the ion was *set*, which is always the monoisotopic
+    figure, and `computeMZ` only added the total it had been handed. The adduct was decided before
+    anything knew which table the answer wanted
+  * **Nil for sodium, +0.135 per potassium, +0.484 per chloride, and negative for lithium**, since ⁷Li is
+    the monoisotopic mass while ⁶Li pulls the average below it. The test is written on potassium and
+    chloride for that reason: sodium has one stable isotope, so a sodiated m/z - the default - was right
+    by accident throughout, and a test on it would have passed before the fix. Sodium is in there as the
+    control that says so
+  * A charge added with an explicit mass, a neutral exchange, keeps the mass it was given. There is no
+    second figure for it and inventing one would be worse
+* **A repeat unit keeps the position it closes on** (#204). `l1-m3~n` was read in and written back as
+  `l?-m3~n`, while every other linkage in the sequence survived
+  * `?` is not a rounding of `1`. It is the sequence saying the position is unknown, about a position the
+    input had stated, so the export said less than the import did and said it in a form that looks
+    deliberate
+  * Dropped on the way in, and one line. `addChild` rebuilds a linkage from its bonds and ends by taking
+    the child's own anomeric carbon; the closing repeat marker is created fresh and has none, so the `?`
+    it was born with was written over the position that had just been worked out. The opening marker was
+    always given its position before being added - only the closing side was missing that, which is why
+    one end of a repeat survived and the other did not
+* **Branches are drawn in the numeric order of their linkage positions** (#29), so a bisecting GlcNAc at
+  4 sits between the 3- and 6-antennae rather than above both of them
+  * Every ordinary monosaccharide is placed straight out: the placement rules that pick a side from the
+    position apply to substituents - `(!cs)` reads "child is not a monosaccharide" - so a saccharide
+    child falls through to the catch-all, in the SNFG and CFG dictionaries alike. All of a residue's
+    branches therefore arrive in one region and were stacked in the order the children happened to be
+    stored. Attaching one to a finished core appended it, so it was stacked last, which is the far edge
+  * That is why the report is phrased as "if you add it after drawing": the same molecule imported from a
+    sequence drew correctly, because the sequence listed the children differently
+  * Ascending, in all four orientations - which is what three of the four were already doing for a plain
+    biantennary core, so a middle branch moves into place and nothing already right moves at all.
+    Measured, default orientation: 6-antenna at y=30, bisecting GlcNAc at y=82 level with its β-Man,
+    3-antenna at y=134, which is the arrangement DrawGlycan-SNFG gives
+  * An unknown position sorts last and keeps the order it came in. There is nothing to compare it with
+* **A failed export says so once** (#183). The export wrote every structure for the file and then wrote
+  them all again to find which had come out empty, and one failure is already two windows - the message,
+  then the stack - so the second pass produced a second pair
+  * **The sequence in the report no longer fails.** `WURCS=2.0/1,1,0/[A111h]/1/` writes back unchanged, so
+    those steps produce no dialogs at all now. The doubling was still there to be read, and would have
+    doubled the next failure, so it is fixed rather than closed as not-reproducible
+* **A bridge's label has the same room on every side** (#88). The area cleared behind it was the glyphs'
+  bounds cast to `int`, which truncates the origin one way and the width the other
+* **The CFG hat diamonds no longer take an angle they never used** (#83). Removing it does not answer
+  whether the symbol looks wrong, which is what the reporter was asked; it removes a parameter that
+  claimed to matter and did not
+* `TRIAGE.md` carries the order the work was taken in and why, and
+  `docs/linkage-positions-and-anomers.md` corrects what the placement dictionaries actually say - both
+  rules are about substituents, not saccharides. The earlier, wrong reading is recorded rather than
+  removed, because it is the kind of mistake that document exists to stop
+
 ### 1.37.0  (20260814)
 Everything at the top of the triage list, in both bands: a wrong answer nobody can see is wrong, and
 work that quietly disappears.

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -82,10 +82,27 @@ remains, and the issue should say so rather than being closed.
 
 ## P3 — visibly wrong
 
-#29 (bisecting GlcNAc position) · #57 (repeat-unit linkage position) · #58 (G07957FT layout) ·
-#20 (bracket not symmetric about the reducing end) · #88 (no right margin on a bridge) ·
-#83 (CFG hat diamonds take orientation from the bond) · #91 (Add-structure menu misaligned) ·
-#6 (fragments carrying a bridge)
+~~#88 (no right margin on a bridge)~~ — **done**: the cleared area was the glyphs' bounds cast to
+int, which truncates the origin one way and the width the other.
+
+**#29** (bisecting GlcNAc position) — measured: the placement dictionary sends both position 4 and
+position 6 to the same side (`lp=[4-9]` → 90), so a bisecting GlcNAc and the 6-antenna compete and one
+gives way. Adding it after drawing is not the cause. Not changed: the rule that would fix it is a
+drawing convention, and picking it decides every picture the application draws — asked the reporter
+which rule they want.
+
+#58 (G07957FT layout) · #20 (bracket not symmetric about the
+reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is
+orientation-independent, and the measurements are on the issue.
+
+#91 (Add-structure menu
+misaligned) · #6 (fragments carrying a bridge)
+
+**#57** (repeat-unit linkage position) — measured: the model holds position 2 as the sequence says,
+so the 3 appears between the model and the picture, and the likely candidate is the position
+belonging to the *other* end of the repeat. Asked the reporter to confirm which label. Found
+separately while measuring: the round trip drops the repeat's own linkage position, `l1` → `l?`,
+which is a different fault in the same corner and wants its own issue.
 
 ## P4 — not there yet
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -169,9 +169,15 @@ never used, and is gone as of #201, on `develop`. That does not establish the sy
 orientation-independent; the measurements are on the issue, and the reporter was asked whether it
 looks *rotated* or merely *placed differently*.
 
-**#183** (a failed WURCS export shows every error twice) — two dialogs per failed structure, so four
-for two bad structures. #108 (a message for a partially failed export) was closed in 1.35.x and this
-is the same code path, so start by reading what that change left behind.
+~~**#183** (a failed WURCS export shows every error twice)~~ — **fixed, in PR #208, waiting to merge.**
+The export wrote every structure for the file and then wrote them all again to find which had come out
+empty, and one failure is already two windows — `LogUtils.report` shows the message and then a
+`ReportDialog` — so the second pass produced a second pair. One pass now.
+
+**The reported sequence no longer fails.** `WURCS=2.0/1,1,0/[A111h]/1/` writes back unchanged as of
+1.37.0, so those steps produce no dialogs at all and the fix changes nothing a user would see with it.
+Fixed on the mechanism rather than on anything watchable, and the reporter has been asked for a structure
+that still refuses to export.
 
 #58 (G07957FT layout) · #20 (bracket not symmetric about the reducing end) ·
 #91 (Add-structure menu misaligned) · #6 (fragments carrying a bridge)
@@ -264,11 +270,13 @@ so it was checked in all four orientations and the plain core comes out unchange
 turned up a mistake in `docs/linkage-positions-and-anomers.md`, corrected on this branch: the
 position-to-side rules in the placement dictionaries apply to substituents only, not to saccharides.
 
-**5. #183, the doubled export error — the next piece of work.** Cheap P3, and the same code path as
-#108, which is closed.
+**5. ~~#183, the doubled export error~~ — fixed, PR #208.** The mechanism was real; the reported
+sequence turned out to write back unchanged, so there was nothing to watch fail. Recorded as such rather
+than claimed as verified.
 
-**6. The waiting list, before starting anything new.** #17, #57, #58, #66, #83, #185, #16 are all
-waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
+**6. The waiting list — the next piece of work.** #17, #57, #58, #66, #83, #185, #16 are all waiting on
+somebody else and several are closable on a reply. A nudge costs a paragraph, and #183 has just joined
+them.
 
 Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
 changes and neither is small.
@@ -300,8 +308,8 @@ installers as every release before them. What is missing on all of them is the W
 is uploaded by hand and is what #180 is about.
 
 **Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope),
-#206 (#204, the repeat's position) and #207 (#29, branch order). All four are for `develop` and carry no
-version bump.
+#206 (#204, the repeat's position), #207 (#29, branch order) and #208 (#183, one message per failed
+export). All five are for `develop` and carry no version bump.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:
@@ -314,6 +322,7 @@ closable:
 | #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
 | #83 | whether the symbol looks *rotated* or merely *placed differently* |
 | #185 | a retest on Windows; all five formats write here |
+| #183 | a structure that still refuses to export — the one in the report writes fine now |
 | #16 | whether to split it per modification |
 | #189 | whether they mean GlcNS or a sulfate on an already-acetylated nitrogen — a chemistry question, and the only thing left on it |
 | #190 | the WURCS or GlycoCT for G13093, for whoever takes #181 |

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -103,7 +103,7 @@ Both were found while measuring something else and existed nowhere but this file
 | ~~#132~~ | ~~`v_stripes`/`h_stripes` never painted~~ | **Done.** Three bars, clipped to the outline. The test asserts the drawn image and, separately, that the stripes exist — Tal is green and All is blue, so comparing the pair passes on colour alone |
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
 | ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass**, 1.36.0, and closed. Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82) |
-| **#203** | An m/z pairs an average neutral mass with a monoisotopic adduct | **The top of this list.** `IonCloud` captures an adduct's mass when the ion is set rather than when the mass is computed, so the isotope choice never reaches it. `Molecule` already carries both masses — what is missing is resolving the adduct at `computeMZ` time. Test it with potassium or chloride; sodium would pass while proving nothing |
+| ~~#203~~ | ~~An m/z pairs an average neutral mass with a monoisotopic adduct~~ | **Fixed, in PR #205, waiting to merge.** `IonCloud` captured an adduct's mass when the ion was set rather than when it was computed, so the choice could not reach it. `computeMZ`/`computeMass` take the flag now and `getIonsMass(boolean)` recomputes the total; a charge given an explicit mass keeps it. The test is on potassium and chloride, with sodium as the control — one stable isotope, so a sodiated m/z was right by accident and a test on the default adduct would have passed before the fix |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
 | **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
 | ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
@@ -114,7 +114,7 @@ Both were found while measuring something else and existed nowhere but this file
 |---|---|---|
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
-| **#204** | A repeat unit's own linkage position does not survive a round trip | `l1` → `l?` on G03246MZ, measured on 1.37.0. A position the sequence states is written back as unknown, so the export says less than the import did and says it in a form that looks deliberate. Which end drops it is not known; the first move is a test that asserts the round trip keeps it |
+| ~~#204~~ | ~~A repeat unit's own linkage position does not survive a round trip~~ | **Fixed, in PR #206, waiting to merge.** It was dropped on the way in, not on the way out: `addChild` rebuilds a linkage from its bonds and ends by taking the child's anomeric carbon, and the closing marker is created fresh with none — so the `?` it was born with was written over the position that had just been worked out. `makeEdgeWithStartBracket` had always set it for the opening marker; only the closing side was missing the line, which is why one end of a repeat survived and the other did not. G03246MZ now round-trips character for character |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
 | ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
@@ -244,18 +244,16 @@ hour rather than a week, which is why they came first.
 Ten issues closed with their measurements, #203 and #204 filed, #88 left open on purpose until the fix
 is in a release, #189 answered from the dictionary and #190 pointed at #181.
 
-**2. #203, the ion adduct isotope** — now the top of P1, and the last thing in the project that hands
-someone a wrong number they cannot see is wrong: an m/z pairing an average neutral mass with a
-monoisotopic adduct. P1 by the same rule that put #127 there in the first place. **This is the next
-piece of work.**
+**2. ~~#203, the ion adduct isotope~~ — fixed, PR #205.** The last thing in the project that handed
+someone a wrong number they could not see was wrong. P1 by the same rule that put #127 there.
 
-**3. #204, the repeat unit's linkage position lost on a round trip** — a position the sequence states
-does not survive being written back, which is P2: the output cannot be used for what it was written
-for.
+**3. ~~#204, the repeat unit's linkage position lost on a round trip~~ — fixed, PR #206.** It turned out
+to be dropped on the way in rather than on the way out, and to be one line: the closing repeat marker
+was the only one of the two that was never given the position before being added.
 
-**4. #29, the bisecting GlcNAc** — the largest P3 and the one with a known next step
-(`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it wants a
-clear run at it rather than being squeezed in.
+**4. #29, the bisecting GlcNAc — the next piece of work.** The largest P3 and the one with a known next
+step (`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it
+wants a clear run at it rather than being squeezed in.
 
 **5. #183, the doubled export error** — cheap P3, and the same code path as #108, which is closed.
 
@@ -291,7 +289,8 @@ pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each c
 installers as every release before them. What is missing on all of them is the Windows `.msix`, which
 is uploaded by hand and is what #180 is about.
 
-**Open pull request**: #202, this file and the layout document. Nothing else is unmerged.
+**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope) and
+#206 (#204, the repeat's position). All three are for `develop` and carry no version bump.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -125,8 +125,7 @@ Both were found while measuring something else and existed nowhere but this file
 ~~#88 (no right margin on a bridge)~~ — **done, on `develop` and not yet released**: the cleared area
 was the glyphs' bounds cast to int, which truncates the origin one way and the width the other.
 
-**#29** (bisecting GlcNAc position) — **the rule and the expected numbers are both known; what is
-not known is where in the layout to apply them.**
+~~**#29** (bisecting GlcNAc position)~~ — **fixed, in PR #207, waiting to merge.**
 
 The convention: branches are drawn in the numeric order of their linkage positions, so a bisecting
 GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft states the same
@@ -137,17 +136,26 @@ thing as an explicit rule and gives worked numbers —
 >
 > 最終配置: α1-6 Man at y=-70, bisecting GlcNAc at y=0, α1-3 Man at y=+70
 
-Measured here, on the same structure: 6-antenna y=82, β-Man y=82, 3-antenna y=134, bisecting y=30 —
-the bisecting sits above the 6-antenna instead of between the two.
+Now measured, default orientation: 6-antenna y=30, bisecting GlcNAc y=82 level with its β-Man,
+3-antenna y=134. Was 82 / 30 / 134 — the bisecting above the 6-antenna, with the 6-antenna pushed onto
+its parent's line.
 
-**Where it is not.** Every ordinary monosaccharide gets the same placement from
-`conf/residue_placements_snfg` — the catch-all `1 → 0`, straight out — and `BookingManager` puts them
-all in one bucket for angle 0. So the branch order is not decided there. Sorting the children by
-linkage position before the booking loop in `AbstractGlycanRenderer.assignPosition` was tried and
-changed nothing; it was reverted rather than left in place looking like a fix.
+**What it turned out to be.** Every ordinary monosaccharide is placed straight out, so all of a
+residue's branches arrive in one region and are stacked in whatever order that region's list is in —
+which was the order the children were stored. Attaching one afterwards appended it, so it was stacked
+last, which is the far edge. That is why the issue is phrased as "if you add it after drawing": the
+same molecule imported from a sequence drew correctly, because the sequence listed the children
+differently.
 
-**Where to look next**: `BBoxManager`, and its `alignLeftsOnTop` / `alignLeftsOnBottom` family, which
-is what turns one bucket of children into rows.
+`AbstractGlycanRenderer.inPositionOrder` sorts that region before it is stacked, ascending, in all four
+orientations — which is what three of the four were already doing for a plain biantennary core, so a
+middle branch moves into place and nothing already right moves at all.
+
+**Two dead ends worth not repeating.** Sorting the children in `assignPosition` changed nothing: the
+region list is rebuilt from `PositionManager.getChildrenAtPosition`, which walks the residue's own
+linkages. And the first version of the test found the bisecting GlcNAc by name and position and picked
+up the chitobiose core's GlcNAc, which is also at 4 — it failed without the change, for the wrong
+reason.
 
 
 **#57** (repeat-unit linkage position) — measured: the model holds position 2 as the sequence says,
@@ -251,11 +259,13 @@ someone a wrong number they could not see was wrong. P1 by the same rule that pu
 to be dropped on the way in rather than on the way out, and to be one line: the closing repeat marker
 was the only one of the two that was never given the position before being added.
 
-**4. #29, the bisecting GlcNAc — the next piece of work.** The largest P3 and the one with a known next
-step (`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it
-wants a clear run at it rather than being squeezed in.
+**4. ~~#29, the bisecting GlcNAc~~ — fixed, PR #207.** It reached every picture the application draws,
+so it was checked in all four orientations and the plain core comes out unchanged in each. It also
+turned up a mistake in `docs/linkage-positions-and-anomers.md`, corrected on this branch: the
+position-to-side rules in the placement dictionaries apply to substituents only, not to saccharides.
 
-**5. #183, the doubled export error** — cheap P3, and the same code path as #108, which is closed.
+**5. #183, the doubled export error — the next piece of work.** Cheap P3, and the same code path as
+#108, which is closed.
 
 **6. The waiting list, before starting anything new.** #17, #57, #58, #66, #83, #185, #16 are all
 waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
@@ -289,8 +299,9 @@ pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each c
 installers as every release before them. What is missing on all of them is the Windows `.msix`, which
 is uploaded by hand and is what #180 is about.
 
-**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope) and
-#206 (#204, the repeat's position). All three are for `develop` and carry no version bump.
+**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope),
+#206 (#204, the repeat's position) and #207 (#29, branch order). All four are for `develop` and carry no
+version bump.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -41,20 +41,60 @@ and it is what lets the next person trust this file.
 
 ---
 
-## Verified, and can be closed
+## Verified, and closed
 
-Measured on 1.35.2. Each needs a comment carrying the measurement, not a bare close.
+Measured on 1.35.2, commented with the measurement, and closed on 2026-08-14.
 
 | # | Title | What was measured |
 |---|---|---|
 | #67 | Composition m/z is incorrect | Hex₃HexNAc₂ as a composition weighs 910.3278, as does the same glycan linked. Fixed by the 1.34.1–1.34.3 composition work |
 | #150 | Ambiguous linkage read as the parent's position | Fixed in 1.34.0, `AmbiguousLinkageKeepsUnknownPositionsTest` holds it |
 | #158 | org.jdom has no fixed version | Duplicate of #175, which carries the fuller investigation |
-| #17 | AUdxxxxxh no longer supported | G00771KP reads and draws. Ask the reporter to confirm before closing — it is their report |
+| #125 | Redrawing G11127BT | Half done, and split: the structure no longer takes the JVM down, it is refused with a sentence. Being unable to draw it carried on as **#200** under the title it should have had |
 
-**#125** (redrawing G11127BT) is half done: the structure no longer takes the JVM down, it is refused
-with a sentence saying a ring through a bridge cannot be represented. Being unable to draw it is what
-remains, and the issue should say so rather than being closed.
+**#17** (AUdxxxxxh no longer supported) is still open and still wants the same thing: G00771KP reads
+and draws, so ask the reporter to confirm the import is what they meant before closing — it is their
+report.
+
+---
+
+## Fixed, and still open on the tracker
+
+**The largest gap between this file and the tracker.** Nine issues are marked done below — eight of
+them in a version a user can already install — and every one of them is still open on GitHub. Somebody
+reading the tracker sees a backlog that is not there, and none of the reporters has been told.
+
+Each wants a comment carrying what was measured and the version it went out in, then a close — not a
+bare close.
+
+| # | What it was | Released in |
+|---|---|---|
+| #132 | `v_stripes`/`h_stripes` never painted | 1.36.0 |
+| #107 | Composition export to WURCS fails | 1.36.0 |
+| #34 | Duplicated linkage position in a branched glycan | 1.37.0 |
+| #186 | PNG background not transparent | 1.37.0 |
+| #188 | SVG gives every character a white background | 1.37.0 |
+| #106 | Saving on close offers Save As for an already-saved file | 1.37.0 |
+| #178 | "Open additional document" leaves the document counted as unchanged | 1.37.0 |
+| #179 | "Remember files after restarting" carries a reducing end into new imports | 1.37.0 |
+| #88 | No right margin on a bridge label | **`develop`, unreleased** — merged as #199, no version carries it yet |
+
+**#127** is a different case and should stay open with its scope narrowed rather than closed: the
+neutral mass follows `MassOptions.ISOTOPE` as of 1.36.0, the ion adducts still do not. See the
+unfiled follow-ups below.
+
+**#83** is on `develop` too (merged as #201) but is not fixed by it — removing an angle that was never
+used does not answer whether the symbol looks wrong, which is what the reporter was asked.
+
+### Two things measured but never filed
+
+Both were found while measuring something else, both are real, and neither exists as an issue — so
+they are invisible to anyone who does not read this file.
+
+- **`IonCloud` captures an ion's mass when the ion is set, not when the mass is computed**, so an m/z
+  can pair an average neutral mass with a monoisotopic adduct. This is the remainder of #127.
+- **A repeat unit's own linkage position does not survive a round trip**, `l1` → `l?`. Found while
+  measuring #57, and a different fault from the one that issue reports.
 
 ---
 
@@ -82,8 +122,8 @@ remains, and the issue should say so rather than being closed.
 
 ## P3 — visibly wrong
 
-~~#88 (no right margin on a bridge)~~ — **done**: the cleared area was the glyphs' bounds cast to
-int, which truncates the origin one way and the width the other.
+~~#88 (no right margin on a bridge)~~ — **done, on `develop` and not yet released**: the cleared area
+was the glyphs' bounds cast to int, which truncates the origin one way and the width the other.
 
 **#29** (bisecting GlcNAc position) — **the rule and the expected numbers are both known; what is
 not known is where in the layout to apply them.**
@@ -110,18 +150,23 @@ changed nothing; it was reverted rather than left in place looking like a fix.
 is what turns one bucket of children into rows.
 
 
-#58 (G07957FT layout) · #20 (bracket not symmetric about the
-reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is
-orientation-independent, and the measurements are on the issue.
-
-#91 (Add-structure menu
-misaligned) · #6 (fragments carrying a bridge)
-
 **#57** (repeat-unit linkage position) — measured: the model holds position 2 as the sequence says,
 so the 3 appears between the model and the picture, and the likely candidate is the position
 belonging to the *other* end of the repeat. Asked the reporter to confirm which label. Found
 separately while measuring: the round trip drops the repeat's own linkage position, `l1` → `l?`,
-which is a different fault in the same corner and wants its own issue.
+which is a different fault in the same corner and is not filed.
+
+**#83** (CFG hat diamonds take orientation from the bond) — the angle those two symbols took was
+never used, and is gone as of #201, on `develop`. That does not establish the symbol is
+orientation-independent; the measurements are on the issue, and the reporter was asked whether it
+looks *rotated* or merely *placed differently*.
+
+**#183** (a failed WURCS export shows every error twice) — two dialogs per failed structure, so four
+for two bad structures. #108 (a message for a partially failed export) was closed in 1.35.x and this
+is the same code path, so start by reading what that change left behind.
+
+#58 (G07957FT layout) · #20 (bracket not symmetric about the reducing end) ·
+#91 (Add-structure menu misaligned) · #6 (fragments carrying a bridge)
 
 ## P4 — not there yet
 
@@ -129,7 +174,8 @@ which is a different fault in the same corner and wants its own issue.
 |---|---|---|
 | #95 | Validate a drawn structure | Before submitting to GlyTouCan. Validation code exists elsewhere and could be called |
 | #100 | Substituents and defined residues in the composition builder | Overlaps #7 (which monosaccharides the list should offer); decide them together |
-| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench |
+| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench. #189 and #190 are both instances of it, per R. Ranzinger on #190 — a modified residue can be imported from a sequence but not drawn |
+| #200 | A ring closed through a bridge cannot be represented | The bridge plus the direct bond make a genuine cycle where everything downstream assumes a tree, so it is a change to the structure model, not the renderer. Carried on from #125, which is closed |
 | #184 | Multi-format clipboard (bitmap + text + SVG) | |
 | #177 | Open a .gws by double-clicking it | Needs file association *and* accepting a path at startup |
 | #41 | SNFG with linkage placement notation | CFG has it; SNFG does not |
@@ -137,6 +183,7 @@ which is a different fault in the same corner and wants its own issue.
 | #172 | Check for updates at startup | Waiting on the Microsoft Store question |
 | #109 | Compositions with linkage (lactonised sialic acid) | A WURCS question more than a GB2 one |
 | #7 | Review the Add-composition monosaccharide list | |
+| #16 | A standing list of modifications that were not handled | Fourteen WURCS collected since 2021, almost certainly not one fault — `*OSO`, `*=NO` and the rest fail at different points and some read now. Asked the reporter whether to re-measure each on 1.35.2, close this, and file one issue per modification that still fails. Overlaps #181 |
 
 ## P5 — plumbing
 
@@ -151,28 +198,90 @@ which is a different fault in the same corner and wants its own issue.
 #182 ("Unknown" is a misleading group name) · #189 (sulfate on a GlcNAc nitrogen) ·
 #190 (a KEGG structure with ribitol)
 
-#189 and #190 are asked as "how do I input this?" and may each turn out to be a missing capability
-rather than a missing instruction. Answer them by trying it, and re-file what does not work.
+#189 and #190 are asked as "how do I input this?" and both look like the missing capability #181
+describes rather than a missing instruction — R. Ranzinger said so on #190. Confirm it by trying, then
+say so on each and let #181 carry the work.
+
+**#90** (no second window on macOS) — Swing runs one instance per application on macOS, and it is not
+ours to change. Two workarounds are already in the thread, `open -n /Applications/GlycanBuilder2.app`
+and the same line wrapped as a Script Editor app. The answer is to put one of them somewhere a user
+will find it and close the issue, not to keep it open against an approach nobody has.
 
 ---
 
 ## Not a priority band, but do it first
 
 **#123** is someone outside the project offering patches — NPEs turned into exceptions that say what
-failed in WURCS terms — and asking how to submit them. The last word is theirs: they will be back in
-about a week. Replying with how to send it costs a paragraph, and not replying costs the patches.
+failed in WURCS terms. **Answered on 2026-08-14** with how to send them, what shape a test wants, and
+two recent refusals to imitate. They said about a week, so nothing is owed here until roughly the 21st;
+the next move is theirs.
 
 Contribution questions are answered ahead of the queue, whatever band the code would fall in.
 
 ---
 
+## The order to take them in
+
+The bands say what a thing costs. This says what to pick up, and it is the bands applied twice: once
+for cost, once for what it costs to leave the tracker saying something untrue.
+
+**1. One sitting of tracker work — about an hour, and it outranks every open defect.** Nine fixed
+issues are still open and two measured faults are not filed at all. Both are the same failure and it
+is the one this file is most emphatic about: *silence outranks severity*. An issue that says a fixed
+bug is live, and a real fault that exists in nobody's tracker, are both quietly wrong to everyone
+outside this repository — and unlike the defects below, they cost an hour rather than a week.
+
+- Close the nine with the measurement and the version, from the table above
+- File the `IonCloud` m/z fault, and narrow #127 to it
+- File the repeat unit's `l1` → `l?` round trip
+- Close #90 with the `open -n` workaround, and say on #189 and #190 that #181 is the work
+
+**2. The ion adduct isotope** — the new #127 issue. The last thing left in the project that hands
+someone a wrong number they cannot see is wrong: an m/z pairing an average neutral mass with a
+monoisotopic adduct. P1 by the same rule that put #127 there in the first place.
+
+**3. The repeat unit's linkage position, lost on a round trip** — the other new issue. A position the
+sequence states does not survive being written back, which is P2: the output cannot be used for what
+it was written for.
+
+**4. #29, the bisecting GlcNAc** — the largest P3 and the one with a known next step
+(`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it wants a
+clear run at it rather than being squeezed in.
+
+**5. #183, the doubled export error** — cheap P3, and the same code path as #108, which is closed.
+
+**6. The waiting list, before starting anything new.** #17, #57, #58, #66, #83, #185, #16 are all
+waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
+
+Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
+changes and neither is small.
+
+**When the next release goes out**, it already has two fixes waiting on `develop` (#199, #201) and the
+version bump belongs immediately before the merge to `master`, not before that.
+
+---
+
 ## Where this stands, for whoever picks it up next
 
-As of 2026-08-14, after 1.37.0.
+Re-checked against the tracker on 2026-08-15.
 
-**Released**: P1 and P2 are done. 1.36.0 carried the composition WURCS export, the average mass and
-the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
+**Released**: P1 and P2 are done in the code. 1.36.0 carried the composition WURCS export, the average
+mass and the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
 document-loses-your-work bugs.
+
+**The code is ahead of the tracker, and the tracker is what other people read.** Nine fixed issues are
+still open — the table under "Fixed, and still open on the tracker" is the shortest piece of work on
+this page and the one that changes what the project looks like from outside. Two measured faults are
+not filed at all.
+
+**On `develop`, waiting for the next release**: #199 (#88, the bridge label's margin) and #201 (#83's
+unused angle). `pom.xml` still reads 1.37.0 on both branches, correctly — the bump belongs immediately
+before the merge to `master`.
+
+**Releases are in order**, checked against the API rather than the release page: nothing is a
+pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each carry the same five
+installers as every release before them. What is missing on all of them is the Windows `.msix`, which
+is uploaded by hand and is what #180 is about.
 
 **Open pull request**: #202, this file and the layout document. Nothing else is unmerged.
 
@@ -182,7 +291,7 @@ closable:
 | # | Waiting for |
 |---|---|
 | #17 | the reporter to confirm the import is what they meant, or close it |
-| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` wants its own issue |
+| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` is still not filed |
 | #58 | which part of the layout is wrong |
 | #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
 | #83 | whether the symbol looks *rotated* or merely *placed differently* |

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -58,43 +58,41 @@ report.
 
 ---
 
-## Fixed, and still open on the tracker
+## Fixed and closed, on 2026-08-15
 
-**The largest gap between this file and the tracker.** Nine issues are marked done below — eight of
-them in a version a user can already install — and every one of them is still open on GitHub. Somebody
-reading the tracker sees a backlog that is not there, and none of the reporters has been told.
-
-Each wants a comment carrying what was measured and the version it went out in, then a close — not a
-bare close.
+For a day these were all marked done here and open on GitHub — the tracker showed a backlog that did
+not exist, and no reporter had been told. Each is now closed with a comment carrying what was measured
+and the version it went out in.
 
 | # | What it was | Released in |
 |---|---|---|
 | #132 | `v_stripes`/`h_stripes` never painted | 1.36.0 |
 | #107 | Composition export to WURCS fails | 1.36.0 |
+| #127 | `MassOptions.ISOTOPE` has no effect | 1.36.0, for the neutral mass — the adducts became **#203** |
 | #34 | Duplicated linkage position in a branched glycan | 1.37.0 |
 | #186 | PNG background not transparent | 1.37.0 |
 | #188 | SVG gives every character a white background | 1.37.0 |
 | #106 | Saving on close offers Save As for an already-saved file | 1.37.0 |
 | #178 | "Open additional document" leaves the document counted as unchanged | 1.37.0 |
 | #179 | "Remember files after restarting" carries a reducing end into new imports | 1.37.0 |
-| #88 | No right margin on a bridge label | **`develop`, unreleased** — merged as #199, no version carries it yet |
+| #90 | No second window on macOS | Not a code change — closed with the `open -n` workaround |
 
-**#127** is a different case and should stay open with its scope narrowed rather than closed: the
-neutral mass follows `MassOptions.ISOTOPE` as of 1.36.0, the ion adducts still do not. See the
-unfiled follow-ups below.
+**#88 is fixed and deliberately still open.** The fix is on `develop` (merged as #199) and no version
+a user can install carries it, so closing it would read as done to somebody whose build still shows
+the problem. It is commented to that effect and closes with the next release.
 
 **#83** is on `develop` too (merged as #201) but is not fixed by it — removing an angle that was never
 used does not answer whether the symbol looks wrong, which is what the reporter was asked.
 
-### Two things measured but never filed
+### Two things measured, now filed
 
-Both were found while measuring something else, both are real, and neither exists as an issue — so
-they are invisible to anyone who does not read this file.
+Both were found while measuring something else and existed nowhere but this file until 2026-08-15.
 
-- **`IonCloud` captures an ion's mass when the ion is set, not when the mass is computed**, so an m/z
-  can pair an average neutral mass with a monoisotopic adduct. This is the remainder of #127.
-- **A repeat unit's own linkage position does not survive a round trip**, `l1` → `l?`. Found while
-  measuring #57, and a different fault from the one that issue reports.
+- **#203** — `IonCloud` captures an adduct's mass when the ion is set rather than when the mass is
+  computed, so an m/z can pair an average neutral mass with a monoisotopic adduct. Nil for sodium,
+  +0.135 per potassium, +0.484 per chloride, and *negative* for lithium. The remainder of #127.
+- **#204** — a repeat unit's own linkage position does not survive a round trip, `l1` → `l?`. Found
+  while measuring #57, and a different fault from the one that issue reports.
 
 ---
 
@@ -104,7 +102,8 @@ they are invisible to anyone who does not read this file.
 |---|---|---|
 | ~~#132~~ | ~~`v_stripes`/`h_stripes` never painted~~ | **Done.** Three bars, clipped to the outline. The test asserts the drawn image and, separately, that the stripes exist — Tal is green and All is blue, so comparing the pair passes on colour alone |
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
-| ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass.** Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82). **Still monoisotopic: the ion adducts.** `IonCloud` captures an ion's mass when the ion is set, not when the mass is computed, so an m/z carries an average neutral mass and a monoisotopic adduct. Worth its own issue |
+| ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass**, 1.36.0, and closed. Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82) |
+| **#203** | An m/z pairs an average neutral mass with a monoisotopic adduct | **The top of this list.** `IonCloud` captures an adduct's mass when the ion is set rather than when the mass is computed, so the isotope choice never reaches it. `Molecule` already carries both masses — what is missing is resolving the adduct at `computeMZ` time. Test it with potassium or chloride; sodium would pass while proving nothing |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
 | **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
 | ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
@@ -115,6 +114,7 @@ they are invisible to anyone who does not read this file.
 |---|---|---|
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
+| **#204** | A repeat unit's own linkage position does not survive a round trip | `l1` → `l?` on G03246MZ, measured on 1.37.0. A position the sequence states is written back as unknown, so the export says less than the import did and says it in a form that looks deliberate. Which end drops it is not known; the first move is a test that asserts the round trip keeps it |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
 | ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
@@ -174,7 +174,7 @@ is the same code path, so start by reading what that change left behind.
 |---|---|---|
 | #95 | Validate a drawn structure | Before submitting to GlyTouCan. Validation code exists elsewhere and could be called |
 | #100 | Substituents and defined residues in the composition builder | Overlaps #7 (which monosaccharides the list should offer); decide them together |
-| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench. #189 and #190 are both instances of it, per R. Ranzinger on #190 — a modified residue can be imported from a sequence but not drawn |
+| #181 | No way to add deoxy / en / alditol to a monosaccharide | A regression against the old GlycoWorkbench: a modified residue can be imported from a sequence but not drawn, per R. Ranzinger. #190 (ribitol) is the concrete case to satisfy. #189 is **not** one of these — see P6 |
 | #200 | A ring closed through a bridge cannot be represented | The bridge plus the direct bond make a genuine cycle where everything downstream assumes a tree, so it is a change to the structure model, not the renderer. Carried on from #125, which is closed |
 | #184 | Multi-format clipboard (bitmap + text + SVG) | |
 | #177 | Open a .gws by double-clicking it | Needs file association *and* accepting a path at startup |
@@ -198,14 +198,24 @@ is the same code path, so start by reading what that change left behind.
 #182 ("Unknown" is a misleading group name) · #189 (sulfate on a GlcNAc nitrogen) ·
 #190 (a KEGG structure with ribitol)
 
-#189 and #190 are asked as "how do I input this?" and both look like the missing capability #181
-describes rather than a missing instruction — R. Ranzinger said so on #190. Confirm it by trying, then
-say so on each and let #181 carry the work.
+**#190** (a KEGG structure with ribitol) is an instance of #181 — a modified residue can be imported
+from a sequence but not drawn, per R. Ranzinger on the issue. Left open as the concrete case #181 has
+to satisfy, and the reporter asked for the sequence, which is worth more to whoever takes #181 than a
+description of alditols.
 
-**#90** (no second window on macOS) — Swing runs one instance per application on macOS, and it is not
-ours to change. Two workarounds are already in the thread, `open -n /Applications/GlycanBuilder2.app`
-and the same line wrapped as a Script Editor app. The answer is to put one of them somewhere a user
-will find it and close the issue, not to keep it open against an approach nobody has.
+**#189** (sulfate on a GlcNAc nitrogen) **is not an instance of #181, and this file said it was for a
+day.** The dictionary answers it. `NS` — N-sulfate, `*NSO/3=O/3=O` — is an N-type substituent sitting
+right beside `NAc`, and `GlcN` declares `3,4,5,6,N` as its positions while `GlcNAc` declares `3,4,5,6`:
+
+- GlcN with `NS` at N is GlcNS, and it can be drawn today
+- GlcNAc has no free nitrogen, and 1.37.0's position rules refuse a second substituent there **on
+  purpose** — that is the rule working, not a gap
+
+What is left is the one chemistry question, which is the reporter's: whether they mean GlcNS or a
+sulfate on top of an acetylated nitrogen. Asked on the issue.
+
+*The lesson worth keeping: "these two look like the same missing capability" was written from the
+titles. Two greps at the dictionary said one of them had an answer already.*
 
 ---
 
@@ -225,24 +235,23 @@ Contribution questions are answered ahead of the queue, whatever band the code w
 The bands say what a thing costs. This says what to pick up, and it is the bands applied twice: once
 for cost, once for what it costs to leave the tracker saying something untrue.
 
-**1. One sitting of tracker work — about an hour, and it outranks every open defect.** Nine fixed
-issues are still open and two measured faults are not filed at all. Both are the same failure and it
-is the one this file is most emphatic about: *silence outranks severity*. An issue that says a fixed
-bug is live, and a real fault that exists in nobody's tracker, are both quietly wrong to everyone
-outside this repository — and unlike the defects below, they cost an hour rather than a week.
+**1. ~~One sitting of tracker work~~ — done on 2026-08-15.** Nine fixed issues were still open and two
+measured faults were filed nowhere. Both are the same failure, and it is the one this file is most
+emphatic about: *silence outranks severity*. An issue saying a fixed bug is live, and a real fault that
+exists in nobody's tracker, are equally wrong to everyone outside this repository — and they cost an
+hour rather than a week, which is why they came first.
 
-- Close the nine with the measurement and the version, from the table above
-- File the `IonCloud` m/z fault, and narrow #127 to it
-- File the repeat unit's `l1` → `l?` round trip
-- Close #90 with the `open -n` workaround, and say on #189 and #190 that #181 is the work
+Ten issues closed with their measurements, #203 and #204 filed, #88 left open on purpose until the fix
+is in a release, #189 answered from the dictionary and #190 pointed at #181.
 
-**2. The ion adduct isotope** — the new #127 issue. The last thing left in the project that hands
+**2. #203, the ion adduct isotope** — now the top of P1, and the last thing in the project that hands
 someone a wrong number they cannot see is wrong: an m/z pairing an average neutral mass with a
-monoisotopic adduct. P1 by the same rule that put #127 there in the first place.
+monoisotopic adduct. P1 by the same rule that put #127 there in the first place. **This is the next
+piece of work.**
 
-**3. The repeat unit's linkage position, lost on a round trip** — the other new issue. A position the
-sequence states does not survive being written back, which is P2: the output cannot be used for what
-it was written for.
+**3. #204, the repeat unit's linkage position lost on a round trip** — a position the sequence states
+does not survive being written back, which is P2: the output cannot be used for what it was written
+for.
 
 **4. #29, the bisecting GlcNAc** — the largest P3 and the one with a known next step
 (`BBoxManager.alignLeftsOnTop`). Reaches every picture the application draws, which is why it wants a
@@ -269,10 +278,9 @@ Re-checked against the tracker on 2026-08-15.
 mass and the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
 document-loses-your-work bugs.
 
-**The code is ahead of the tracker, and the tracker is what other people read.** Nine fixed issues are
-still open — the table under "Fixed, and still open on the tracker" is the shortest piece of work on
-this page and the one that changes what the project looks like from outside. Two measured faults are
-not filed at all.
+**The tracker matches the code again**, as of 2026-08-15. Ten issues closed with their measurements,
+#203 and #204 filed for the two faults that had been measured and never written down anywhere but here.
+The next piece of work is #203.
 
 **On `develop`, waiting for the next release**: #199 (#88, the bridge label's margin) and #201 (#83's
 unused angle). `pom.xml` still reads 1.37.0 on both branches, correctly — the bump belongs immediately
@@ -291,13 +299,15 @@ closable:
 | # | Waiting for |
 |---|---|
 | #17 | the reporter to confirm the import is what they meant, or close it |
-| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` is still not filed |
+| #57 | which label shows 3 — the round trip dropping `l1` → `l?` is #204 now |
 | #58 | which part of the layout is wrong |
 | #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
 | #83 | whether the symbol looks *rotated* or merely *placed differently* |
 | #185 | a retest on Windows; all five formats write here |
 | #16 | whether to split it per modification |
-| #189, #190 | the structure, as WURCS or GlycoCT |
+| #189 | whether they mean GlcNS or a sulfate on an already-acetylated nitrogen — a chemistry question, and the only thing left on it |
+| #190 | the WURCS or GlycoCT for G13093, for whoever takes #181 |
+| #88 | nothing — it is fixed, and waits only for a release to close against |
 | #123 | the contributor said about a week, from 2026-08-14 |
 
 **Deliberately not started**: #175 (jdom2) and taking glycanbuilder2web to 1.37.0 are both on hold at

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -87,9 +87,12 @@ int, which truncates the origin one way and the width the other.
 
 **#29** (bisecting GlcNAc position) — measured: the placement dictionary sends both position 4 and
 position 6 to the same side (`lp=[4-9]` → 90), so a bisecting GlcNAc and the 6-antenna compete and one
-gives way. Adding it after drawing is not the cause. Not changed: the rule that would fix it is a
-drawing convention, and picking it decides every picture the application draws — asked the reporter
-which rule they want.
+gives way. Adding it after drawing is not the cause. **The convention is settled**: branches are ordered by their linkage
+position, so 3 below, 4 between, 6 above (I. Yamada, 2026-08-14; recorded in
+`docs/linkage-positions-and-anomers.md`). Implementing it is wider than the dictionary, which matches
+one linkage at a time and cannot see its siblings — it needs candidate positions that admit a middle
+branch *and* `BookingManager` allocating in position order. Not attempted yet: it reaches every
+picture the application draws.
 
 #58 (G07957FT layout) · #20 (bracket not symmetric about the
 reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -85,14 +85,30 @@ remains, and the issue should say so rather than being closed.
 ~~#88 (no right margin on a bridge)~~ — **done**: the cleared area was the glyphs' bounds cast to
 int, which truncates the origin one way and the width the other.
 
-**#29** (bisecting GlcNAc position) — measured: the placement dictionary sends both position 4 and
-position 6 to the same side (`lp=[4-9]` → 90), so a bisecting GlcNAc and the 6-antenna compete and one
-gives way. Adding it after drawing is not the cause. **The convention is settled**: branches are ordered by their linkage
-position, so 3 below, 4 between, 6 above (I. Yamada, 2026-08-14; recorded in
-`docs/linkage-positions-and-anomers.md`). Implementing it is wider than the dictionary, which matches
-one linkage at a time and cannot see its siblings — it needs candidate positions that admit a middle
-branch *and* `BookingManager` allocating in position order. Not attempted yet: it reaches every
-picture the application draws.
+**#29** (bisecting GlcNAc position) — **the rule and the expected numbers are both known; what is
+not known is where in the layout to apply them.**
+
+The convention: branches are drawn in the numeric order of their linkage positions, so a bisecting
+GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft states the same
+thing as an explicit rule and gives worked numbers —
+`/Users/yamada/git/gitlab/glycoinfo-dev/glycocraft/LAYOUT_ALGORITHM.md`, §4.5 Step 3 and §5:
+
+> DrawGlycan-SNFG ルール: acceptorPos=4 (例: bisecting GlcNAc) は y=0 に固定
+>
+> 最終配置: α1-6 Man at y=-70, bisecting GlcNAc at y=0, α1-3 Man at y=+70
+
+Measured here, on the same structure: 6-antenna y=82, β-Man y=82, 3-antenna y=134, bisecting y=30 —
+the bisecting sits above the 6-antenna instead of between the two.
+
+**Where it is not.** Every ordinary monosaccharide gets the same placement from
+`conf/residue_placements_snfg` — the catch-all `1 → 0`, straight out — and `BookingManager` puts them
+all in one bucket for angle 0. So the branch order is not decided there. Sorting the children by
+linkage position before the booking loop in `AbstractGlycanRenderer.assignPosition` was tried and
+changed nothing; it was reverted rather than left in place looking like a fix.
+
+**Where to look next**: `BBoxManager`, and its `alignLeftsOnTop` / `alignLeftsOnBottom` family, which
+is what turns one bucket of children into rows.
+
 
 #58 (G07957FT layout) · #20 (bracket not symmetric about the
 reducing end) · **#83** — the angle those two took was never used, and is gone; that does not establish the symbol is
@@ -147,3 +163,36 @@ failed in WURCS terms — and asking how to submit them. The last word is theirs
 about a week. Replying with how to send it costs a paragraph, and not replying costs the patches.
 
 Contribution questions are answered ahead of the queue, whatever band the code would fall in.
+
+---
+
+## Where this stands, for whoever picks it up next
+
+As of 2026-08-14, after 1.37.0.
+
+**Released**: P1 and P2 are done. 1.36.0 carried the composition WURCS export, the average mass and
+the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
+document-loses-your-work bugs.
+
+**Open pull request**: #202, this file and the layout document. Nothing else is unmerged.
+
+**Waiting on somebody else**, and worth a look before starting anything new — several of these may be
+closable:
+
+| # | Waiting for |
+|---|---|
+| #17 | the reporter to confirm the import is what they meant, or close it |
+| #57 | which label shows 3 — and the round trip dropping `l1` → `l?` wants its own issue |
+| #58 | which part of the layout is wrong |
+| #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
+| #83 | whether the symbol looks *rotated* or merely *placed differently* |
+| #185 | a retest on Windows; all five formats write here |
+| #16 | whether to split it per modification |
+| #189, #190 | the structure, as WURCS or GlycoCT |
+| #123 | the contributor said about a week, from 2026-08-14 |
+
+**Deliberately not started**: #175 (jdom2) and taking glycanbuilder2web to 1.37.0 are both on hold at
+the maintainer's request.
+
+**The reducing-end note in "Before ranking anything, verify it" is the trap most likely to waste your
+first hour.** It has caught two measurements so far.

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -103,7 +103,7 @@ Both were found while measuring something else and existed nowhere but this file
 | ~~#132~~ | ~~`v_stripes`/`h_stripes` never painted~~ | **Done.** Three bars, clipped to the outline. The test asserts the drawn image and, separately, that the stripes exist — Tal is green and All is blue, so comparing the pair passes on colour alone |
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
 | ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass**, 1.36.0, and closed. Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82) |
-| ~~#203~~ | ~~An m/z pairs an average neutral mass with a monoisotopic adduct~~ | **Fixed, in PR #205, waiting to merge.** `IonCloud` captured an adduct's mass when the ion was set rather than when it was computed, so the choice could not reach it. `computeMZ`/`computeMass` take the flag now and `getIonsMass(boolean)` recomputes the total; a charge given an explicit mass keeps it. The test is on potassium and chloride, with sodium as the control — one stable isotope, so a sodiated m/z was right by accident and a test on the default adduct would have passed before the fix |
+| ~~#203~~ | ~~An m/z pairs an average neutral mass with a monoisotopic adduct~~ | **Fixed in PR #205, merged to `develop` on 2026-08-15.** `IonCloud` captured an adduct's mass when the ion was set rather than when it was computed, so the choice could not reach it. `computeMZ`/`computeMass` take the flag now and `getIonsMass(boolean)` recomputes the total; a charge given an explicit mass keeps it. The test is on potassium and chloride, with sodium as the control — one stable isotope, so a sodiated m/z was right by accident and a test on the default adduct would have passed before the fix |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
 | **#66** | WURCS export fails with `"_map" is null` on a heavily modified Fuc | **Does not reproduce on 1.36.0** — a Fuc with 2-O-Me, 3-NH₂ and 4-O-Me writes WURCS, drawn or imported, alone or as a branch. The substituent MAP handling has been reworked since it was filed. Waiting on a retest and the GWS |
 | ~~#34~~ | ~~Duplicated linkage position in a branched glycan~~ | **Done.** A stated position another child holds is refused, in `addChild` as well as `canAddChild` — the two had grown apart and adding is the path that makes the structure. Unknown positions still stack, and a file that already contains one still opens |
@@ -114,7 +114,7 @@ Both were found while measuring something else and existed nowhere but this file
 |---|---|---|
 | ~~#186~~ | ~~PNG background not transparent~~ | **Done.** The renderer could always paint without one; the export passed opaque for every format alike. BMP and JPEG keep theirs, having no alpha to write |
 | ~~#188~~ | ~~SVG gives every character its own white background~~ | **Done.** `clearRect` on an SVG surface paints the background colour rather than removing anything, and the export set that colour to white. Measured: white rectangles 9 → 0, colours intact |
-| ~~#204~~ | ~~A repeat unit's own linkage position does not survive a round trip~~ | **Fixed, in PR #206, waiting to merge.** It was dropped on the way in, not on the way out: `addChild` rebuilds a linkage from its bonds and ends by taking the child's anomeric carbon, and the closing marker is created fresh with none — so the `?` it was born with was written over the position that had just been worked out. `makeEdgeWithStartBracket` had always set it for the opening marker; only the closing side was missing the line, which is why one end of a repeat survived and the other did not. G03246MZ now round-trips character for character |
+| ~~#204~~ | ~~A repeat unit's own linkage position does not survive a round trip~~ | **Fixed in PR #206, merged to `develop` on 2026-08-15.** It was dropped on the way in, not on the way out: `addChild` rebuilds a linkage from its bonds and ends by taking the child's anomeric carbon, and the closing marker is created fresh with none — so the `?` it was born with was written over the position that had just been worked out. `makeEdgeWithStartBracket` had always set it for the opening marker; only the closing side was missing the line, which is why one end of a repeat survived and the other did not. G03246MZ now round-trips character for character |
 | **#187** | Ungrouping in PowerPoint destroys Fuc and Man | May be answered by #188 — there is no white background left to go hunting for. Worth a retest before anything else is done |
 | ~~#106~~ | ~~Saving on close offers Save As for an already-saved file~~ | **Done.** The close prompt called `onSaveAs` outright; `onSave` writes to the file the document came from and falls back by itself |
 | ~~#178~~ | ~~"Open additional document" leaves the document counted as unchanged~~ | **Done.** `setFilename` cleared the changed flag as a side effect, and a merge took the merged file's name as well. A merge now keeps its own name and counts as changed |
@@ -125,7 +125,7 @@ Both were found while measuring something else and existed nowhere but this file
 ~~#88 (no right margin on a bridge)~~ — **done, on `develop` and not yet released**: the cleared area
 was the glyphs' bounds cast to int, which truncates the origin one way and the width the other.
 
-~~**#29** (bisecting GlcNAc position)~~ — **fixed, in PR #207, waiting to merge.**
+~~**#29** (bisecting GlcNAc position)~~ — **fixed in PR #207, merged to `develop` on 2026-08-15.**
 
 The convention: branches are drawn in the numeric order of their linkage positions, so a bisecting
 GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft states the same
@@ -169,7 +169,7 @@ never used, and is gone as of #201, on `develop`. That does not establish the sy
 orientation-independent; the measurements are on the issue, and the reporter was asked whether it
 looks *rotated* or merely *placed differently*.
 
-~~**#183** (a failed WURCS export shows every error twice)~~ — **fixed, in PR #208, waiting to merge.**
+~~**#183** (a failed WURCS export shows every error twice)~~ — **fixed in PR #208, merged to `develop` on 2026-08-15.**
 The export wrote every structure for the file and then wrote them all again to find which had come out
 empty, and one failure is already two windows — `LogUtils.report` shows the message and then a
 `ReportDialog` — so the second pass produced a second pair. One pass now.
@@ -278,6 +278,10 @@ than claimed as verified.
 somebody else and several are closable on a reply. A nudge costs a paragraph, and #183 has just joined
 them.
 
+**Then a release.** Six fixes are on `develop` and none of them has reached anybody: #88, #83's dead
+angle, and the four from 2026-08-15. That is the whole of P1 and P2 sitting where no user can install
+it, which by this file's own ranking is worth more than the next defect on the list.
+
 Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
 changes and neither is small.
 
@@ -307,9 +311,16 @@ pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each c
 installers as every release before them. What is missing on all of them is the Windows `.msix`, which
 is uploaded by hand and is what #180 is about.
 
-**Open pull requests**: #202 (this file and the layout document), #205 (#203, the adduct isotope),
-#206 (#204, the repeat's position), #207 (#29, branch order) and #208 (#183, one message per failed
-export). All five are for `develop` and carry no version bump.
+**On `develop`, waiting only for a release**: #199 (#88's bridge margin), #201 (#83's unused angle),
+#205 (#203), #206 (#204), #207 (#29) and #208 (#183). 181 tests pass with all of them together.
+`pom.xml` still reads 1.37.0, correctly — the bump belongs immediately before the merge to `master`.
+
+**Four issues are fixed and still open on purpose**: #203, #204, #29 and #183. `develop` is not the
+default branch, so "Closes #N" did not fire on merge, and closing them by hand would tell each reporter
+it is done while no version they can install has it. They close with the release, alongside #88. This is
+the same judgement as #88's, applied consistently rather than issue by issue.
+
+**Open pull request**: #202, this file and the layout document.
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:

--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -76,6 +76,33 @@ of them.
 
 ## What is drawn
 
+### Which way a branch goes
+
+**Branches are ordered by their linkage position.** A residue's children are drawn in the numeric
+order of the positions they attach at, so on a β-Man carrying 3, 4 and 6 the 3-antenna is on one
+side, the 6-antenna on the other, and the bisecting GlcNAc at 4 sits between them.
+
+*Confirmed by I. Yamada, 2026-08-14: "単糖の結合方向は数字の順番になるようにするのが慣例であるので、
+4位の単糖は、3と６の間の位置に配置される".*
+
+**This is not what the code does.** `conf/residue_placements_snfg` assigns a side from the position
+alone, in two ranges:
+
+```
+(!cs)&(!cx)&(lp=[1-3[N]])   -90
+(!cs)&(!cx)&(lp=[4-9])       90
+```
+
+4 and 6 both fall in `[4-9]`, so a bisecting GlcNAc and a 6-antenna are sent to the same side and one
+of them gives way — measured, the bisecting GlcNAc ends up above the 6-antenna and the 6-antenna
+drops to the β-Man's own line (#29).
+
+Ordering by position cannot be expressed in that dictionary, which matches one linkage at a time and
+cannot see its siblings. Making the drawing follow the convention needs both halves: candidate
+positions wide enough for a middle branch to exist, and `BookingManager` allocating them in position
+order rather than in the order the children happen to be stored. That reaches every picture the
+application draws, which is why it is written down here before it is attempted.
+
 ### The anomeric configuration
 
 α and β describe the configuration at the anomeric centre. **Where there is no anomeric centre there

--- a/docs/linkage-positions-and-anomers.md
+++ b/docs/linkage-positions-and-anomers.md
@@ -85,23 +85,36 @@ side, the 6-antenna on the other, and the bisecting GlcNAc at 4 sits between the
 *Confirmed by I. Yamada, 2026-08-14: "単糖の結合方向は数字の順番になるようにするのが慣例であるので、
 4位の単糖は、3と６の間の位置に配置される".*
 
-**This is not what the code does.** `conf/residue_placements_snfg` assigns a side from the position
-alone, in two ranges:
+**Where it is decided, and where it is not.** `conf/residue_placements_snfg` does have rules that pick
+a side from the position:
 
 ```
 (!cs)&(!cx)&(lp=[1-3[N]])   -90
 (!cs)&(!cx)&(lp=[4-9])       90
 ```
 
-4 and 6 both fall in `[4-9]`, so a bisecting GlcNAc and a 6-antenna are sent to the same side and one
-of them gives way — measured, the bisecting GlcNAc ends up above the 6-antenna and the 6-antenna
-drops to the β-Man's own line (#29).
+**They are not about saccharides.** `cs` reads "child is a monosaccharide", so `(!cs)&(!cx)` restricts
+both rules to substituents. Every ordinary monosaccharide falls through to the catch-all `1 → 0` and is
+placed straight out — in `residue_placements_cfg` too, which has the same shape.
 
-Ordering by position cannot be expressed in that dictionary, which matches one linkage at a time and
-cannot see its siblings. Making the drawing follow the convention needs both halves: candidate
-positions wide enough for a middle branch to exist, and `BookingManager` allocating them in position
-order rather than in the order the children happen to be stored. That reaches every picture the
-application draws, which is why it is written down here before it is attempted.
+*An earlier version of this section said 4 and 6 both match `lp=[4-9]` and are therefore sent to the
+same side. That was read off the rule without checking which children it applies to, and it was wrong.
+It is recorded here rather than quietly removed, because it is the kind of mistake this document exists
+to stop: the dictionary is easy to read as saying more than it does.*
+
+So all of a residue's branches arrive in one region, and the picture is decided by the order that
+region's list is in. That was the order the children happened to be stored — what the sequence said, or
+what somebody drew first. Attaching a bisecting GlcNAc to a finished core appended it and it was
+stacked last, which is the far edge: above the 6-antenna, with the 6-antenna pushed down onto the
+β-Man's own line (#29).
+
+**The fix is in the renderer, not the dictionary.** Ordering by position cannot be expressed in a
+dictionary that matches one linkage at a time and cannot see its siblings.
+`AbstractGlycanRenderer.inPositionOrder` sorts the straight-out region before it is stacked, ascending,
+in all four orientations — which is what three of the four were already doing correctly for a plain
+biantennary core, so a middle branch moves into place and nothing that was already right moves at all.
+
+An unknown position sorts last and keeps the order it came in: there is nothing to compare it with.
 
 ### The anomeric configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.37.0</version>
+	<version>1.38.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/FragmentEntry.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/FragmentEntry.java
@@ -320,8 +320,10 @@ public class FragmentEntry implements Comparable<FragmentEntry>, SAXUtils.SAXWri
 			fragment.getMassOptions().ION_CLOUD = charges;
 			fragment.getMassOptions().NEUTRAL_EXCHANGES = exchanges;
 			structure = fragment.toString();
-			if( update_mz )
-				mz_ratio = charges.computeMZ(exchanges.getIonsMass() + mass);
+			if( update_mz ) {
+				boolean average = fragment.getMassOptions().isAverage();
+				mz_ratio = charges.computeMZ(exchanges.getIonsMass(average) + mass, average);
+			}
 		}
 	}
 
@@ -331,8 +333,9 @@ public class FragmentEntry implements Comparable<FragmentEntry>, SAXUtils.SAXWri
 	public void updateMass() {
 		IonCloud charges = fragment.getMassOptions().ION_CLOUD;
 		IonCloud exchanges = fragment.getMassOptions().NEUTRAL_EXCHANGES;
+		boolean average = fragment.getMassOptions().isAverage();
 		mass = fragment.computeMass();
-		mz_ratio = charges.computeMZ(exchanges.getIonsMass() + mass);
+		mz_ratio = charges.computeMZ(exchanges.getIonsMass(average) + mass, average);
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Glycan.java
@@ -1283,9 +1283,10 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
        Compute the mass-to-charge ratio given the current mass settings.
 	 */
 	public double computeMZ() {
-		double mass = computeMass();		
-		return mass_options.ION_CLOUD.and(mass_options.NEUTRAL_EXCHANGES).computeMZ(mass);
-	}   
+		double mass = computeMass();
+		return mass_options.ION_CLOUD.and(mass_options.NEUTRAL_EXCHANGES)
+				.computeMZ(mass, weighedAsAverage());
+	}
 
 	/**
        Compute the chemical formula for this structure.
@@ -1367,7 +1368,7 @@ public class Glycan implements Comparable, SAXUtils.SAXWriter, MassAware {
 	 * @return Returns whether {@code ISOTOPE} says average.
 	 */
 	private boolean weighedAsAverage() {
-		return mass_options != null && MassOptions.ISOTOPE_AVG.equals(mass_options.ISOTOPE);
+		return mass_options != null && mass_options.isAverage();
 	}
 
 	/** @return Returns a residue's mass, of the kind this structure is being weighed in. */

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
@@ -1336,12 +1336,9 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 		try {
 			String str_encode = "";
 			GlycanParser parser = GlycanParserFactory.getParser(format);
-			str_encode = toString(a_lstGlycan, parser);
-			if (str_encode.equals("")) throw new Exception("Invalid output string");
-
 			this.lastExportFailures = new ArrayList<Glycan>();
-			for (Glycan g : a_lstGlycan)
-				if (parser.writeGlycan(g).equals("")) this.lastExportFailures.add(g);
+			str_encode = toString(a_lstGlycan, parser, null, this.lastExportFailures);
+			if (str_encode.equals("")) throw new Exception("Invalid output string");
 
 			for (String s : str_encode.split(";")) this.lst_encode.addLast(s);
 			return true;
@@ -1381,12 +1378,9 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 
 			// serialize structures
 			GlycanParser parser = GlycanParserFactory.getParser(format);
-			String str = toString(parser);
-			if (str == null) throw new Exception("Invalid output string");
-
 			this.lastExportFailures = new ArrayList<Glycan>();
-			for (Glycan g : structures)
-				if (parser.writeGlycan(g).equals("")) this.lastExportFailures.add(g);
+			String str = toString(structures, parser, null, this.lastExportFailures);
+			if (str == null) throw new Exception("Invalid output string");
 
 			// write to file
 			bw.write(str, 0, str.length());
@@ -1518,30 +1512,68 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	 */
 	static public String toString(Collection<Glycan> structures,
 								  GlycanParser parser, BBoxManager bboxManager) {
+		return toString(structures, parser, bboxManager, null);
+	}
+
+	/**
+	 * Create a string representation of the specified structures using the given parser, noting which
+	 * of them produced nothing.
+	 *
+	 * <p><b>Why the failures are collected here.</b> The callers used to write everything once for the
+	 * file and then write it all again to find out which structures had come out empty. A structure
+	 * that cannot be converted reports that on the way through - a message naming what it could not
+	 * encode, and the exception under it - so writing it twice said it all twice, and a workspace with
+	 * two bad structures produced four dialogs to dismiss (#183).
+	 *
+	 * <p>One pass, and the emptiness noticed as it happens.
+	 *
+	 * @param failures
+	 *            filled with the structures that produced no output, or {@code null} to not ask
+	 */
+	static public String toString(Collection<Glycan> structures, GlycanParser parser,
+								  BBoxManager bboxManager, Collection<Glycan> failures) {
 
 		String str = "";
 		if (parser instanceof GWSParser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
-				str += parser.writeGlycan(i.next(), bboxManager);
+				Glycan structure = i.next();
+				str += record(parser.writeGlycan(structure, bboxManager), structure, failures);
 				if (i.hasNext()) str += ";";
 			}
 		} else if (parser instanceof WURCS2Parser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
-				str += parser.writeGlycan(i.next());
+				Glycan structure = i.next();
+				str += record(parser.writeGlycan(structure), structure, failures);
 				if (i.hasNext()) str += "\n";
 			}
 		} else {
+			// These formats hold one structure, so only the first is written - and the rest are
+			// therefore absent from the file, which is what the caller warns about.
+			Glycan first = structures.isEmpty() ? null : structures.iterator().next();
 			if (bboxManager != null) { //At the moment this will force conversion to GlycoCT_XML
-				str = parser.writeGlycan(structures.isEmpty() ? null : structures
-						.iterator().next(), bboxManager);
+				str = record(parser.writeGlycan(first, bboxManager), first, failures);
 			} else {
-				str = parser.writeGlycan(structures.isEmpty() ? null : structures
-						.iterator().next());
+				str = record(parser.writeGlycan(first), first, failures);
 			}
-
+			if (failures != null)
+				for (Glycan unwritten : structures)
+					if (unwritten != first && !failures.contains(unwritten)) failures.add(unwritten);
 		}
 
 		return str;
+	}
+
+	/**
+	 * Note a structure as a failure when it encoded to nothing, and hand the encoding straight back.
+	 *
+	 * <p>Returned unchanged, null included: {@code exportTo} tells a null apart from an empty string
+	 * and refuses the export on it, and turning one into the other here would write an empty file
+	 * without saying so.
+	 */
+	static private String record(String encoded, Glycan structure, Collection<Glycan> failures) {
+		if (failures != null && structure != null && (encoded == null || encoded.isEmpty()))
+			failures.add(structure);
+		return encoded;
 	}
 
 	public void fromString(String str, String format) throws Exception {

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/IonCloud.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/IonCloud.java
@@ -92,11 +92,31 @@ public class IonCloud {
 	 *            the mass of the glycan molecule
 	 */
 	public double computeMZ(double mass) {
+		return computeMZ(mass, false);
+	}
+
+	/**
+	 * Compute the mass/charge value of a structure with a certain mass given the charges in this
+	 * object, weighing the adducts the same way the structure was weighed.
+	 *
+	 * <p>The adducts used to be whatever they were when the ion was <em>set</em>, which is always
+	 * the monoisotopic figure - so an average neutral mass arrived carrying a monoisotopic adduct,
+	 * and the m/z was neither (#203). It matters most for potassium and chloride, +0.135 and +0.484
+	 * per adduct, and is nil for sodium, which has one stable isotope and would let a test pass
+	 * while proving nothing.
+	 *
+	 * @param mass
+	 *            the mass of the glycan molecule
+	 * @param average
+	 *            whether the adducts are to be averaged too, as {@link MassOptions#isAverage} says
+	 */
+	public double computeMZ(double mass, boolean average) {
 		if (mass <= 0.)
 			return mass;
+		double ionsMass = getIonsMass(average);
 		if (ionsNum == 0)
-			return (mass + ionsTotalMass);
-		return (mass + ionsTotalMass) / ionsNum;
+			return (mass + ionsMass);
+		return (mass + ionsMass) / ionsNum;
 	}
 
 	/**
@@ -108,12 +128,27 @@ public class IonCloud {
 	 *            associated charges
 	 */
 	public double computeMass(double mz) {
+		return computeMass(mz, false);
+	}
+
+	/**
+	 * Compute the original mass of a structure with a certain mass/charge value given the charges in
+	 * this object, taking the adducts off in the same weighing they were put on in.
+	 *
+	 * @param mz
+	 *            the mass/charge value of the glycan molecule with the associated charges
+	 * @param average
+	 *            whether the adducts were averaged, as {@link MassOptions#isAverage} says
+	 * @see #computeMZ(double, boolean)
+	 */
+	public double computeMass(double mz, boolean average) {
 		if (mz <= 0.)
 			return mz;
+		double ionsMass = getIonsMass(average);
 		if (ionsNum == 0)
-			return (mz - ionsTotalMass);
+			return (mz - ionsMass);
 
-		return (mz * ionsNum - ionsTotalMass);
+		return (mz * ionsNum - ionsMass);
 	}
 
 	/**
@@ -216,55 +251,28 @@ public class IonCloud {
 	 * has been added
 	 */
 	public IonCloud and(String charge, int quantity) {
-		if (charge.equals(MassOptions.ION_H))
-			return this.and(charge, MassUtils.h_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_LI))
-			return this.and(charge, MassUtils.li_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_NA))
-			return this.and(charge, MassUtils.na_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_K))
-			return this.and(charge, MassUtils.k_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_CL))
-			return this.and(charge, MassUtils.cl_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_H2PO4))
-			return this.and(charge, MassUtils.h2po4_ion.getMass(), quantity);
-		return this.clone();
+		Molecule adduct = moleculeFor(charge);
+		if (adduct == null)
+			return this.clone();
+		return this.and(charge, adduct.getMass(), quantity);
 	}
 
 	/**
 	 * Add a certain quantity of a new charge to this object
 	 */
 	public void add(String charge, int quantity) {
-		if (charge.equals(MassOptions.ION_H))
-			add(charge, MassUtils.h_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_LI))
-			add(charge, MassUtils.li_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_NA))
-			add(charge, MassUtils.na_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_K))
-			add(charge, MassUtils.k_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_CL))
-			add(charge, MassUtils.cl_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_H2PO4))
-			add(charge, MassUtils.h2po4_ion.getMass(), quantity);
+		Molecule adduct = moleculeFor(charge);
+		if (adduct != null)
+			add(charge, adduct.getMass(), quantity);
 	}
 
 	/**
 	 * Set the quantity of a specific charge
 	 */
 	public void set(String charge, int quantity) {
-		if (charge.equals(MassOptions.ION_H))
-			set(charge, MassUtils.h_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_LI))
-			set(charge, MassUtils.li_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_NA))
-			set(charge, MassUtils.na_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_K))
-			set(charge, MassUtils.k_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_CL))
-			set(charge, MassUtils.cl_ion.getMass(), quantity);
-		else if (charge.equals(MassOptions.ION_H2PO4))
-			set(charge, MassUtils.h2po4_ion.getMass(), quantity);
+		Molecule adduct = moleculeFor(charge);
+		if (adduct != null)
+			set(charge, adduct.getMass(), quantity);
 	}
 
 	/**
@@ -451,6 +459,56 @@ public class IonCloud {
 	}
 
 	/**
+	 * The total mass of the charges in this object, weighed monoisotopically or on average.
+	 *
+	 * <p>Recomputed from the adducts rather than read off {@link #ionsTotalMass}, which is whatever
+	 * was passed when each ion was set and is therefore always monoisotopic for the six named
+	 * adducts (#203).
+	 *
+	 * <p>A charge added with an explicit mass - a neutral exchange, say - keeps the mass it was
+	 * given. There is no second figure to reach for, and inventing one would be worse than using the
+	 * one the caller supplied.
+	 *
+	 * @param average
+	 *            whether to take each known adduct's average mass rather than its monoisotopic one
+	 */
+	public double getIonsMass(boolean average) {
+		if (!average)
+			return ionsTotalMass;
+
+		double total = 0.;
+		for (Map.Entry<String, Integer> e : this.ions.entrySet()) {
+			Molecule adduct = moleculeFor(e.getKey());
+			double mass = (adduct != null) ? adduct.getAverageMass()
+					: ionNameToChargeMass.getOrDefault(e.getKey(), 0.);
+			total += e.getValue() * mass;
+		}
+		return total;
+	}
+
+	/**
+	 * The molecule for one of the named adducts, or <code>null</code> for a charge this class does
+	 * not know by name.
+	 *
+	 * <p>One place, because adding a seventh adduct used to mean finding six copies of this chain.
+	 */
+	private static Molecule moleculeFor(String charge_name) {
+		if (MassOptions.ION_H.equals(charge_name))
+			return MassUtils.h_ion;
+		if (MassOptions.ION_LI.equals(charge_name))
+			return MassUtils.li_ion;
+		if (MassOptions.ION_NA.equals(charge_name))
+			return MassUtils.na_ion;
+		if (MassOptions.ION_K.equals(charge_name))
+			return MassUtils.k_ion;
+		if (MassOptions.ION_CL.equals(charge_name))
+			return MassUtils.cl_ion;
+		if (MassOptions.ION_H2PO4.equals(charge_name))
+			return MassUtils.h2po4_ion;
+		return null;
+	}
+
+	/**
 	 * Return a map containing the identities and quantities of the charges in
 	 * this object
 	 */
@@ -465,21 +523,9 @@ public class IonCloud {
 	public Molecule getMolecule() throws Exception {
 		Molecule ret = new Molecule();
 		for (Map.Entry<String, Integer> e : this.ions.entrySet()) {
-			String charge = e.getKey();
-			int num = e.getValue();
-
-			if (charge.equals(MassOptions.ION_H))
-				ret.add(MassUtils.h_ion, num);
-			else if (charge.equals(MassOptions.ION_LI))
-				ret.add(MassUtils.li_ion, num);
-			else if (charge.equals(MassOptions.ION_NA))
-				ret.add(MassUtils.na_ion, num);
-			else if (charge.equals(MassOptions.ION_K))
-				ret.add(MassUtils.k_ion, num);
-			else if (charge.equals(MassOptions.ION_CL))
-				ret.add(MassUtils.cl_ion, num);
-			else if (charge.equals(MassOptions.ION_H2PO4))
-				ret.add(MassUtils.h2po4_ion, num);
+			Molecule adduct = moleculeFor(e.getKey());
+			if (adduct != null)
+				ret.add(adduct, e.getValue());
 		}
 		return ret;
 	}

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/MassOptions.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/MassOptions.java
@@ -120,6 +120,19 @@ public class MassOptions {
 	}
 
 	/**
+	 * Whether masses are to be averaged rather than taken monoisotopically.
+	 *
+	 * <p>Asked here rather than compared to {@link #ISOTOPE_AVG} at each site that needs to know,
+	 * because there are several and they must agree: a neutral mass from the average table with an
+	 * adduct from the monoisotopic one gives a figure that is neither (#127, #203).
+	 *
+	 * @return Returns whether {@code ISOTOPE} says average.
+	 */
+	public boolean isAverage() {
+		return ISOTOPE_AVG.equals(ISOTOPE);
+	}
+
+	/**
 	 * Return the type of persubstitution applied to the structure.
 	 */
 	public String getDerivatization() {

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractGlycanRenderer.java
@@ -15,6 +15,7 @@ import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.text.DecimalFormat;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -692,6 +693,61 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		return text.toString();
 	}
 
+	/**
+	 * The children of one region, in the numeric order of the positions they attach at.
+	 *
+	 * <p><b>Why the order matters.</b> Every ordinary monosaccharide is placed straight out by
+	 * {@code residue_placements_snfg} and {@code residue_placements_cfg} — the rules that pick a side
+	 * from the linkage position apply to substituents, and a saccharide child falls through to the
+	 * catch-all {@code 1 → 0}. So all the branches of one residue arrive in a single region and are
+	 * stacked in the order this list happens to be in, which until now was the order the children were
+	 * stored: whatever the sequence said, or the order somebody drew them in.
+	 *
+	 * <p>That is what #29 is. Drawing a biantennary core and then attaching a GlcNAc to the β-Man's 4
+	 * appended it to the list, so it was stacked last and came out at the far edge — above the
+	 * 6-antenna rather than between the two antennae. Measured on 1.37.0, default orientation: the
+	 * 6-antenna fell from y=30 to y=82 and the new GlcNAc took y=30.
+	 *
+	 * <p><b>The convention.</b> Branches are drawn in the numeric order of their linkage positions, so
+	 * a bisecting GlcNAc at 4 sits between the 3- and 6-antennae (I. Yamada, 2026-08-14). GlycoCraft's
+	 * {@code LAYOUT_ALGORITHM.md} states the same rule and gives worked coordinates: α1-6 Man above,
+	 * the bisecting GlcNAc level with its parent, α1-3 Man below.
+	 *
+	 * <p><b>Ascending, in every orientation.</b> The four orientations stack a region from opposite
+	 * ends — LR downwards, RL upwards, TB leftwards, BT rightwards — so the same ascending list lands
+	 * differently in each. Ascending is what each of them was already doing correctly for a plain
+	 * biantennary core, in the three orientations that had it right, so ordering by position fixes
+	 * where a middle branch goes without moving anything that was already where it belonged.
+	 *
+	 * <p>An unknown position sorts last and keeps the order it came in: there is nothing to compare it
+	 * with, and moving it would be a guess dressed as a rule.
+	 */
+	private LinkedList<Residue> inPositionOrder(LinkedList<Residue> children) {
+		if (children.size() < 2) return children;
+
+		// A stable sort, so children that cannot be compared stay as they were.
+		children.sort(Comparator.comparingInt(AbstractGlycanRenderer::linkagePositionOf));
+		return children;
+	}
+
+	/**
+	 * The position a residue attaches to its parent at, for ordering.
+	 *
+	 * @return Returns the position as a number, or {@link Integer#MAX_VALUE} when there is no single
+	 *         known position — no parent, an unknown position, or several candidates, none of which
+	 *         says where the branch belongs.
+	 */
+	private static int linkagePositionOf(Residue residue) {
+		Linkage link = residue.getParentLinkage();
+		if (link == null) return Integer.MAX_VALUE;
+
+		Collection<Character> positions = link.getParentPositions();
+		if (positions == null || positions.size() != 1) return Integer.MAX_VALUE;
+
+		char position = positions.iterator().next();
+		return Character.isDigit(position) ? Character.getNumericValue(position) : Integer.MAX_VALUE;
+	}
+
 	private void computeBoundingBoxes(Residue node, PositionManager posManager,
 									  BBoxManager bboxManager, boolean _isComposition) throws Exception {
 		if (node == null) return;
@@ -762,7 +818,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (right)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0));
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0)));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager, _isComposition);
 			if (i > 0)
@@ -887,7 +943,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (left)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0), false);
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0), false));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager ,_isComposition);
 			if (i > 0)
@@ -1019,7 +1075,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (bottom)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0));
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0)));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager, _isComposition);
 			if (i > 0)
@@ -1145,7 +1201,7 @@ public abstract class AbstractGlycanRenderer implements GlycanRenderer{
 		}
 
 		// position 0 (top)
-		LinkedList<Residue> region_0 = posManager.getChildrenAtPosition(node, new ResAngle(0));
+		LinkedList<Residue> region_0 = inPositionOrder(posManager.getChildrenAtPosition(node, new ResAngle(0)));
 		for (int i = 0; i < region_0.size(); i++) {
 			computeBoundingBoxes(region_0.get(i), posManager, bboxManager, _isComposition);
 			if (i > 0)

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractResidueRenderer.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/AbstractResidueRenderer.java
@@ -181,7 +181,19 @@ public abstract class AbstractResidueRenderer implements ResidueRenderer{
     	return p;
     }
 
-    static private Shape createHatDiamond(double angle, double x, double y, double w, double h) {
+    /**
+     * A diamond with a hat on its upper left.
+     *
+     * <p>Takes no angle, and never did anything with one. {@code createShape} handed it the
+     * direction of the residue's own bond, which read as though the symbol turned with the
+     * structure - and #83 was opened to ask whether that was intended for CFG. It was not happening:
+     * the hat is placed from the bounding box and nothing else, so the symbol has always been the
+     * same whichever way the structure is drawn. The argument is gone so that the code says so.
+     *
+     * <p>If CFG should turn these with the bond, that is a change to make deliberately, and this is
+     * not it.
+     */
+    static private Shape createHatDiamond(double x, double y, double w, double h) {
     	GeneralPath f = new GeneralPath();
 
     	// append diamond
@@ -196,7 +208,8 @@ public abstract class AbstractResidueRenderer implements ResidueRenderer{
     	return f;
     }
 
-    static private Shape createRHatDiamond(double angle, double x, double y, double w, double h) {
+    /** The mirror of {@link #createHatDiamond}, with the hat on the upper right. Also takes no angle. */
+    static private Shape createRHatDiamond(double x, double y, double w, double h) {
     	GeneralPath f = new GeneralPath();
 
     	// append diamond
@@ -733,10 +746,11 @@ public abstract class AbstractResidueRenderer implements ResidueRenderer{
     			return createUpTriangle(x,y,w,h);
     		return createTriangle(angle(pp,ps),x,y,w,h);
     	}
-    	if( shape.equals("hatdiamond") ) 
-    		return createHatDiamond(angle(pp,ps),x,y,w,h);            
-    	if( shape.equals("rhatdiamond") ) 
-    		return createRHatDiamond(angle(pp,ps),x,y,w,h);            
+    	// No angle: these have never turned with the bond, whatever passing one suggested (#83)
+    	if( shape.equals("hatdiamond") )
+    		return createHatDiamond(x,y,w,h);
+    	if( shape.equals("rhatdiamond") )
+    		return createRHatDiamond(x,y,w,h);
     
     	if( shape.equals("bracket") ) 
     		return createBracket(orientation.getAngle(),x,y,w,h);

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/ResidueRendererAWT.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/renderutil/ResidueRendererAWT.java
@@ -244,7 +244,7 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
     		if( orientation.equals(0) || orientation.equals(180) ) {
     			Rectangle2D.Double text_rect = new Rectangle2D.Double(midx(cur_bbox)-text_bound.width/2,midy(cur_bbox)-text_bound.height/2,text_bound.width,text_bound.height);
     			if( shape==null || fill_shape==null ) 
-    				g2d.clearRect((int)text_rect.x,(int)text_rect.y,(int)text_rect.width,(int)text_rect.height);
+    				clearAround(g2d,text_rect);
     			g2d.drawString(text,(int)text_rect.x,(int)(text_rect.y+text_rect.height));
     		}
     		if(orientation.equals(-90) || orientation.equals(90)) {
@@ -257,12 +257,12 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
     			if(isSNFG || shape==null) {
     				Rectangle2D.Double text_rect = new Rectangle2D.Double(midx(cur_bbox)-text_bound.width/2,midy(cur_bbox)-text_bound.height/2,text_bound.width,text_bound.height);
         			if( shape==null || fill_shape==null )
-        				g2d.clearRect((int)text_rect.x,(int)text_rect.y,(int)text_rect.width,(int)text_rect.height);
+        				clearAround(g2d,text_rect);
         			g2d.drawString(text,(int)text_rect.x,(int)(text_rect.y+text_rect.height));
     			} else {
     				Rectangle2D.Double text_rect = new Rectangle2D.Double(midx(cur_bbox)-text_bound.height/2,midy(cur_bbox)-text_bound.width/2,text_bound.height,text_bound.width);
     				if( shape==null || fill_shape==null ) 
-    					g2d.clearRect((int)text_rect.x,(int)text_rect.y,(int)text_rect.width,(int)text_rect.height);        
+    					clearAround(g2d,text_rect);        
     				
     				g2d.rotate(-Math.PI/2.0); 
     				g2d.drawString(text,-(int)(text_rect.y+text_rect.height),(int)(text_rect.x+text_rect.width));
@@ -272,6 +272,8 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
 
     		g2d.setFont(old_font);
     	}
+
+
     	
     	boolean isShow = false;
     	if(node.isSaccharide()) isShow = GlycanUtils.isFacingAnom(node);
@@ -286,6 +288,41 @@ public class ResidueRendererAWT extends AbstractResidueRenderer {
 
     	g2d.setColor(Color.black);
     	//g2d.drawString(""+node.id,left(cur_bbox),bottom(cur_bbox));
+    }
+
+    /**
+       Clears a margin around a label so it does not run into what is behind it.
+
+       <p>The cleared area used to be the glyphs' own bounds, cast to int - which truncates the
+       origin one way and the width the other, so a label came out with about a pixel of room on its
+       left and none on its right. On a phosphate bridge the P then touched the edge of the linkage
+       and read as part of it (#88).</p>
+
+       <p>A pixel each side, and rounded rather than truncated, so the room is the same on both.</p>
+
+       @param g2d Where the label is being drawn.
+       @param text_rect The glyphs' bounds.
+    */
+    static private void clearAround(Graphics2D g2d, Rectangle2D.Double text_rect) {
+    	Rectangle room = clearanceAround(text_rect);
+    	g2d.clearRect(room.x,room.y,room.width,room.height);
+    }
+
+    /**
+       The area to clear for a label: its glyphs, and a pixel of room on every side.
+
+       @param text_rect The glyphs' bounds.
+       @return Returns the area, in whole pixels.
+    */
+    static public Rectangle clearanceAround(Rectangle2D.Double text_rect) {
+    	final int margin = 1;
+
+    	int x = (int)Math.floor(text_rect.x) - margin;
+    	int y = (int)Math.floor(text_rect.y) - margin;
+    	int right = (int)Math.ceil(text_rect.x + text_rect.width) + margin;
+    	int bottom = (int)Math.ceil(text_rect.y + text_rect.height) + margin;
+
+    	return new Rectangle(x,y,right-x,bottom-y);
     }
     
     private Graphics2D showAnomericState(Graphics2D g2d, Residue node, ResAngle orientation, Rectangle cur_bbox) {

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/LinkageConnector.java
@@ -178,6 +178,17 @@ public class LinkageConnector {
 		a_oEndRep.setStartResidue(this.start);
 		a_oRES.setEndRepitionResidue(a_oEndRep);
 
+		/*
+		 * The marker has to carry the position the repeat closes on before it is added as a child
+		 * (#204). addChild rebuilds the linkage from the bonds and finishes by taking the child's own
+		 * anomeric carbon, which for a freshly created marker is '?' - so the position GLINToLinkage
+		 * had just worked out was read back over, and l1-m3~n was written out as l?-m3~n.
+		 *
+		 * makeEdgeWithStartBracket has always done this for the opening marker. Only this side was
+		 * missing it.
+		 */
+		a_oEndRep.setAnomericCarbon(a_oG2L.getEndSideRepLinkage().getAnomericCarbon());
+
 		// sugar->sub->EndRep
 		if(a_oG2L.getEndSideRepLinkage().getChildResidue() != null) {
 			a_oSUB = a_oG2L.getEndSideRepLinkage().getChildResidue();

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ABridgeLabelHasRoomTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/ABridgeLabelHasRoomTest.java
@@ -1,0 +1,55 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.awt.geom.Rectangle2D;
+
+import org.eurocarbdb.application.glycanbuilder.renderutil.ResidueRendererAWT;
+import org.junit.Test;
+
+/**
+ * That a label is cleared with the same room on every side (#88).
+ *
+ * <p>The cleared area used to be the glyphs' bounds cast to int, which truncates the origin one way
+ * and the width the other — so a label came out with about a pixel of room on its left and none on
+ * its right. On a phosphate bridge the P then touched the edge of the linkage and read as part of
+ * it.
+ */
+public class ABridgeLabelHasRoomTest {
+
+	/** Room on all four sides, whatever fraction of a pixel the glyphs happen to start on. */
+	@Test
+	public void thereIsRoomOnEverySide() {
+		for (double offset : new double[] { 0.0, 0.1, 0.5, 0.9 }) {
+			Rectangle2D.Double glyphs = new Rectangle2D.Double(10 + offset, 20 + offset, 7.4, 9.6);
+			Rectangle cleared = ResidueRendererAWT.clearanceAround(glyphs);
+
+			assertTrue("nothing cleared to the left at offset " + offset,
+					cleared.getX() < glyphs.getX());
+			assertTrue("nothing cleared above at offset " + offset,
+					cleared.getY() < glyphs.getY());
+			assertTrue("nothing cleared to the right at offset " + offset,
+					cleared.getMaxX() > glyphs.getMaxX());
+			assertTrue("nothing cleared below at offset " + offset,
+					cleared.getMaxY() > glyphs.getMaxY());
+		}
+	}
+
+	/**
+	 * And the room is even, which is what the report was about.
+	 *
+	 * <p>It is the asymmetry that made the P look attached: one side had a pixel and the other had
+	 * nothing, so the label sat against the linkage on the right.
+	 */
+	@Test
+	public void theRoomIsTheSameOnBothSides() {
+		Rectangle2D.Double glyphs = new Rectangle2D.Double(10.6, 20.6, 7.4, 9.6);
+		Rectangle cleared = ResidueRendererAWT.clearanceAround(glyphs);
+
+		double left = glyphs.getX() - cleared.getX();
+		double right = cleared.getMaxX() - glyphs.getMaxX();
+
+		assertTrue("left " + left + " against right " + right, Math.abs(left - right) <= 1.0);
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AdductIsWeighedLikeTheStructureTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AdductIsWeighedLikeTheStructureTest.java
@@ -1,0 +1,123 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an m/z weighs its adduct the same way it weighed the structure (#203).
+ *
+ * <p>#127 brought the neutral mass under {@code MassOptions.ISOTOPE}. It did not reach the adducts:
+ * {@code IonCloud} captured an ion's mass when the ion was <em>set</em>, which is always the
+ * monoisotopic figure, so an average neutral mass arrived carrying a monoisotopic adduct and the m/z
+ * was neither.
+ *
+ * <p><b>The test is written on potassium and chloride on purpose.</b> Sodium has one stable isotope,
+ * so its average and monoisotopic masses are the same number and a sodiated m/z was right by accident
+ * throughout - a test written on the default adduct would have passed before the fix. Sodium appears
+ * here as the control that says so.
+ *
+ * <p>The expected differences are the atomic ones, from the periodic table rather than from this
+ * code: K 39.0983 against 38.96371, Cl 35.4525 against 34.96885. The electron taken off for the
+ * charge is a constant and cancels.
+ */
+public class AdductIsWeighedLikeTheStructureTest {
+
+	/** Man₃GlcNAc₂, the N-glycan core: 910.3278 monoisotopic, 910.82 average. */
+	private static final String CORE =
+			"freeEnd--?b1D-GlcNAc,p--4b1D-GlcNAc,p--4b1D-Man,p--3b1D-Man,p--?b1D-Man,p";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * A potassiated m/z gains the adduct's average-minus-monoisotopic difference on top of the
+	 * structure's own.
+	 *
+	 * <p>This is the assertion that fails without the fix, by 0.1346 - small, never zero, and
+	 * plausible at every digit somebody would think to check.
+	 */
+	@Test
+	public void potassiumIsAveragedToo() {
+		assertEquals("the potassium adduct is still monoisotopic in an average m/z",
+				0.134594, adductContributionToTheAverage(MassOptions.ION_K), 0.001);
+	}
+
+	/** Chloride is the same fault at four times the size. */
+	@Test
+	public void chlorideIsAveragedToo() {
+		assertEquals("the chloride adduct is still monoisotopic in an average m/z",
+				0.483685, adductContributionToTheAverage(MassOptions.ION_CL), 0.001);
+	}
+
+	/**
+	 * Sodium contributes nothing, having one stable isotope — the control.
+	 *
+	 * <p>If this ever fails, the adduct is being averaged against something that is not the atom.
+	 */
+	@Test
+	public void sodiumHasNothingToAverage() {
+		assertEquals("sodium has one stable isotope and cannot differ",
+				0., adductContributionToTheAverage(MassOptions.ION_NA), 0.0001);
+	}
+
+	/**
+	 * And the monoisotopic m/z is unchanged, which is the half that matters more.
+	 *
+	 * <p>Man₃GlcNAc₂ 910.3278 plus a sodium ion, 22.98977 less the electron.
+	 */
+	@Test
+	public void theMonoisotopicMZIsUnchanged() {
+		assertEquals(933.3170, mz(MassOptions.ISOTOPE_MONO, MassOptions.ION_NA), 0.001);
+		assertEquals(949.2911, mz(MassOptions.ISOTOPE_MONO, MassOptions.ION_K), 0.001);
+	}
+
+	/**
+	 * How much of the m/z's average-minus-monoisotopic gap the adduct is responsible for.
+	 *
+	 * <p>The structure's own gap is subtracted, so what is left is the adduct's alone and can be
+	 * compared against the periodic table.
+	 */
+	private static double adductContributionToTheAverage(String ion) {
+		double mzGap = mz(MassOptions.ISOTOPE_AVG, ion) - mz(MassOptions.ISOTOPE_MONO, ion);
+		double massGap = mass(MassOptions.ISOTOPE_AVG) - mass(MassOptions.ISOTOPE_MONO);
+		return mzGap - massGap;
+	}
+
+	private static double mz(String isotope, String ion) {
+		return weigh(isotope, ion).computeMZ();
+	}
+
+	private static double mass(String isotope) {
+		return weigh(isotope, null).computeMass();
+	}
+
+	private static Glycan weigh(String isotope, String ion) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		try {
+			document.importFromString(CORE, "gws");
+		} catch (Exception cannotRead) {
+			throw new IllegalStateException(CORE, cannotRead);
+		}
+
+		Glycan glycan = document.getStructures().get(0);
+		MassOptions options = glycan.getMassOptions();
+		options.DERIVATIZATION = MassOptions.NO_DERIVATIZATION;
+		options.ISOTOPE = isotope;
+		options.ION_CLOUD = new IonCloud();
+		if (ion != null)
+			options.ION_CLOUD.set(ion, 1);
+		glycan.setMassOptions(options);
+
+		return glycan;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/BranchesAreDrawnInPositionOrderTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/BranchesAreDrawnInPositionOrderTest.java
@@ -1,0 +1,202 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.linkage.Linkage;
+import org.eurocarbdb.application.glycanbuilder.renderutil.BBoxManager;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.eurocarbdb.application.glycanbuilder.renderutil.PositionManager;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a branch goes where its linkage position says, not where the drawing order left it (#29).
+ *
+ * <p>Every ordinary monosaccharide is placed straight out — the placement rules that pick a side from
+ * the linkage position apply to substituents, and a saccharide child falls through to the catch-all.
+ * So all of a residue's branches arrive in one region and are stacked in the order the children are
+ * stored, which was the order the sequence listed them or the order somebody drew them in.
+ *
+ * <p>Attaching a GlcNAc to the β-Man's 4 of a finished biantennary core therefore appended it, and it
+ * was stacked last: at the far edge, above the 6-antenna, rather than between the two antennae. The
+ * convention is that branches are drawn in the numeric order of their positions, so a bisecting
+ * GlcNAc at 4 belongs between the 3- and 6-antennae (I. Yamada, 2026-08-14), which is also what
+ * GlycoCraft's layout document states.
+ *
+ * <p>These assertions are about order along the axis the branches stack on, not about coordinates. A
+ * test pinned to y=30 and y=82 would fail on any change to spacing and would say nothing about what
+ * had gone wrong.
+ */
+public class BranchesAreDrawnInPositionOrderTest {
+
+	private static final String RESIDUES =
+			"[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5]";
+
+	/** A biantennary N-glycan core: antennae at the β-Man's 3 and 6. */
+	private static final String CORE =
+			"WURCS=2.0/3,5,4/" + RESIDUES + "/1-1-2-3-3/a4-b1_b4-c1_c3-d1_c6-e1";
+
+	/** The same with a bisecting GlcNAc at 4, stated in the sequence. */
+	private static final String BISECTED =
+			"WURCS=2.0/3,6,5/" + RESIDUES + "/1-1-2-3-1-3/a4-b1_b4-c1_c3-d1_c4-e1_c6-f1";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * The bisecting GlcNAc sits between the two antennae, in the default orientation.
+	 *
+	 * <p>Without the fix it is above both of them: measured on 1.37.0, the 6-antenna fell from y=30 to
+	 * y=82 and the new GlcNAc took y=30.
+	 */
+	@Test
+	public void aBisectingGlcNAcSitsBetweenTheAntennae() throws Exception {
+		Glycan structure = coreWithGlcNAcAddedAfterwards();
+
+		int sixAntenna = topOf(structure, branchAt(structure, '6'));
+		int bisecting = topOf(structure, branchAt(structure, '4'));
+		int threeAntenna = topOf(structure, branchAt(structure, '3'));
+
+		assertTrue("the 6-antenna should be above the bisecting GlcNAc, and is at " + sixAntenna
+				+ " against " + bisecting, sixAntenna < bisecting);
+		assertTrue("the bisecting GlcNAc should be above the 3-antenna, and is at " + bisecting
+				+ " against " + threeAntenna, bisecting < threeAntenna);
+	}
+
+	/**
+	 * It is drawn level with the residue it hangs off, which is what "straight out" means.
+	 *
+	 * <p>GlycoCraft states this as the rule for position 4 and gives the coordinate: the bisecting
+	 * GlcNAc on the parent's own line, an antenna above and an antenna below.
+	 */
+	@Test
+	public void aBisectingGlcNAcIsLevelWithItsParent() throws Exception {
+		Glycan structure = coreWithGlcNAcAddedAfterwards();
+
+		assertEquals("the bisecting GlcNAc should be on the β-Man's own line",
+				topOf(structure, betaMan(structure)), topOf(structure, branchAt(structure, '4')));
+	}
+
+	/**
+	 * Adding it afterwards gives the same picture as stating it in the sequence.
+	 *
+	 * <p>This is what the issue reports — that it depends on when you attach it — and it is the whole
+	 * of the rule: the picture follows the molecule, not the order it was assembled in.
+	 */
+	@Test
+	public void whenItWasAddedMakesNoDifference() throws Exception {
+		Glycan added = coreWithGlcNAcAddedAfterwards();
+		Glycan stated = wurcs(BISECTED);
+
+		assertEquals("stating the GlcNAc in the sequence and adding it afterwards draw differently",
+				rowsOf(stated), rowsOf(added));
+	}
+
+	/**
+	 * And a plain biantennary core is where it always was: 6-antenna above, 3-antenna below.
+	 *
+	 * <p>The way to make the assertions above pass wrongly is to reverse the stacking, which would move
+	 * every branch in every structure. This is the half that says nothing else moved.
+	 */
+	@Test
+	public void aPlainCoreIsUnchanged() throws Exception {
+		Glycan structure = wurcs(CORE);
+
+		assertTrue("the 6-antenna should be above the 3-antenna",
+				topOf(structure, branchAt(structure, '6')) < topOf(structure, branchAt(structure, '3')));
+	}
+
+	/** The core as imported, with a GlcNAc then attached to the β-Man's 4 — the path #29 describes. */
+	private static Glycan coreWithGlcNAcAddedAfterwards() throws Exception {
+		Glycan structure = wurcs(CORE);
+
+		assertTrue("the GlcNAc was refused at the β-Man's 4",
+				betaMan(structure).addChild(ResidueDictionary.newResidue("GlcNAc"), '4'));
+
+		return structure;
+	}
+
+	/**
+	 * Which residue is drawn on which row, so two layouts can be compared as a whole.
+	 *
+	 * <p>Sorted, because the two structures are walked in different orders — the same picture described
+	 * from two directions is the same picture, and comparing the walk would be comparing the wrong
+	 * thing.
+	 */
+	private static List<String> rowsOf(Glycan structure) throws Exception {
+		BBoxManager boxes = boxes(structure);
+
+		List<String> rows = new ArrayList<String>();
+		for (Residue residue : structure.getAllResidues()) {
+			Rectangle box = boxes.getCurrent(residue);
+			if (box == null || residue.getParentLinkage() == null) continue;
+			rows.add(residue.getTypeName() + "@" + positionOf(residue) + ":" + box.y);
+		}
+		Collections.sort(rows);
+
+		return rows;
+	}
+
+	/** Where the top edge of a residue ends up. */
+	private static int topOf(Glycan structure, Residue residue) throws Exception {
+		Rectangle box = boxes(structure).getCurrent(residue);
+		assertTrue(residue.getTypeName() + " was not laid out", box != null);
+		return box.y;
+	}
+
+	/**
+	 * The branch point: the Man carrying more than one child.
+	 *
+	 * <p>Found by its children rather than by name and position. The chitobiose core has a GlcNAc at
+	 * position 4 as well, and an earlier version of this test picked that one up and compared the wrong
+	 * pair of residues — it failed without the change, but for the wrong reason.
+	 */
+	private static Residue betaMan(Glycan structure) {
+		for (Residue residue : structure.getAllResidues())
+			if ("Man".equals(residue.getTypeName()) && residue.getNoChildren() >= 2)
+				return residue;
+		throw new IllegalStateException("no branch point");
+	}
+
+	/** The β-Man's child at one of its positions — an antenna, or the bisecting GlcNAc. */
+	private static Residue branchAt(Glycan structure, char position) {
+		for (Linkage link : betaMan(structure).getChildrenLinkages())
+			if (positionOf(link.getChildResidue()) == position)
+				return link.getChildResidue();
+		throw new IllegalStateException("the branch point has nothing at " + position);
+	}
+
+	private static char positionOf(Residue residue) {
+		Linkage link = residue.getParentLinkage();
+		if (link == null || link.getParentPositions().size() != 1) return '?';
+		return link.getParentPositions().iterator().next();
+	}
+
+	private static BBoxManager boxes(Glycan structure) throws Exception {
+		GlycanRendererAWT renderer = new GlycanRendererAWT();
+		BBoxManager boxes = new BBoxManager();
+		renderer.computeBoundingBoxes(Collections.singletonList(structure), false, false,
+				new PositionManager(), boxes);
+		return boxes;
+	}
+
+	private static Glycan wurcs(String sequence) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the WURCS would not import", document.importFromString(sequence, "wurcs2"));
+
+		return document.getStructures().get(0);
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OneMessagePerFailedExportTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/OneMessagePerFailedExportTest.java
@@ -1,0 +1,126 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a structure which cannot be exported is only converted once (#183).
+ *
+ * <p>The export wrote everything for the file and then wrote it all over again to find out which
+ * structures had come out empty. A structure that cannot be converted says so on the way through, and
+ * {@code LogUtils.report} answers one failure with two windows — the message, then the stack — so a
+ * second pass produced a second pair. That is the "two sets (error+exception)" per failed structure the
+ * report describes, and with two bad structures, four.
+ *
+ * <p><b>The count is what this tests.</b> Asserting on dialogs would mean driving Swing; asserting that
+ * each structure is handed to the parser exactly once says the same thing about the cause, and it was
+ * the cause that was doubled.
+ *
+ * <p><b>The sequence in the report no longer fails.</b> {@code WURCS=2.0/1,1,0/[A111h]/1/} writes back
+ * unchanged as of 1.37.0, so the skeleton-code error it was reported with is gone and those steps
+ * produce no dialogs at all. The doubling was still there to be found by reading, and would have
+ * doubled the next failure just as well — which is why it is fixed here rather than closed as
+ * not-reproducible.
+ */
+public class OneMessagePerFailedExportTest {
+
+	private static final String ORDINARY_GLYCAN =
+			"freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd";
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * Each structure is handed to the parser once, whether it converts or not.
+	 *
+	 * <p>Before the change this counted two per structure.
+	 */
+	@Test
+	public void everyStructureIsConvertedOnce() throws Exception {
+		CountingParser parser = new CountingParser();
+		GlycanDocument.toString(twoStructures(), parser, null, new ArrayList<Glycan>());
+
+		assertEquals("each structure should be converted once", 2, parser.calls);
+	}
+
+	/** The ones that produced nothing are still named, which is what the warning dialog reads. */
+	@Test
+	public void theEmptyOnesAreStillNamed() throws Exception {
+		LinkedList<Glycan> structures = twoStructures();
+		Glycan bad = structures.getLast();
+
+		CountingParser parser = new CountingParser();
+		parser.silentAbout = bad;
+		List<Glycan> failures = new ArrayList<Glycan>();
+		GlycanDocument.toString(structures, parser, null, failures);
+
+		assertEquals("the structure that produced nothing should be named once", 1, failures.size());
+		assertTrue("the wrong structure was named", failures.contains(bad));
+		assertEquals("and it should still have been converted only once", 2, parser.calls);
+	}
+
+	/**
+	 * An ordinary export is unaffected: both structures in the file, nothing reported as failed.
+	 *
+	 * <p>Through the real writer, since the point of collecting the failures during the single pass is
+	 * that it still fills in what the warning needs.
+	 */
+	@Test
+	public void anOrdinaryExportStillWritesEverything() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.importFromString(ORDINARY_GLYCAN, "gws"));
+		assertTrue(document.importFromString("WURCS=2.0/1,1,0/[A111h]/1/", "wurcs2"));
+
+		File file = File.createTempFile("glycanbuilder-183-", ".wurcs");
+		file.deleteOnExit();
+		assertTrue("the export failed outright", document.exportTo(file.getAbsolutePath(), "wurcs2"));
+
+		String written = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+		assertEquals("both structures should have been written",
+				2, written.trim().split("\\R").length);
+		assertTrue("nothing should have been reported as failed: "
+				+ document.getLastExportFailures(), document.getLastExportFailures().isEmpty());
+	}
+
+	private static LinkedList<Glycan> twoStructures() throws Exception {
+		LinkedList<Glycan> structures = new LinkedList<Glycan>();
+		structures.add(Glycan.fromString(ORDINARY_GLYCAN));
+		structures.add(Glycan.fromString(ORDINARY_GLYCAN));
+		return structures;
+	}
+
+	/**
+	 * Counts what it is asked to write, and can be told to produce nothing for one structure.
+	 *
+	 * <p>A {@link WURCS2Parser} rather than a bare {@code GlycanParser}, because the encoder picks its
+	 * loop by the parser's type and only the sequence formats write more than the first structure.
+	 */
+	private static final class CountingParser extends WURCS2Parser {
+
+		private int calls;
+		private Glycan silentAbout;
+
+		@Override
+		public String writeGlycan(Glycan structure) {
+			calls++;
+			return (structure == silentAbout) ? "" : "written";
+		}
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RepeatKeepsItsLinkagePositionTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/RepeatKeepsItsLinkagePositionTest.java
@@ -1,0 +1,74 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That the position a repeat closes on survives a round trip (#204).
+ *
+ * <p>It did not: {@code l1-m3~n} was read in and written back as {@code l?-m3~n}. Every other linkage
+ * in the sequence round-tripped. {@code ?} is not a rounding of {@code 1} — it is the sequence saying
+ * the position is unknown, about a position the input had stated, so the export said less than the
+ * import and said it in a form that looks deliberate.
+ *
+ * <p><b>Where it went.</b> {@code addChild} rebuilds a linkage from its bonds and finishes by taking
+ * the child residue's own anomeric carbon. The closing marker is created fresh and has none, so the
+ * position {@code GLINToLinkage} had just worked out from the donor side was read back over with
+ * {@code '?'}. The opening marker never had the problem, because
+ * {@code makeEdgeWithStartBracket} sets its anomeric carbon before adding it; only the closing side
+ * was missing that line.
+ */
+public class RepeatKeepsItsLinkagePositionTest {
+
+	/**
+	 * G03246MZ, the structure the fault was found on while measuring #57 — a repeating unit inside an
+	 * N-glycan antenna.
+	 */
+	private static final String G03246MZ = "WURCS=2.0/7,15,15/[h2122h_2*NCC/3=O]"
+			+ "[a2122h-1b_1-5_2*NCC/3=O][a1122h-1b_1-5][a1122h-1a_1-5][a2112h-1b_1-5]"
+			+ "[Aad21122h-2a_2-6_5*NCC/3=O][a1221m-1a_1-5]/1-2-3-4-2-5-6-2-5-6-4-2-5-6-7/"
+			+ "a4-b1_a6-o1_b4-c1_c3-d1_c6-k1_d2-e1_d4-h1_e4-f1_f3-g2_h4-i1_i3-j2_k2-l1_l4-m1_m3-n2"
+			+ "_l1-m3~n";
+
+	/**
+	 * A repeat and nothing else, so a failure here cannot be blamed on anything around it: GlcNAc
+	 * and GlcA repeating through {@code a1-b3}.
+	 */
+	private static final String REPEAT_ALONE =
+			"WURCS=2.0/2,2,2/[a2122h-1b_1-5_2*NCC/3=O][a2122A-1b_1-5]/1-2/a4-b1_a1-b3~n";
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * The smallest case: the repeat's own position comes back as it went in.
+	 *
+	 * <p>Without the fix this reads {@code a?-b3~n}.
+	 */
+	@Test
+	public void aRepeatAloneKeepsItsPosition() throws Exception {
+		assertRoundTrip(REPEAT_ALONE);
+	}
+
+	/** And in the structure it was reported on, where the repeat sits inside an antenna. */
+	@Test
+	public void aRepeatInsideAnAntennaKeepsItsPosition() throws Exception {
+		assertRoundTrip(G03246MZ);
+	}
+
+	private void assertRoundTrip(String wurcs) throws Exception {
+		WURCS2Parser parser = new WURCS2Parser();
+		Glycan glycan = parser.readGlycan(wurcs, new MassOptions());
+		assertEquals("the position the repeat closes on did not survive", wurcs,
+				parser.writeGlycan(glycan));
+	}
+}


### PR DESCRIPTION
Release 1.38.0.

**Minor rather than patch**: `IonCloud.computeMZ` and `computeMass` gain an isotope-aware overload and
`GlycanDocument.toString` a four-argument one, `MassOptions` gains `isAverage()`, and an m/z built on the
average table now returns a different number than it did. Every picture with more than one branch off a
residue may also be laid out differently. A consumer relying on any of those would see the change.

| # | What | Verified by |
|---|---|---|
| #203 | An m/z paired an average neutral mass with a monoisotopic adduct | potassium assertion read `0.0` before, `0.134594` after — against the periodic table, not this code |
| #204 | A repeat unit's own position was written back as unknown | `l1-m3~n` → `l?-m3~n` before; G03246MZ now round-trips character for character |
| #29 | A bisecting GlcNAc was drawn above the 6-antenna | 6-antenna y=82→30, bisecting y=30→82, level with its β-Man; plain core unchanged in all four orientations |
| #183 | A failed export said everything twice | each structure handed to the parser once instead of twice |
| #88 | A bridge label had no room on its right | the cleared area was the glyphs' bounds cast to `int` |
| #83 | The CFG hat diamonds took an angle nothing used | removed; it does not answer the report, and the reporter has been asked |

181 tests pass. `origin/develop` reads 1.38.0 — checked against the remote rather than the local ref.

### Three things worth reading twice

**Sodium was right by accident.** #203's adduct fault is invisible on the default adduct: sodium has one
stable isotope, so its average and monoisotopic masses are the same number and a sodiated m/z was correct
throughout. A test written on the default would have passed before the fix. It is written on potassium and
chloride, with sodium kept as the control that says why.

**#29 was not where the issue and I both thought it was.** My own earlier comment said 4 and 6 both match
`lp=[4-9]` in the placement dictionary and are therefore sent to the same side. That was read off the rule
without checking which children it applies to: `(!cs)` means "child is not a monosaccharide", so both
position-to-side rules are about substituents and every ordinary monosaccharide falls through to the
catch-all. The real cause was that all branches land in one region and were stacked in whatever order the
children happened to be stored. `docs/linkage-positions-and-anomers.md` now says so and keeps the wrong
version on the page, because the dictionary reads as saying more than it does and the next reader deserves
the warning.

**#183 is fixed on the mechanism, not on a reproduction.** `WURCS=2.0/1,1,0/[A111h]/1/`, the sequence in
the report, writes back unchanged now — so the steps described produce no dialogs at all and this changes
nothing a user would see with that structure. The doubling was real and would have doubled the next
failure, so it is fixed rather than closed as not-reproducible, and the reporter has been asked for a case
that still fails. Its tests do not fail before the change and cannot: the doubling was in callers that
build their own parser, so a counting parser cannot observe them. The deleted second loop is the evidence.

### Before this release, the tracker was corrected

Nine issues were marked fixed in `TRIAGE.md` and still open on GitHub, and two measured faults were filed
nowhere. That was dealt with first — ten issues closed with their measurements, #203 and #204 filed — on
the grounds this repository's own list is most emphatic about: silence outranks severity, and an issue
saying a fixed bug is live is quietly wrong to everyone outside the project.

**#88, #83, #203, #204, #29 and #183 are still open on purpose** and close when this release is out.
`develop` is not the default branch so `Closes #N` did not fire on merge, and closing them by hand would
have told each reporter it was done while no installable version had it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
