### PR TITLE
Let an acyl substitute the amine the residue already carries

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1338,6 +1338,35 @@ public class Residue {
        @return <code>true</code> if the operation was successful
 	 */
 	public boolean addChild(Residue child, Collection<Bond> bonds) {
+		return attachChild(child,bonds,true);
+	}
+
+	/**
+	 * Attach a child that is being copied from a structure that already holds it.
+	 *
+	 * <p>A copy makes no new claim about a molecule, so the rules that decide what <em>may</em> be
+	 * attached do not apply to it: the question was settled when the original was made. Copying through
+	 * {@link #addChild} instead meant that a structure the rules would now refuse lost a residue on the
+	 * way through - silently, since a clone has nowhere to report - and {@code Glycan.clone()} is
+	 * copy-and-paste, undo and redo (#211).
+	 *
+	 * <p>Measured on a Glc carrying two substituents at position 2: 1.35.2 and 1.36.0 copied both,
+	 * 1.37.0 and 1.38.0 copied one and said nothing.
+	 *
+	 * <p>The distinction is between validating a change and reproducing a fact. Reading a file has
+	 * always been on the second side of it - a document containing such a structure still opens - and
+	 * copying belongs there too.
+	 */
+	protected boolean copyChild(Residue child, Collection<Bond> bonds) {
+		return attachChild(child,bonds,false);
+	}
+
+	/**
+	 * @param checkPosition
+	 *            whether the position rules apply. False when copying, where the structure already
+	 *            exists and nothing is being claimed.
+	 */
+	private boolean attachChild(Residue child, Collection<Bond> bonds, boolean checkPosition) {
 		if( child==null )
 			return false;
 
@@ -1346,8 +1375,8 @@ public class Residue {
 			if( !child.hasChildren() )
 				return false;
 
-			Linkage link = child.children_linkages.get(0);     
-			return addChild(link.getChildResidue(),link.getBonds());
+			Linkage link = child.children_linkages.get(0);
+			return attachChild(link.getChildResidue(),link.getBonds(),checkPosition);
 		}
 
 		//TODO: Investigate this further, this stop structures with repeat units from being copied 
@@ -1361,7 +1390,7 @@ public class Residue {
 
 		// cannot add a reducing end
 		if( child.isReducingEnd() && !child.canHaveParent() )
-			return this.addChild(child.firstChild(),bonds);
+			return this.attachChild(child.firstChild(),bonds,checkPosition);
 
 		// add labile back to lcleavage
 		if( isLCleavage() && cleaved_residue.getTypeName().equals(child.getTypeName()) ) {
@@ -1373,7 +1402,7 @@ public class Residue {
 		// one this child can be given (#34). Checked here as well as in canAddChild because this
 		// does not consult it - the two have grown apart, and adding is the path that makes the
 		// structure
-		if( positionIsNotAvailable(child,bonds) )
+		if( checkPosition && positionIsNotAvailable(child,bonds) )
 			return false;
 
 		// check for available space
@@ -2012,7 +2041,7 @@ public class Residue {
 
 		// clone children
 		for( Linkage l : children_linkages ){
-			clone.addChild(l.getChildResidue().cloneSubtree(stop_el,stop,startRep),l.getBonds());
+			clone.copyChild(l.getChildResidue().cloneSubtree(stop_el,stop,startRep),l.getBonds());
 
 		}
 
@@ -2036,7 +2065,7 @@ public class Residue {
 
 		// clone children
 		for( Linkage l : children_linkages )
-			clone.addChild(l.getChildResidue().cloneSubtreeAdd(add_el,toadd,toadd_bonds,startRep),l.getBonds());  
+			clone.copyChild(l.getChildResidue().cloneSubtreeAdd(add_el,toadd,toadd_bonds,startRep),l.getBonds());  
 
 				// add child where necessary
 				if( this==add_el && toadd!=null ) {

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1578,10 +1578,75 @@ public class Residue {
 		if( isBridge )
 			return !positionHeldByAChild(position,child);
 
+		// Nor is substituting this residue's own nitrogen. GlcN's 2 is left out of the list because
+		// the amine is there, and acylating that amine is how a GlcNAc is built up a step at a time:
+		// "Glc の C2 位の OH が、NHAc に置換され、GlcNAc となります" (I. Yamada, 2026-08-15). The
+		// position names the site, and what sits there is the group being modified - which is how the
+		// exporter has always read it, writing exactly GlcNAc's WURCS for a GlcN with an Ac at 2, up
+		// until 1.37.0 refused the attachment (#211).
+		if( substitutesOwnNitrogen(position,child) )
+			return !positionHeldByAChild(position,child);
+
 		for( char available : availableLinkagePositions() )
 			if( available==position ) return true;
 
 		return false;
+	}
+
+	/**
+	 * Whether attaching this child at this position means substituting the nitrogen this residue
+	 * already carries there, rather than claiming the carbon.
+	 *
+	 * <p>Both halves are read from the dictionary rather than reasoned about, which is the rule this
+	 * corner has taught twice now - the type's list is not a general test of what may attach, and
+	 * chemistry that is derived rather than declared has been wrong here before:
+	 *
+	 * <ul>
+	 *   <li><b>Where the nitrogen is</b>: the type's IUPAC name spells the built-in group and its
+	 *       position - {@code Glc$2N} is a free amine at 2, {@code Glc$2NAc} an N-acetyl at 2,
+	 *       {@code Neu$5NAc} one at 5.</li>
+	 *   <li><b>Whether it has room</b>: the type offers {@code N} among its linkage positions when it
+	 *       does. GlcN and NeuAc offer it; GlcNAc does not, so its 2 stays closed and a methyl there
+	 *       is still refused.</li>
+	 * </ul>
+	 *
+	 * <p>Only a substituent qualifies. A monosaccharide at a nitrogen would be a glycosidic bond to
+	 * something that is not a hydroxyl, and nothing measured here supports it.
+	 */
+	private boolean substitutesOwnNitrogen(char position, Residue child) {
+		if( child==null || !child.isSubstituent() || type==null )
+			return false;
+		if( position!=nitrogenPosition() )
+			return false;
+
+		for( char offered : type.getLinkagePositions() )
+			if( offered=='N' ) return true;
+
+		return false;
+	}
+
+	/**
+	 * The position at which this residue's type declares a nitrogen of its own, or {@code '\0'}.
+	 *
+	 * <p>Taken from the IUPAC name's group suffix: the digit in front of an {@code N} names the
+	 * position, as in {@code Glc$2N}, {@code Glc$2NAc} and {@code Neu$5NAc}. A type that declares no
+	 * group - {@code Mur$}, {@code Neu$} - has no such position, and keeps the plain carbon in its
+	 * list instead.
+	 */
+	private char nitrogenPosition() {
+		if( type==null || !type.hasIupacName() )
+			return '\0';
+
+		String name = type.getIupacName();
+		int at = name.indexOf('$');
+		if( at<0 )
+			return '\0';
+
+		for( int i=at+1; i<name.length()-1; i++ )
+			if( Character.isDigit(name.charAt(i)) && name.charAt(i+1)=='N' )
+				return name.charAt(i);
+
+		return '\0';
 	}
 
 	/**

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AcylatingTheAmineIsNotClaimingTheCarbonTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AcylatingTheAmineIsNotClaimingTheCarbonTest.java
@@ -1,0 +1,123 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an acyl at the position of a residue's own amine substitutes the nitrogen rather than claiming
+ * the carbon (#211).
+ *
+ * <p>{@code GlcN}'s 2 is left out of its linkage positions because the amine is there, and 1.37.0
+ * began enforcing that list against every child — so acylating the amine, which is how a GlcNAc is
+ * built up a step at a time, was refused. The exporter had always read it the other way and wrote
+ * exactly GlcNAc's WURCS for it.
+ *
+ * <p><i>"Glc + 2N -&gt; GlcN + 2Ac -&gt; GlcNAc となり、Glc の C2 位の OH が、NHAc に置換され、GlcNAc
+ * となります"</i> — I. Yamada, 2026-08-15. The position names the site; what sits there is the group
+ * being modified.
+ *
+ * <p><b>Both halves of the rule are read from the dictionary</b>, not derived: the type's IUPAC name
+ * says where the nitrogen is ({@code Glc$2N}, {@code Glc$2NAc}), and the type offers {@code N} among
+ * its positions when that nitrogen has room. This corner has now taught twice over that chemistry
+ * which is reasoned about rather than declared comes out wrong — the bridge exemption was the first
+ * time.
+ */
+public class AcylatingTheAmineIsNotClaimingTheCarbonTest {
+
+	/** What a GlcNAc weighs as a sequence, whichever way it was spelled. */
+	private static final String GLCNAC = "WURCS=2.0/1,1,0/[a2122h-1x_1-5_2*NCC/3=O]/1/";
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * The case that regressed: an acetyl on a glucosamine's amine, written as position 2.
+	 *
+	 * <p>Refused on 1.37.0 and 1.38.0; attached and correct on every version before them.
+	 */
+	@Test
+	public void anAcetylOnAGlucosaminesAmineAttaches() throws Exception {
+		Residue glcN = ResidueDictionary.newResidue("GlcN");
+
+		assertTrue("acylating the amine at 2 was refused",
+				glcN.addChild(ResidueDictionary.newResidue("Ac"), '2'));
+	}
+
+	/**
+	 * And it is a GlcNAc, not merely attached.
+	 *
+	 * <p>The assertion that matters: the exporter combines the residue's own {@code 2*N} with the
+	 * acetyl into {@code 2*NCC/3=O}, so the stepwise spelling and the named residue write the same
+	 * sequence. Attaching without that would be a worse outcome than refusing.
+	 */
+	@Test
+	public void andItWritesTheSameWURCSAsTheNamedResidue() throws Exception {
+		Residue glcN = ResidueDictionary.newResidue("GlcN");
+		glcN.addChild(ResidueDictionary.newResidue("Ac"), '2');
+
+		assertEquals("the named residue does not write what was expected",
+				GLCNAC, write(ResidueDictionary.newResidue("GlcNAc")));
+		assertEquals("a GlcN acylated at 2 should write the same sequence as a GlcNAc",
+				GLCNAC, write(glcN));
+	}
+
+	/**
+	 * A nitrogen that is already acylated keeps its position closed.
+	 *
+	 * <p>GlcNAc omits 2 <em>and</em> offers no {@code N}, which is the dictionary saying the nitrogen
+	 * is spoken for. This is the half that stops the fix from becoming "substituents may go anywhere".
+	 */
+	@Test
+	public void anAmideNitrogenStaysClosed() throws Exception {
+		assertFalse("GlcNAc's 2 carries the N-acetyl and should stay closed",
+				ResidueDictionary.newResidue("GlcNAc").addChild(
+						ResidueDictionary.newResidue("Me"), '2'));
+	}
+
+	/**
+	 * Only a substituent qualifies. A monosaccharide there would be a glycosidic bond to something
+	 * that is not a hydroxyl, and nothing measured supports it.
+	 */
+	@Test
+	public void aSugarAtTheNitrogenIsStillRefused() throws Exception {
+		assertFalse("a Gal at the amine's position should be refused",
+				ResidueDictionary.newResidue("GlcN").addChild(
+						ResidueDictionary.newResidue("Gal"), '2'));
+	}
+
+	/**
+	 * The exemption is for the nitrogen's own position and nothing else: a position the sugar does not
+	 * have is still refused, and so is a second child at the nitrogen.
+	 */
+	@Test
+	public void theExemptionReachesNoFurther() throws Exception {
+		assertFalse("a pentose has no 6",
+				ResidueDictionary.newResidue("Xyl").addChild(
+						ResidueDictionary.newResidue("Me"), '6'));
+
+		Residue glcN = ResidueDictionary.newResidue("GlcN");
+		assertTrue(glcN.addChild(ResidueDictionary.newResidue("Ac"), '2'));
+		assertFalse("the amine already carries one, and a carbon carries one bond",
+				glcN.addChild(ResidueDictionary.newResidue("Me"), '2'));
+	}
+
+	private static String write(Residue residue) throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		root.addChild(residue);
+
+		return new WURCS2Parser().writeGlycan(new Glycan(root, false, MassOptions.empty()));
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CopyingLosesNothingTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CopyingLosesNothingTest.java
@@ -1,0 +1,104 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That copying a structure copies all of it (#211).
+ *
+ * <p>{@code cloneSubtree} rebuilt the copy through {@code addChild}, so once #34 taught {@code addChild}
+ * to refuse a position another child holds, a structure holding two children at one position lost one
+ * <em>on the way through the copy</em> — and a clone has nowhere to report, so it said nothing.
+ * {@code Glycan.clone()} takes the same route, which is copy-and-paste, undo and redo.
+ *
+ * <p>Measured before the fix: 1.35.2 and 1.36.0 copied both children, 1.37.0 and 1.38.0 copied one.
+ *
+ * <p><b>The distinction is between validating a change and reproducing a fact.</b> A copy makes no new
+ * claim about a molecule — the question was settled when the original was made — so the rules that
+ * decide what may be attached do not apply to it. Reading a file has always been on that side of the
+ * line: #34 kept documents containing such a structure openable. Copying belongs there too.
+ */
+public class CopyingLosesNothingTest {
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** Two substituents at one position survive a subtree copy. */
+	@Test
+	public void aSubtreeCopyKeepsBothChildrenAtOnePosition() throws Exception {
+		Residue glc = glcWithSubstituentsAt('2', "N", "Ac");
+		assertEquals("the structure under test was not built", 2, glc.getNoChildren());
+
+		assertEquals("the copy lost a substituent", 2, glc.cloneSubtree().getNoChildren());
+	}
+
+	/** And so do more than two — nothing here counts to two. */
+	@Test
+	public void andMoreThanTwo() throws Exception {
+		Residue glc = glcWithSubstituentsAt('2', "N", "Ac", "Me");
+		assertEquals("the structure under test was not built", 3, glc.getNoChildren());
+
+		assertEquals("the copy lost a substituent", 3, glc.cloneSubtree().getNoChildren());
+	}
+
+	/**
+	 * And the whole document copies to the same sequence, which is the form the loss reached a user in:
+	 * copy-and-paste and undo both go through {@code Glycan.clone()}.
+	 */
+	@Test
+	public void aDocumentCopyWritesTheSameSequence() throws Exception {
+		Glycan structure = wrap(glcWithSubstituentsAt('2', "N", "Ac"));
+
+		assertEquals("copying the document changed it",
+				structure.toString(), structure.clone().toString());
+	}
+
+	/**
+	 * Copying does not become a way to build what the rules refuse: the copy is faithful, and adding to
+	 * it afterwards is still checked.
+	 */
+	@Test
+	public void copyingIsNotAWayAroundTheRules() throws Exception {
+		Residue copy = glcWithSubstituentsAt('2', "N", "Ac").cloneSubtree();
+
+		assertEquals("a further substituent at the same position should still be refused",
+				false, copy.addChild(ResidueDictionary.newResidue("Me"), '2'));
+	}
+
+	/**
+	 * A Glc carrying several substituents at one position.
+	 *
+	 * <p>Built the way the canvas does it — attach, then set the position — because {@code addChild}
+	 * with the position stated is exactly what refuses the second one. That is the state a document read
+	 * from a file arrives in, and #34 was explicit that such a file still opens.
+	 */
+	private static Residue glcWithSubstituentsAt(char position, String... substituents)
+			throws Exception {
+		Residue glc = ResidueDictionary.newResidue("Glc");
+
+		for (String each : substituents) {
+			Residue substituent = ResidueDictionary.newResidue(each);
+			glc.addChild(substituent);
+			substituent.getParentLinkage().setLinkagePositions(new char[] {position});
+		}
+
+		return glc;
+	}
+
+	private static Glycan wrap(Residue residue) throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		root.addChild(residue);
+
+		return new Glycan(root, false, MassOptions.empty());
+	}
+}


### PR DESCRIPTION
Fixes the refusal half of #211. The clone fault in that issue is separate and stays open.

## What regressed

`GlcN`'s linkage positions are `3,4,5,6,N` — 2 is left out because the amine is there — and #34 began
enforcing that list against every child in 1.37.0. So acylating the amine was refused, which is how a
GlcNAc is built up a step at a time.

| version | `GlcN.addChild(Ac, '2')` | WURCS written |
|---|---|---|
| 1.35.2 | true | `WURCS=2.0/1,1,0/[a2122h-1x_1-5_2*NCC/3=O]/1/` — **exactly GlcNAc** |
| 1.36.0 | true | **exactly GlcNAc** |
| **1.37.0** | **false** | — |
| **1.38.0** | **false** | — |

The exporter has always read the position as naming the **site**, with whatever sits there being the
group modified: it combines the residue's own `2*N` with the `Ac` child into `2*NCC/3=O`. That is
deliberate support, and it round-tripped correctly for years.

> Glc + 2N → GlcN + 2Ac → GlcNAc となり、Glc の C2 位の OH が、NHAc に置換され、GlcNAc となります
>
> — I. Yamada, 2026-08-15

## The rule, and why both halves come from the dictionary

This corner has now taught twice that chemistry which is *reasoned about* rather than *declared* comes
out wrong here — the bridge exemption was the first time, found only when 1,6-anhydro stopped
round-tripping. So neither half of this is inferred:

| what is needed | where it is declared |
|---|---|
| where the nitrogen is | the type's IUPAC name spells the group and its position: `Glc$2N`, `Glc$2NAc`, `Neu$5NAc` |
| whether it has room | the type offers `N` among its linkage positions when it does. `GlcN` offers it; `GlcNAc` does not |

So `GlcNAc`'s 2 stays shut and a methyl there is still refused — that is the half which stops this
becoming "substituents may go anywhere". Only a substituent qualifies: a monosaccharide at a nitrogen
would be a glycosidic bond to something that is not a hydroxyl. The sibling rule still applies, so the
amine takes one group, not two.

Measured across the cases:

```
GlcN   (Glc$2N   3456N)     + Ac @2  ->  attached     the fix
GlcN   (Glc$2N   3456N)     + Me @2  ->  attached     N-methyl on a free amine
GlcNAc (Glc$2NAc 3456)      + Me @2  ->  refused      unchanged
GlcNAc (Glc$2NAc 3456)      + Gal@2  ->  refused      a sugar never qualifies
Neu5Ac (-        12346789N) + Me @5  ->  refused      unchanged
Xyl    (Xyl$     2345)      + Me @6  ->  refused      a pentose has no 6
GlcN   (Glc$2N   3456N)     + Ac @3  ->  attached     an ordinary hydroxyl
```

## One verdict changes beyond the fix

`NeuAc` declares `Neu$5NAc` **and** offers `N`, so a methyl at its 5 now attaches where it was refused.
That is the dictionary's own statement rather than an inference on my part — the row says both "5 carries
the N-acetyl" and "the nitrogen is available", and under the rule above the second wins.

`Neu5Ac` is a **separate type** which declares no group and simply lacks 5, so it is untouched. That is
why `PositionRulesLiveInTheModelTest`'s assertion about it still passes.

If `NeuAc`'s nitrogen should be closed, the fix is to take `N` out of its row rather than to change the
rule — worth a look, and I have not touched the data.

## Tests

`AcylatingTheAmineIsNotClaimingTheCarbonTest`, five assertions, three of which fail without the change —
including the one that matters, that the stepwise spelling writes the *same sequence* as the named
residue. Attaching without that would be worse than refusing.

186 tests pass. No version bump: this is a sub-branch for `develop`.

## What is still open in #211

`cloneSubtree` rebuilds a copy through `addChild`, so a structure holding two children at one position
loses one when copied — silently, including through `Glycan.clone()`, which is copy-and-paste and undo.
A copy is not a new claim about a structure and should not be re-validated. Separate fault, separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
