### PR TITLE
Fix the six faults from the 2026-08-15 code review, and make tests a release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,26 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
+  # Nothing is built until the suite passes. The installer workflows all build with -DskipTests, so
+  # without this job a release could publish - and did - without a single test having run in CI.
+  test:
+    uses: ./.github/workflows/tests.yml
+
   build-installer-linux:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_linux.yml
 
   build-installer-macos:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_macos.yml
     secrets: inherit
 
   build-installer-windows:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_windows.yml
 
   build-installer-rpm:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_rpm.yml
 
   release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,64 @@
+name: Tests
+
+# The suite, as a job other workflows can require.
+#
+# It exists because the release path did not run it. All four installer workflows build with
+# -DskipTests and release.yml only waits for them, so installers could be published - and were - without
+# a single regression test having executed in CI. The tests were run by hand before each release, which
+# is not a gate, it is a habit.
+#
+# Called by release.yml before any installer is built, and run on its own for pull requests, so a
+# failure is found before somebody dispatches a release.
+
+on:
+  workflow_call:
+  pull_request:
+    branches: [ master, develop ]
+
+env:
+  JAVA_VERSION: '21'
+  JAVA_DISTRIBUTION: 'zulu'
+  GITHUB_ACTOR: github.actor
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK ${{ env.JAVA_VERSION }}
+      uses: actions/setup-java@v5
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DISTRIBUTION }}
+        server-id: github
+        server-username: GITHUB_ACTOR
+        server-password: GITHUB_TOKEN
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v5
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}_m2
+
+    # Headless, because much of the suite draws. Without it AWT initialization aborts the JVM on a
+    # runner with no display, which reads as a crash rather than as a missing display.
+    - name: Run the test suite
+      run: mvn -B -Djava.awt.headless=true test
+      shell: bash
+
+    # Kept whatever the outcome: a failing release is exactly when somebody needs to see which test
+    # failed, and surefire's own output is what says so.
+    - name: Upload test reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: surefire-reports
+        path: target/surefire-reports/
+        if-no-files-found: warn

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -319,20 +319,25 @@ public abstract class BaseDocument {
        be parsed
        @see #read
      */
-    public boolean open(File file, boolean merge, boolean warning) 
+    public boolean open(File file, boolean merge, boolean warning)
     {
+    FileInputStream fis = null;
     try {
-        FileInputStream fis = new FileInputStream(file);
-        
+        fis = new FileInputStream(file);
+
         // read structure
         try {
         read(fis,merge);
         }
         catch(Exception e) {
-        	System.err.println("Got exception: "+e.getMessage());
-        init();
+        // What is already open is not the file's fault. This used to call init(), which cleared the
+        // current document before returning false - so a malformed file took the work that was on
+        // screen with it, and "Open additional document..." destroyed the document it was supposed
+        // to be adding to. GlycanDocument.fromString parses into a list of its own before it touches
+        // this document, so there is nothing half-read to tidy up after.
+        System.err.println("Got exception: "+e.getMessage());
         if( warning )
-            throw e;        
+            throw e;
         return false;
         }
 
@@ -359,8 +364,21 @@ public abstract class BaseDocument {
     catch( Exception e ) {
         LogUtils.report(e);
         return false;
-    }    
-    }    
+    }
+    finally {
+        // Closed either way. It used to be left to the garbage collector, so a failed open held the
+        // file open for as long as the collector took to notice - which on Windows is the difference
+        // between being able to delete or replace it and not.
+        if( fis!=null ) {
+            try {
+                fis.close();
+            }
+            catch( Exception cannotClose ) {
+                LogUtils.report(cannotClose);
+            }
+        }
+    }
+    }
 
     protected void read(InputStream is, boolean merge) throws Exception {
     	System.err.println("in read");

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -385,28 +385,40 @@ public abstract class BaseDocument {
      */
     public boolean save(String filename) {
 
+    // The document is told it has been saved only once it has been. setFilename sets was_saved and
+    // clears has_changed as a side effect, and calling it first meant that an unwritable destination,
+    // a full disk or a serialization failure returned false while leaving the document marked saved
+    // and clean - so the asterisk went away, Save went grey, and the next close let the work go
+    // without asking. The write is what decides; the bookkeeping follows it.
+    File tmpfile = null;
+
     try{
-    	setFilename(filename);
-    	
-        // write to tmp file
-        File tmpfile = File.createTempFile("gwb",null);
-        write(new FileOutputStream(tmpfile));
+        // write to tmp file, so nothing touches the destination until a whole document exists
+        tmpfile = File.createTempFile("gwb",null);
 
-        // copy to dest file and delete tmp file
+        FileOutputStream out = new FileOutputStream(tmpfile);
+        try {
+            write(out);
+        }
+        finally {
+            out.close();
+        }
+
+        // copy to dest file
         FileUtils.copy(tmpfile,new File(filename));
-        tmpfile.delete();
 
-        //
-        
-        
-        //
+        setFilename(filename);
         fireDocumentInit();
         return true;
     }
     catch( Exception e ) {
         LogUtils.report(e);
         return false;
-    }        
+    }
+    finally {
+        // Ours, and gone either way. It used to be left behind on every failing path.
+        if( tmpfile!=null ) tmpfile.delete();
+    }
     }
     
     /**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -817,10 +817,11 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 
 			// esporta il documento su file
 			if( theDoc.isSequenceFormat(format) ) {
-				if( theDoc.exportTo(filename,format) ) {
-					setLastExportedFile(filename);
-					warnAboutExportFailures(theDoc, format);
-				}
+				if( !exportSequenceTo(theDoc,filename,format) )
+					return false;
+
+				setLastExportedFile(filename);
+				warnAboutExportFailures(theDoc, format);
 				return true;
 			}
 			else if( SVGUtils.export((GlycanRendererAWT) theWorkspace.getGlycanRenderer(),filename,theDoc.getStructures(),theWorkspace.getGraphicOptions().SHOW_MASSES,theWorkspace.getGraphicOptions().SHOW_REDEND,format) ) {
@@ -829,6 +830,24 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 			}        
 		}
 		return false;
+	}
+
+	/**
+	 * Write the document out in a sequence format, and say whether it was written.
+	 *
+	 * <p>Separated from {@link #onExportTo(String)} so the answer can be tested without a file chooser.
+	 * It used to be discarded and {@code true} returned regardless, so an export that wrote nothing
+	 * reported success - which also made a liar of the warning that follows it, whose whole purpose is
+	 * to tell a user what did not come out. The graphical formats in the same method had always
+	 * returned their real result.
+	 *
+	 * <p>The caller records the file as exported and warns about partial failures <em>only</em> on
+	 * true, so a failed export leaves no trace of having worked.
+	 *
+	 * @return Returns whether the document was written.
+	 */
+	public static boolean exportSequenceTo(GlycanDocument doc, String filename, String format) {
+		return doc!=null && doc.exportTo(filename,format);
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -666,17 +666,36 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 	public boolean onSave(BaseDocument doc, boolean ask_filename) {
 		if( doc==null ) return false;
 
-		// controlla se e' possibile salvare il file nella stessa posizione da cui e' stato aperto
-		File cur = doc.getFile();                
-		if( cur!=null && cur.canWrite() ) {
-			// salvo il documento su file
-			doc.save(cur.getAbsolutePath());       
-			return true;
-		}
+		Boolean saved = saveToItsOwnFile(doc);
+		if( saved!=null ) return saved.booleanValue();
 
 		// non e' stato possibile salvare il file nella posizione da cui e' stato aperto. Richiedo il salvataggio con scelta file
-		if( ask_filename ) return onSaveAs(doc);        
+		if( ask_filename ) return onSaveAs(doc);
 		return false;
+	}
+
+	/**
+	 * Write the document back to the file it came from, if it has one that can be written.
+	 *
+	 * <p>Separated from {@link #onSave(BaseDocument, boolean)} so the decision can be tested without a
+	 * window: everything above it is a file chooser, and everything about it that was wrong was here.
+	 * The result used to be discarded and {@code true} returned regardless, so an I/O failure read as a
+	 * successful save - and this is the branch "Save changes?" takes on exit, so answering Yes to it let
+	 * the application close over work that had not been written.
+	 *
+	 * <p>No second file chooser on failure: the document has a writable file, and asking again where to
+	 * put it would be answering a different question.
+	 *
+	 * @return Returns whether the save succeeded, or {@code null} when the document has no writable
+	 *         file of its own and the caller should offer Save As instead.
+	 */
+	public static Boolean saveToItsOwnFile(BaseDocument doc) {
+		// controlla se e' possibile salvare il file nella stessa posizione da cui e' stato aperto
+		File cur = (doc==null) ? null : doc.getFile();
+		if( cur==null || !cur.canWrite() )
+			return null;
+
+		return Boolean.valueOf(doc.save(cur.getAbsolutePath()));
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SAXUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SAXUtils.java
@@ -381,8 +381,7 @@ public class SAXUtils {
        @throws Exception on errors
      */
     public static void read(InputStream is, DefaultHandler h) throws Exception {
-    SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
-    parser.parse(is,h);
+    SecureXml.newSAXParser().parse(is,h);
     }
     
     /**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SecureXml.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SecureXml.java
@@ -1,0 +1,117 @@
+package org.eurocarbdb.application.glycanbuilder.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+/**
+ * The XML readers this application uses, configured to read only the document it was given.
+ *
+ * <p>A default JAXP parser resolves external entities, so a document can name a file and have its
+ * contents substituted into the parse. Measured on this project before this class existed: an entity
+ * pointing at a temporary file was expanded and the file's contents came back through both
+ * {@link XMLUtils#read(String)} and {@link SAXUtils#read}. The same configuration will issue network
+ * requests from a document, so the reach is not limited to the local disk.
+ *
+ * <p>Everything this application reads as XML - workspaces, configuration, fragment definitions,
+ * sequences pasted in by a user - goes through those two helpers, and none of it uses a
+ * {@code DOCTYPE}. So the strongest setting is also the compatible one: a document type declaration is
+ * refused outright, which removes entity substitution rather than restricting it.
+ *
+ * <p><b>It fails closed.</b> A parser that cannot be told to be safe is not returned - an unsupported
+ * feature is thrown rather than logged and stepped over, because a reader that quietly falls back to
+ * the default configuration is the fault this class exists to remove.
+ *
+ * <p>Java 8 and the Java 21 runtime the installers carry both support all of these.
+ */
+public final class SecureXml {
+
+	/** Rejects a document type declaration, and with it every entity that could be declared in one. */
+	private static final String DISALLOW_DOCTYPE =
+			"http://apache.org/xml/features/disallow-doctype-decl";
+
+	/** Belt and braces behind the DOCTYPE refusal, for a parser that honours these instead. */
+	private static final String EXTERNAL_GENERAL_ENTITIES =
+			"http://xml.org/sax/features/external-general-entities";
+	private static final String EXTERNAL_PARAMETER_ENTITIES =
+			"http://xml.org/sax/features/external-parameter-entities";
+	private static final String LOAD_EXTERNAL_DTD =
+			"http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+	private SecureXml() {
+	}
+
+	/**
+	 * A DOM builder that reads only what it is handed.
+	 *
+	 * @throws Exception
+	 *             when the parser cannot be configured safely. Deliberately not caught here: the
+	 *             caller gets no parser rather than an unsafe one.
+	 */
+	public static DocumentBuilder newDocumentBuilder() throws Exception {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+		factory.setFeature(DISALLOW_DOCTYPE, true);
+		factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+		factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+		factory.setFeature(LOAD_EXTERNAL_DTD, false);
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setXIncludeAware(false);
+		factory.setExpandEntityReferences(false);
+
+		// Belongs to the factory rather than the builder, and is only honoured by some
+		// implementations - which is why it sits behind the DOCTYPE refusal rather than in front of it.
+		trySetAttribute(factory, XMLConstants.ACCESS_EXTERNAL_DTD);
+		trySetAttribute(factory, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+
+		return factory.newDocumentBuilder();
+	}
+
+	/**
+	 * A SAX parser that reads only what it is handed.
+	 *
+	 * @throws Exception
+	 *             when the parser cannot be configured safely.
+	 */
+	public static SAXParser newSAXParser() throws Exception {
+		SAXParserFactory factory = SAXParserFactory.newInstance();
+
+		factory.setFeature(DISALLOW_DOCTYPE, true);
+		factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+		factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+		factory.setFeature(LOAD_EXTERNAL_DTD, false);
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setXIncludeAware(false);
+
+		SAXParser parser = factory.newSAXParser();
+		trySetProperty(parser, XMLConstants.ACCESS_EXTERNAL_DTD);
+		trySetProperty(parser, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+
+		return parser;
+	}
+
+	/**
+	 * Deny an external-access property, where the implementation has one.
+	 *
+	 * <p>The one place something is allowed to be unsupported, and it is safe for it to be: the
+	 * DOCTYPE refusal above has already removed the declaration these properties would restrict. An
+	 * implementation that does not recognise the name has nothing to restrict either.
+	 */
+	private static void trySetAttribute(DocumentBuilderFactory factory, String name) {
+		try {
+			factory.setAttribute(name, "");
+		} catch (IllegalArgumentException notSupported) {
+			// see above
+		}
+	}
+
+	private static void trySetProperty(SAXParser parser, String name) {
+		try {
+			parser.setProperty(name, "");
+		} catch (Exception notSupported) {
+			// see above
+		}
+	}
+}

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/XMLUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/XMLUtils.java
@@ -48,9 +48,7 @@ public class XMLUtils {
      */
     static public Document newDocument() {
     try {
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        return builder.newDocument();
+        return SecureXml.newDocumentBuilder().newDocument();
     }    
     catch(Exception e) {
         LogUtils.report(e);
@@ -63,10 +61,7 @@ public class XMLUtils {
      */
     static public Document read(String data) {
     try {        
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        
-        return builder.parse(new ByteArrayInputStream(data.getBytes()));
+        return SecureXml.newDocumentBuilder().parse(new ByteArrayInputStream(data.getBytes()));
     }
     catch(Exception e) {
         LogUtils.report(e);
@@ -79,10 +74,7 @@ public class XMLUtils {
      */
     static public Document read(byte[] data) {
     try {        
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        
-        return builder.parse(new ByteArrayInputStream(data));
+        return SecureXml.newDocumentBuilder().parse(new ByteArrayInputStream(data));
     }
     catch(Exception e) {
         LogUtils.report(e);
@@ -95,10 +87,7 @@ public class XMLUtils {
      */
     static public Document read(InputStream is) {
     try {        
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-
-        return builder.parse(is);
+        return SecureXml.newDocumentBuilder().parse(is);
     }
     catch(Exception e) {
         LogUtils.report(e);

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedOpenKeepsWhatIsOpenTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedOpenKeepsWhatIsOpenTest.java
@@ -1,0 +1,130 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a file which cannot be read does not take the open document with it.
+ *
+ * <p>{@code open} caught the parse failure and called {@code init()} before returning {@code false},
+ * which clears the document. So choosing a malformed file lost whatever was on screen, and
+ * "Open additional document…" destroyed the very document it was supposed to be adding to.
+ *
+ * <p>Nothing needs tidying up after a failure: {@code GlycanDocument.fromString} parses into a list of
+ * its own and only then hands it over, so a failed parse has not touched the document at all.
+ * {@code init()} was cleaning up after something that had not happened.
+ *
+ * <p>Companion to {@link SavedWorkIsNotLostTest}, which holds the successful paths — a fix here must
+ * not buy a failing open at the cost of a working one.
+ */
+public class AFailedOpenKeepsWhatIsOpenTest {
+
+	private static final String A_GLYCAN = "freeEnd--?b1D-GlcNAc,p$MONO,perMe,Na,0,freeEnd";
+
+	/** Not a sequence in any format the reader knows. */
+	private static final String MALFORMED = "this is not a glycan sequence {{{";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A normal Open of a malformed file leaves the current document alone. */
+	@Test
+	public void aFailedOpenKeepsTheCurrentDocument() throws Exception {
+		File good = gwsFile(A_GLYCAN);
+		GlycanDocument document = documentHolding(good);
+		String sequenceBefore = document.toString();
+
+		assertFalse("a malformed file should not open", open(document, gwsFile(MALFORMED), false));
+
+		assertEquals("the structure that was open should still be there",
+				1, document.getStructures().size());
+		assertEquals("and unchanged", sequenceBefore, document.toString());
+		assertEquals("the filename should not have moved", good.getAbsolutePath(),
+				document.getFileName());
+		assertTrue("the document should still count as saved", document.wasSaved());
+		assertFalse("and still count as unchanged", document.hasChanged());
+	}
+
+	/**
+	 * And so does a merge, which is the case the report was about.
+	 *
+	 * <p>"Open additional document…" is asking to add something. Failing to add it is not a reason to
+	 * remove what was there.
+	 */
+	@Test
+	public void aFailedMergeKeepsTheCurrentDocument() throws Exception {
+		File good = gwsFile(A_GLYCAN);
+		GlycanDocument document = documentHolding(good);
+		String sequenceBefore = document.toString();
+
+		assertFalse("a malformed file should not merge", open(document, gwsFile(MALFORMED), true));
+
+		assertEquals("the structure that was open should still be there",
+				1, document.getStructures().size());
+		assertEquals("and unchanged", sequenceBefore, document.toString());
+		assertEquals("the filename should not have moved", good.getAbsolutePath(),
+				document.getFileName());
+		assertTrue("the document should still count as saved", document.wasSaved());
+		assertFalse("a failed merge is not a change", document.hasChanged());
+	}
+
+	/** A missing file is the same answer, and must not clear anything either. */
+	@Test
+	public void aMissingFileKeepsTheCurrentDocument() throws Exception {
+		GlycanDocument document = documentHolding(gwsFile(A_GLYCAN));
+
+		File missing = File.createTempFile("glycanbuilder-open-", ".gws");
+		assertTrue(missing.delete());
+
+		assertFalse("a file that is not there should not open", open(document, missing, false));
+		assertEquals("the structure that was open should still be there",
+				1, document.getStructures().size());
+	}
+
+	/**
+	 * {@code open} reports a failure by returning false, and by throwing when asked to warn. Both are
+	 * exercised, since only the second reaches the caller as an exception and both used to clear the
+	 * document on the way.
+	 */
+	private static boolean open(GlycanDocument document, File file, boolean merge) {
+		try {
+			return document.open(file, merge, true);
+		} catch (Exception refused) {
+			return false;
+		}
+	}
+
+	private static GlycanDocument documentHolding(File file) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the fixture did not open", document.open(file, false, true));
+		assertEquals("the fixture should hold one structure", 1, document.getStructures().size());
+
+		return document;
+	}
+
+	private static File gwsFile(String contents) throws Exception {
+		File file = File.createTempFile("glycanbuilder-open-", ".gws");
+		file.deleteOnExit();
+
+		FileWriter writer = new FileWriter(file);
+		try {
+			writer.write(contents);
+		} finally {
+			writer.close();
+		}
+
+		return file;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -1,0 +1,155 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.swing.filechooser.FileFilter;
+
+import org.eurocarbdb.application.glycanbuilder.BaseDocument;
+import org.junit.Test;
+
+/**
+ * That a save which did not happen is not reported as one.
+ *
+ * <p>{@code save} called {@code setFilename} before writing anything, and {@code setFilename} sets
+ * {@code was_saved} and clears {@code has_changed} as a side effect. So an unwritable destination, a
+ * full disk or a serialization failure returned {@code false} while leaving the document marked saved
+ * and clean: the asterisk went away, Save went grey, and the next close let the work go without asking.
+ *
+ * <p>The failure is injected through {@code write}, which is the seam a real one arrives at — no
+ * filesystem is filled and no permissions are relied on.
+ */
+public class AFailedSaveKeepsTheDocumentDirtyTest {
+
+	/** A write that fails leaves the save reporting failure. */
+	@Test
+	public void aFailedWriteIsAFailedSave() throws Exception {
+		Document document = dirtyDocument();
+
+		assertFalse("a save whose write threw should return false",
+				document.save(destination().getAbsolutePath()));
+	}
+
+	/** And leaves the document exactly as dirty, as named and as unsaved as it was. */
+	@Test
+	public void aFailedSaveChangesNothingAboutTheDocument() throws Exception {
+		Document document = dirtyDocument();
+		String nameBefore = document.getFileName();
+		boolean savedBefore = document.wasSaved();
+
+		document.save(destination().getAbsolutePath());
+
+		assertTrue("the document should still be dirty", document.hasChanged());
+		assertEquals("the filename should not have moved to the destination",
+				nameBefore, document.getFileName());
+		assertEquals("wasSaved should not have changed", savedBefore, document.wasSaved());
+	}
+
+	/** The destination is not created, let alone truncated, by a save that could not be written. */
+	@Test
+	public void aFailedSaveLeavesTheDestinationAlone() throws Exception {
+		File destination = destination();
+
+		dirtyDocument().save(destination.getAbsolutePath());
+
+		assertFalse("the destination should not have been written", destination.exists());
+	}
+
+	/** The temporary file the attempt made is its own to clean up, and it does. */
+	@Test
+	public void aFailedSaveLeavesNoTemporaryFileBehind() throws Exception {
+		File temporaryDirectory = new File(System.getProperty("java.io.tmpdir"));
+		String[] before = temporaryDirectory.list(gwbTemporaries());
+
+		dirtyDocument().save(destination().getAbsolutePath());
+
+		String[] after = temporaryDirectory.list(gwbTemporaries());
+		assertEquals("a temporary file was left behind",
+				(before == null) ? 0 : before.length, (after == null) ? 0 : after.length);
+	}
+
+	/** And a save that works still does everything it did: the name, the flags, the file. */
+	@Test
+	public void aSuccessfulSaveStillTakesTheFilenameAndGoesClean() throws Exception {
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		File destination = destination();
+
+		assertTrue("the save should have succeeded", document.save(destination.getAbsolutePath()));
+
+		assertEquals(destination.getAbsolutePath(), document.getFileName());
+		assertTrue("the document should be marked saved", document.wasSaved());
+		assertFalse("the document should be clean", document.hasChanged());
+		assertTrue("the destination should exist", destination.exists());
+	}
+
+	private static Document dirtyDocument() {
+		Document document = new Document();
+		document.setChanged(true);
+		return document;
+	}
+
+	/** A path in the temporary directory that nothing has created. */
+	private static File destination() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-save-", ".tmp");
+		assertTrue(destination.delete());
+		destination.deleteOnExit();
+
+		return destination;
+	}
+
+	private static java.io.FilenameFilter gwbTemporaries() {
+		return new java.io.FilenameFilter() {
+			@Override
+			public boolean accept(File directory, String name) {
+				return name.startsWith("gwb");
+			}
+		};
+	}
+
+	/** The smallest document there can be, with a write that can be told to fail. */
+	private static final class Document extends BaseDocument {
+
+		private boolean failOnWrite = true;
+
+		@Override
+		public void write(OutputStream os) throws Exception {
+			if (failOnWrite) throw new Exception("the disk said no");
+			os.write("written".getBytes("UTF-8"));
+		}
+
+		@Override
+		public int size() {
+			return 1;
+		}
+
+		@Override
+		public String getName() {
+			return "Test document";
+		}
+
+		@Override
+		public void initData() {
+		}
+
+		@Override
+		public void fromString(String str, boolean merge) throws Exception {
+		}
+
+		@Override
+		public Collection<FileFilter> getFileFormats() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public FileFilter getAllFileFormats() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveStopsTheCloseTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveStopsTheCloseTest.java
@@ -1,0 +1,133 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.swing.filechooser.FileFilter;
+
+import org.eurocarbdb.application.glycanbuilder.BaseDocument;
+import org.eurocarbdb.application.glycanbuilder.GlycanBuilder;
+import org.junit.Test;
+
+/**
+ * That a failed Save is reported to whoever asked for it.
+ *
+ * <p>The Save branch for a document with a writable file called {@code save} and then returned
+ * {@code true} regardless of what it said. This is the branch "Save changes to …?" takes when a user
+ * answers Yes on exit, so an I/O failure read as a successful save and the application was allowed to
+ * close over work that had never been written.
+ *
+ * <p>Two separate faults needed two separate fixes and need two separate tests: the model marking an
+ * unwritten document as saved ({@code AFailedSaveKeepsTheDocumentDirtyTest}) and this, the caller
+ * throwing the answer away. Fixing either alone leaves the other.
+ *
+ * <p>Tested through {@code GlycanBuilder.saveToItsOwnFile}, which is the decision without the window
+ * around it. Constructing the frame would need a display and would test the file chooser.
+ */
+public class AFailedSaveStopsTheCloseTest {
+
+	/** A save that fails is reported as failing. */
+	@Test
+	public void aFailedSaveIsReportedAsFailed() throws Exception {
+		Document document = savedDocumentIn(existingWritableFile());
+
+		assertEquals("a failed save should be reported as false",
+				Boolean.FALSE, GlycanBuilder.saveToItsOwnFile(document));
+	}
+
+	/** And one that works, as working. */
+	@Test
+	public void aSuccessfulSaveIsReportedAsSuccessful() throws Exception {
+		Document document = savedDocumentIn(existingWritableFile());
+		document.failOnWrite = false;
+
+		assertEquals(Boolean.TRUE, GlycanBuilder.saveToItsOwnFile(document));
+	}
+
+	/**
+	 * A document with no file of its own is neither, and says so: the caller offers Save As.
+	 *
+	 * <p>This is the case the discarded return value had been written for, and it still works — which
+	 * is the half that says the fix did not turn every failure into a file chooser.
+	 */
+	@Test
+	public void aDocumentWithNoFileAsksTheCallerToChooseOne() {
+		assertNull("a document with no writable file should fall through to Save As",
+				GlycanBuilder.saveToItsOwnFile(new Document()));
+	}
+
+	/** And so is no document at all. */
+	@Test
+	public void noDocumentAsksNothing() {
+		assertNull(GlycanBuilder.saveToItsOwnFile(null));
+	}
+
+	/** A document that believes it came from this file, so {@code getFile} hands it back. */
+	private static Document savedDocumentIn(File file) {
+		Document document = new Document();
+		document.setFilename(file.getAbsolutePath());
+		document.setChanged(true);
+
+		return document;
+	}
+
+	private static File existingWritableFile() throws Exception {
+		File file = File.createTempFile("glycanbuilder-close-", ".tmp");
+		file.deleteOnExit();
+
+		FileWriter writer = new FileWriter(file);
+		try {
+			writer.write("something that was already there");
+		} finally {
+			writer.close();
+		}
+
+		return file;
+	}
+
+	/** The smallest document there can be, with a write that can be told to fail. */
+	private static final class Document extends BaseDocument {
+
+		private boolean failOnWrite = true;
+
+		@Override
+		public void write(OutputStream os) throws Exception {
+			if (failOnWrite) throw new Exception("the disk said no");
+			os.write("written".getBytes("UTF-8"));
+		}
+
+		@Override
+		public int size() {
+			return 1;
+		}
+
+		@Override
+		public String getName() {
+			return "Test document";
+		}
+
+		@Override
+		public void initData() {
+		}
+
+		@Override
+		public void fromString(String str, boolean merge) throws Exception {
+		}
+
+		@Override
+		public Collection<FileFilter> getFileFormats() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public FileFilter getAllFileFormats() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSequenceExportSaysSoTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSequenceExportSaysSoTest.java
@@ -1,0 +1,82 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanBuilder;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an export to a sequence format reports what happened.
+ *
+ * <p>The sequence branch of Export To called {@code exportTo} and returned {@code true} regardless of
+ * what it said, so an export that wrote nothing reported success. The graphical formats in the same
+ * method had always returned their real result — only the sequence formats lied.
+ *
+ * <p>It also made a liar of the warning that follows a successful export, whose whole purpose is to
+ * tell a user which structures did not come out.
+ *
+ * <p>The failure is a destination that cannot be written — a directory — rather than a permission bit,
+ * so it is deterministic and needs no privileged setup.
+ */
+public class AFailedSequenceExportSaysSoTest {
+
+	private static final String A_GLYCAN = "freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** An export that cannot be written is reported as failed. */
+	@Test
+	public void anExportThatCannotBeWrittenIsReportedAsFailed() throws Exception {
+		assertFalse("a sequence export to an unwritable destination should be reported as false",
+				GlycanBuilder.exportSequenceTo(documentWithAGlycan(),
+						aDirectory().getAbsolutePath(), "wurcs2"));
+	}
+
+	/** And one that works, as working — the half that says the fix did not refuse everything. */
+	@Test
+	public void anExportThatWorksIsReportedAsWorking() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-export-", ".wurcs");
+		destination.deleteOnExit();
+
+		assertTrue("an ordinary sequence export should be reported as true",
+				GlycanBuilder.exportSequenceTo(documentWithAGlycan(),
+						destination.getAbsolutePath(), "wurcs2"));
+		assertTrue("and should have written something", destination.length() > 0);
+	}
+
+	/** No document is no export. */
+	@Test
+	public void noDocumentIsNoExport() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-export-", ".wurcs");
+		destination.deleteOnExit();
+
+		assertFalse(GlycanBuilder.exportSequenceTo(null, destination.getAbsolutePath(), "wurcs2"));
+	}
+
+	private static GlycanDocument documentWithAGlycan() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.importFromString(A_GLYCAN, "gws"));
+
+		return document;
+	}
+
+	/** A destination that is not a file, which is the simplest write failure to arrange. */
+	private static File aDirectory() throws Exception {
+		File directory = File.createTempFile("glycanbuilder-export-", "");
+		assertTrue(directory.delete());
+		assertTrue(directory.mkdir());
+		directory.deleteOnExit();
+
+		return directory;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/XmlReadersRefuseExternalEntitiesTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/XmlReadersRefuseExternalEntitiesTest.java
@@ -1,0 +1,129 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.eurocarbdb.application.glycanbuilder.util.SAXUtils;
+import org.eurocarbdb.application.glycanbuilder.util.XMLUtils;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * That neither XML reader will fetch what a document points at.
+ *
+ * <p>A default JAXP parser resolves external entities, so a document can name a file and have its
+ * contents substituted into the parse. Measured before the fix, with an entity pointing at a temporary
+ * file: both {@link XMLUtils#read(String)} and {@link SAXUtils#read} expanded it and handed back the
+ * file's contents. The same configuration will issue network requests from a document, so the reach was
+ * never limited to the local disk.
+ *
+ * <p>The sentinel is written to a temporary file and looked for by name, so the test proves the
+ * substitution did not happen rather than that some particular error was produced. No network and no
+ * listening socket: an entity with a {@code file:} URI is the whole of it.
+ */
+public class XmlReadersRefuseExternalEntitiesTest {
+
+	private static final String SENTINEL = "glycanbuilder-xxe-sentinel-4f2a";
+
+	/** The DOM reader refuses it, by its existing contract of reporting and returning null. */
+	@Test
+	public void theDomReaderDoesNotFetchTheFile() throws Exception {
+		Document parsed = XMLUtils.read(xmlNaming(fileHoldingTheSentinel()));
+
+		assertNull("the DOM reader accepted a document with an external entity", parsed);
+	}
+
+	/** The SAX reader throws, and the handler is given nothing first. */
+	@Test
+	public void theSaxReaderDoesNotFetchTheFile() throws Exception {
+		final StringBuilder seen = new StringBuilder();
+		String xml = xmlNaming(fileHoldingTheSentinel());
+
+		boolean threw = false;
+		try {
+			SAXUtils.read(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
+					new DefaultHandler() {
+						@Override
+						public void characters(char[] ch, int start, int length) {
+							seen.append(ch, start, length);
+						}
+					});
+		} catch (Exception refused) {
+			threw = true;
+		}
+
+		assertTrue("the SAX reader accepted a document with an external entity", threw);
+		assertFalse("the handler was given the file's contents before the parse failed: " + seen,
+				seen.toString().contains(SENTINEL));
+	}
+
+	/**
+	 * And ordinary XML still reads, which is the half that says the hardening did not cost anything.
+	 *
+	 * <p>Nothing this application reads as XML declares a {@code DOCTYPE} — workspaces, configuration,
+	 * fragment definitions — which is why refusing one outright was available as the strongest setting
+	 * and the compatible one at the same time.
+	 */
+	@Test
+	public void ordinaryXmlStillReads() throws Exception {
+		Document parsed = XMLUtils.read(
+				"<?xml version=\"1.0\"?><Workspace><Glycan>ordinary</Glycan></Workspace>");
+
+		assertNotNull("an ordinary document should still parse", parsed);
+		assertEquals("Workspace", parsed.getDocumentElement().getNodeName());
+		assertEquals("ordinary", parsed.getDocumentElement().getTextContent());
+	}
+
+	/** And through SAX as well. */
+	@Test
+	public void ordinaryXmlStillReadsThroughSax() throws Exception {
+		final StringBuilder seen = new StringBuilder();
+
+		SAXUtils.read(new ByteArrayInputStream(
+						"<?xml version=\"1.0\"?><Workspace><Glycan>ordinary</Glycan></Workspace>"
+								.getBytes(StandardCharsets.UTF_8)),
+				new DefaultHandler() {
+					@Override
+					public void characters(char[] ch, int start, int length) {
+						seen.append(ch, start, length);
+					}
+
+					@Override
+					public void startElement(String uri, String local, String name, Attributes a) {
+					}
+				});
+
+		assertEquals("ordinary", seen.toString().trim());
+	}
+
+	/** A file the parse must not be able to reach. */
+	private static File fileHoldingTheSentinel() throws Exception {
+		File secret = File.createTempFile("glycanbuilder-xxe-", ".txt");
+		secret.deleteOnExit();
+
+		FileWriter writer = new FileWriter(secret);
+		try {
+			writer.write(SENTINEL);
+		} finally {
+			writer.close();
+		}
+
+		return secret;
+	}
+
+	private static String xmlNaming(File secret) {
+		return "<?xml version=\"1.0\"?>"
+				+ "<!DOCTYPE root [<!ENTITY leak SYSTEM \"" + secret.toURI() + "\">]>"
+				+ "<root><taken>&leak;</taken></root>";
+	}
+}


### PR DESCRIPTION
All six work packages of `CODE_REVIEW_REMEDIATION.md`. **Every fault was reproduced before it was
fixed**, and each fix has a test that fails against the old behaviour.

200 tests pass, headless. The fat-jar package builds. Java 8 source/target unchanged.

## Taken in a different order than the document proposes, for two reasons

**F first, not fifth.** It is the cheapest of the six and it is *why the other five could ship* — 1.36.0,
1.37.0 and 1.38.0 all went out with `-DskipTests` in every installer workflow and nothing else running
the suite. Fixing the faults without the gate leaves the next one the same road.

**E second, ahead of A and B.** A verified file-disclosure hole in a released product outranks a
data-loss path that needs a save to fail first.

## F — tests gate the release

`tests.yml` runs the suite headless (AWT aborts the JVM on a display-less runner otherwise, which reads
as a crash rather than a missing display) and uploads surefire's reports whatever the outcome. `release.yml`
now reads tests → installers → release: every installer job `needs: test`.

It also runs on pull requests to `master` and `develop` — **including this one, which is the acceptance
evidence.** I did not push a deliberately failing test to prove the gate: a green run of the new job on
this PR shows it executes, and the dependency graph shows what waits on it, without burning a release
run on a known-bad commit.

## E — the XML readers

Reproduced first. With an entity pointing at a temporary file holding a sentinel:

```
XMLUtils.read(String)           returned the file's contents
SAXUtils.read(InputStream, h)   handed the file's contents to the handler
```

The same configuration issues network requests from a document, so the reach was never the local disk
alone. **This is not the XXE work in 1.35.2** — that was `GlycoCTParser` refusing a `DOCTYPE` for one
format, and left these two helpers, which everything else goes through.

`SecureXml` is the one place both parsers are made. Nothing this application reads as XML declares a
`DOCTYPE`, so the strongest setting was also the compatible one: a document type declaration is refused
outright, which *removes* entity substitution rather than restricting it. The external-entity,
external-DTD, XInclude and secure-processing settings sit behind it for a parser that honours those
instead.

**It fails closed.** A parser that cannot be told to be safe is not returned. The one thing allowed to be
unsupported is the JAXP external-access properties, which some implementations do not know by name — and
which have nothing left to restrict once the `DOCTYPE` is refused.

## A and B — the save path

Two faults, two fixes, two tests. Fixing the model does not fix the caller and vice versa.

**A**: `save` called `setFilename` before writing anything, and that sets `was_saved` and clears
`has_changed` as a side effect. An unwritable destination returned `false` while leaving the document
marked saved and clean — asterisk gone, Save greyed, and the next close let the work go without asking.
The write decides now and the bookkeeping follows; the stream is closed; the temporary file is removed on
every path, including the failing ones where it had been left behind.

**B**: `onSave` discarded the result and returned `true`. That is the branch "Save changes to …?" takes on
exit, so an I/O failure read as success and the application closed over unwritten work.
`checkDocumentChanges` already refuses to continue on a `false`, so returning the real answer is the whole
of it. No second file chooser — a document with a writable file has already been asked where to go.

## C — a failed open keeps what is open

`open` caught the parse failure and called `init()`, clearing the document before returning `false`. A
malformed file took whatever was on screen with it, and "Open additional document…" destroyed the document
it was meant to be adding to. Nothing needed tidying: `GlycanDocument.fromString` parses into a list of its
own and only then hands it over, so a failed parse has not touched the document — `init()` was cleaning up
after something that had not happened. The stream is closed either way now, which on Windows is the
difference between being able to replace the file and not.

## D — a failed export says so

The sequence branch returned `true` regardless, so an export that wrote nothing reported success — and made
a liar of the warning that follows it, whose purpose is to say which structures did not come out. The
graphical formats in the same method had always returned their real result. The last-exported file is
recorded and the warning shown only on success.

## Two notes on the document itself

- **The test count does not match.** It says "195 tests ... before these fixes"; `develop` runs 181. I have
  not chased the difference and have not used the document's numbers as an acceptance criterion.
- **`saveToItsOwnFile` and `exportSequenceTo`** are the "extract only the post-selection operation" the
  document asks for. Everything around them is a file chooser; everything about them that was wrong was
  inside.

## Not in scope here

Also open, and fixed separately in #212: the 1.37.0 position-rule regression (#211) — an acyl refused at
its own amine, and a copy silently dropping a residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
