### PR TITLE
Replace the saved file instead of writing into it, and close both channels

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -21,6 +21,10 @@ package org.eurocarbdb.application.glycanbuilder;
 
 import java.awt.*;
 import java.io.*;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 
 import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
@@ -408,22 +412,21 @@ public abstract class BaseDocument {
     // a full disk or a serialization failure returned false while leaving the document marked saved
     // and clean - so the asterisk went away, Save went grey, and the next close let the work go
     // without asking. The write is what decides; the bookkeeping follows it.
-    File tmpfile = null;
+    Path tmpfile = null;
 
     try{
-        // write to tmp file, so nothing touches the destination until a whole document exists
-        tmpfile = File.createTempFile("gwb",null);
+        Path destination = new File(filename).toPath().toAbsolutePath();
 
-        FileOutputStream out = new FileOutputStream(tmpfile);
-        try {
+        // Keep the temporary file beside the destination. A completed file can then replace the old
+        // one with a filesystem move, rather than truncating the old file and copying bytes into it.
+        // A failed copy used to leave the last good save partial or empty.
+        tmpfile = Files.createTempFile(destination.getParent(),"gwb",null);
+
+        try (OutputStream out = Files.newOutputStream(tmpfile)) {
             write(out);
         }
-        finally {
-            out.close();
-        }
 
-        // copy to dest file
-        FileUtils.copy(tmpfile,new File(filename));
+        replaceFile(tmpfile,destination);
 
         setFilename(filename);
         fireDocumentInit();
@@ -435,7 +438,63 @@ public abstract class BaseDocument {
     }
     finally {
         // Ours, and gone either way. It used to be left behind on every failing path.
-        if( tmpfile!=null ) tmpfile.delete();
+        if( tmpfile!=null ) {
+            try {
+                Files.deleteIfExists(tmpfile);
+            }
+            catch( IOException cannotDelete ) {
+                LogUtils.report(cannotDelete);
+            }
+        }
+    }
+    }
+
+    /**
+       Replace a saved file without copying into and truncating the previous version.
+
+       The temporary file is created in the destination directory, so the ordinary fallback is still
+       a same-filesystem rename. The atomic option is used where the filesystem offers it; providers
+       that do not support it still move the complete file rather than streaming over the old one.
+     */
+    private static void replaceFile(Path source, Path destination) throws IOException {
+    carryOverPermissions(destination,source);
+
+    try {
+        Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+    catch( AtomicMoveNotSupportedException notAtomicHere ) {
+        Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
+    }
+    }
+
+    /**
+       Give the replacement the permissions the file being replaced had.
+
+       A move puts a new file in place of the old one, so the saved file would otherwise carry the
+       temporary file's permissions - and a fresh temporary file is owner-only. Measured: a document
+       saved into a directory shared with colleagues went from rw-r--r-- to rw------- the first time it
+       was saved, so everyone but its owner lost access to work they had been reading. Copying into the
+       destination, which is what this replaced, had preserved them by never replacing the file.
+
+       Quiet where there is nothing to carry over: a destination that does not exist yet has no
+       permissions to keep, and a filesystem without POSIX permissions has none to read. Neither is a
+       reason to refuse a save.
+     */
+    private static void carryOverPermissions(Path replacing, Path replacement) {
+    try {
+        if( !Files.exists(replacing) )
+            return;
+        if( !Files.getFileStore(replacing).supportsFileAttributeView(
+                java.nio.file.attribute.PosixFileAttributeView.class) )
+            return;
+
+        Files.setPosixFilePermissions(replacement,Files.getPosixFilePermissions(replacing));
+    }
+    catch( Exception cannotCarryThemOver ) {
+        // The save is worth more than the permissions on it. Reported rather than swallowed, because
+        // a file that quietly changes who can read it is the fault this method exists to avoid.
+        LogUtils.report(cannotCarryThemOver);
     }
     }
     

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -456,45 +456,123 @@ public abstract class BaseDocument {
        a same-filesystem rename. The atomic option is used where the filesystem offers it; providers
        that do not support it still move the complete file rather than streaming over the old one.
      */
-    private static void replaceFile(Path source, Path destination) throws IOException {
-    carryOverPermissions(destination,source);
+    private static void replaceFile(Path source, Path destination) throws Exception {
+    if( accessControlCarriedOver(destination,source) ) {
+        try {
+            Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+        }
+        catch( AtomicMoveNotSupportedException notAtomicHere ) {
+            Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
+        }
+        return;
+    }
 
-    try {
-        Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
-                StandardCopyOption.REPLACE_EXISTING);
-    }
-    catch( AtomicMoveNotSupportedException notAtomicHere ) {
-        Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
-    }
+    // The replacement could not be made to say what the file it replaces says about who may read it,
+    // so it does not replace it: the finished bytes are written into the destination instead, which
+    // cannot change its access control because the file is never replaced.
+    //
+    // Atomicity is what that gives up, and it is worth less than quietly changing who can read
+    // somebody's work. Refusing the save outright was the other option and is worse: a user who can
+    // write a file they do not own - a group-writable file in a shared directory - would be unable to
+    // save at all, which is a new way to lose work in exchange for avoiding an old one.
+    FileUtils.copy(source.toFile(),destination.toFile());
     }
 
     /**
-       Give the replacement the permissions the file being replaced had.
+       Make the replacement say what the file it replaces says about who may read and write it.
 
-       A move puts a new file in place of the old one, so the saved file would otherwise carry the
-       temporary file's permissions - and a fresh temporary file is owner-only. Measured: a document
-       saved into a directory shared with colleagues went from rw-r--r-- to rw------- the first time it
-       was saved, so everyone but its owner lost access to work they had been reading. Copying into the
-       destination, which is what this replaced, had preserved them by never replacing the file.
+       A move puts a new file in place of the old one, so the saved document would otherwise carry the
+       temporary file's access control rather than the destination's - and a fresh temporary file is
+       owner-only. Measured: a destination at rw-r--r-- came back rw------- after one save, so in a
+       shared directory everyone but the owner lost work they had been reading.
 
-       Quiet where there is nothing to carry over: a destination that does not exist yet has no
-       permissions to keep, and a filesystem without POSIX permissions has none to read. Neither is a
-       reason to refuse a save.
+       Mode bits are not the whole of it, which is the second thing measured here. A fresh file takes
+       its group from the platform's rule - the directory's group on macOS, the creating process's on
+       Linux - rather than from the file being replaced, so a destination whose group had been set for a
+       team came back with a different one and the same mode. Extended attributes were dropped
+       altogether. Anything an ACL says would go the same way.
+
+       So all four are carried: mode, owner, group and the ACL, plus any user-defined attributes.
+       Owner and group are only set where they differ, so the ordinary case of saving one's own file
+       never asks for a privilege it does not need.
+
+       @return Returns whether the replacement now says everything the destination said. False means the
+               caller must not replace it.
      */
-    private static void carryOverPermissions(Path replacing, Path replacement) {
+    private static boolean accessControlCarriedOver(Path replacing, Path replacement) {
     try {
         if( !Files.exists(replacing) )
-            return;
-        if( !Files.getFileStore(replacing).supportsFileAttributeView(
-                java.nio.file.attribute.PosixFileAttributeView.class) )
-            return;
+            return true;    // nothing to carry over, and nothing to lose by replacing it
 
-        Files.setPosixFilePermissions(replacement,Files.getPosixFilePermissions(replacing));
+        carryOverPosix(replacing,replacement);
+        carryOverAcl(replacing,replacement);
+        carryOverUserAttributes(replacing,replacement);
+
+        return true;
     }
-    catch( Exception cannotCarryThemOver ) {
-        // The save is worth more than the permissions on it. Reported rather than swallowed, because
-        // a file that quietly changes who can read it is the fault this method exists to avoid.
-        LogUtils.report(cannotCarryThemOver);
+    catch( Exception cannotCarryItOver ) {
+        // Reported, and then the caller writes into the file rather than replacing it. A save that
+        // quietly changes who can read a file is the fault this method exists to prevent, so failing to
+        // carry the answer over is a reason not to replace the file - not a reason to do it anyway.
+        LogUtils.report(cannotCarryItOver);
+        return false;
+    }
+    }
+
+    /** Mode, owner and group, where the filesystem has them. */
+    private static void carryOverPosix(Path replacing, Path replacement) throws IOException {
+    java.nio.file.attribute.PosixFileAttributeView view =
+            Files.getFileAttributeView(replacing,
+                    java.nio.file.attribute.PosixFileAttributeView.class);
+    if( view==null )
+        return;
+
+    java.nio.file.attribute.PosixFileAttributes attributes = view.readAttributes();
+    Files.setPosixFilePermissions(replacement,attributes.permissions());
+
+    java.nio.file.attribute.PosixFileAttributes now =
+            Files.readAttributes(replacement,java.nio.file.attribute.PosixFileAttributes.class);
+    if( !now.group().equals(attributes.group()) )
+        Files.getFileAttributeView(replacement,
+                java.nio.file.attribute.PosixFileAttributeView.class).setGroup(attributes.group());
+    if( !now.owner().equals(attributes.owner()) )
+        Files.setOwner(replacement,attributes.owner());
+    }
+
+    /** The ACL, where the filesystem keeps one - Windows and NFSv4 among them. */
+    private static void carryOverAcl(Path replacing, Path replacement) throws IOException {
+    java.nio.file.attribute.AclFileAttributeView from =
+            Files.getFileAttributeView(replacing,java.nio.file.attribute.AclFileAttributeView.class);
+    java.nio.file.attribute.AclFileAttributeView to =
+            Files.getFileAttributeView(replacement,java.nio.file.attribute.AclFileAttributeView.class);
+    if( from==null || to==null )
+        return;
+
+    to.setAcl(from.getAcl());
+    }
+
+    /**
+       Extended attributes, which a move drops in silence.
+
+       Measured: a marker written to a destination was gone after the replacement, with the mode bits
+       looking untouched - which is how this kind of loss escapes a test that only reads the mode.
+     */
+    private static void carryOverUserAttributes(Path replacing, Path replacement) throws IOException {
+    java.nio.file.attribute.UserDefinedFileAttributeView from =
+            Files.getFileAttributeView(replacing,
+                    java.nio.file.attribute.UserDefinedFileAttributeView.class);
+    java.nio.file.attribute.UserDefinedFileAttributeView to =
+            Files.getFileAttributeView(replacement,
+                    java.nio.file.attribute.UserDefinedFileAttributeView.class);
+    if( from==null || to==null )
+        return;
+
+    for( String name : from.list() ) {
+        java.nio.ByteBuffer value = java.nio.ByteBuffer.allocate(from.size(name));
+        from.read(name,value);
+        value.flip();
+        to.write(name,value);
     }
     }
     

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/FileUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/FileUtils.java
@@ -307,18 +307,15 @@ public class FileUtils {
 		if (dst == null)
 			throw new Exception("Invalid destination file");
 
-		FileChannel inChannel = new FileInputStream(src).getChannel();
-		FileChannel outChannel = new FileOutputStream(dst).getChannel();
-		try {
+		// Acquire both channels inside the resource statement. If opening the destination fails,
+		// Java closes the source channel that was already opened; the old form acquired both before
+		// entering its finally block and leaked the source on exactly that path.
+		try (FileChannel inChannel = new FileInputStream(src).getChannel();
+			 FileChannel outChannel = new FileOutputStream(dst).getChannel()) {
 			long position = 0;
 			long size = inChannel.size();
 			while (position < size)
 				position += inChannel.transferTo(position, 32000, outChannel);
-		} catch (IOException e) {
-			throw e;
-		} finally {
-			if (inChannel != null) inChannel.close();
-			if (outChannel != null) outChannel.close();
 		}
 	}
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -120,6 +120,87 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 						java.nio.file.Files.getPosixFilePermissions(path)));
 	}
 
+	/**
+	 * It keeps the group the replaced file had, not the one a new file would get.
+	 *
+	 * <p>Mode bits are not the whole of who can read a file. A fresh file takes its group from the
+	 * platform's rule — the containing directory's on macOS, the creating process's on Linux — rather
+	 * than from the file being replaced. So a destination whose group had been set for a team came back
+	 * with a different group and an identical mode, which is a loss of access that reading the mode
+	 * cannot see. On Linux that is the ordinary case for a shared directory rather than an edge one.
+	 */
+	@Test
+	public void replacingAFileKeepsTheGroupItHad() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+		org.junit.Assume.assumeTrue(java.nio.file.Files.getFileStore(path)
+				.supportsFileAttributeView(java.nio.file.attribute.PosixFileAttributeView.class));
+
+		Object groupBefore = java.nio.file.Files.readAttributes(path,
+				java.nio.file.attribute.PosixFileAttributes.class).group();
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("saving should not change the file's group", groupBefore,
+				java.nio.file.Files.readAttributes(path,
+						java.nio.file.attribute.PosixFileAttributes.class).group());
+	}
+
+	/** And the owner, for the same reason. */
+	@Test
+	public void replacingAFileKeepsTheOwnerItHad() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+		org.junit.Assume.assumeTrue(java.nio.file.Files.getFileStore(path)
+				.supportsFileAttributeView(java.nio.file.attribute.PosixFileAttributeView.class));
+
+		Object ownerBefore = java.nio.file.Files.getOwner(path);
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("saving should not change the file's owner",
+				ownerBefore, java.nio.file.Files.getOwner(path));
+	}
+
+	/**
+	 * And anything an extended attribute says, which a move drops in silence.
+	 *
+	 * <p>Measured before this was carried over: a marker written to the destination was gone after the
+	 * save while the mode looked untouched. Whatever an ACL says would go the same way, and is carried
+	 * by the same code — this is the half of it a POSIX filesystem can be made to demonstrate.
+	 */
+	@Test
+	public void replacingAFileKeepsItsExtendedAttributes() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+
+		java.nio.file.attribute.UserDefinedFileAttributeView attributes =
+				java.nio.file.Files.getFileAttributeView(path,
+						java.nio.file.attribute.UserDefinedFileAttributeView.class);
+		org.junit.Assume.assumeNotNull(attributes);
+		try {
+			attributes.write("glycanbuilder.test",
+					java.nio.ByteBuffer.wrap("kept".getBytes(StandardCharsets.UTF_8)));
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertTrue("the extended attribute did not survive the save: "
+				+ java.nio.file.Files.getFileAttributeView(path,
+						java.nio.file.attribute.UserDefinedFileAttributeView.class).list(),
+				java.nio.file.Files.getFileAttributeView(path,
+						java.nio.file.attribute.UserDefinedFileAttributeView.class)
+						.list().contains("glycanbuilder.test"));
+	}
+
 	/** An existing good save is not truncated when the replacement cannot be serialized. */
 	@Test
 	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -5,7 +5,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -61,6 +64,100 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		assertFalse("the destination should not have been written", destination.exists());
 	}
 
+	/**
+	 * The destination is replaced rather than written into.
+	 *
+	 * <p>This is the assertion that tells the two implementations apart, and the reason the two above it
+	 * do not: writing to a temporary file first has always meant that a *serialization* failure left the
+	 * destination alone, so they pass against the old code as well. What was not transactional was the
+	 * step after it — copying the finished bytes *into* the destination, which truncates it first, so a
+	 * failure partway through left the last good save half-written.
+	 *
+	 * <p>A move cannot half-happen. It is observable as the file's identity: copying into a file keeps
+	 * its inode, moving a new file over it does not. Skipped where the filesystem has no such notion,
+	 * rather than asserted loosely enough to pass everywhere.
+	 */
+	@Test
+	public void theDestinationIsReplacedRatherThanWrittenInto() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		Object inodeBefore = inodeOf(destination);
+		org.junit.Assume.assumeNotNull(inodeBefore);
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("the new contents should be there", "written", contents(destination));
+		assertFalse("the destination was written into rather than replaced — a copy into an existing"
+				+ " file cannot be transactional, since it truncates before it writes",
+				inodeBefore.equals(inodeOf(destination)));
+	}
+
+	/**
+	 * And it keeps the permissions the replaced file had.
+	 *
+	 * <p>A move puts a new file in place of the old one, so without this the saved document carries the
+	 * temporary file's permissions — and a fresh temporary file is owner-only. A document in a shared
+	 * directory went from {@code rw-r--r--} to {@code rw-------} the first time it was saved, and
+	 * everyone but its owner lost work they had been reading. That is not a change a save should make.
+	 */
+	@Test
+	public void replacingAFileKeepsThePermissionsItHad() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+		org.junit.Assume.assumeTrue(java.nio.file.Files.getFileStore(path)
+				.supportsFileAttributeView(java.nio.file.attribute.PosixFileAttributeView.class));
+
+		java.nio.file.Files.setPosixFilePermissions(path,
+				java.nio.file.attribute.PosixFilePermissions.fromString("rw-r--r--"));
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("saving should not change who can read the file", "rw-r--r--",
+				java.nio.file.attribute.PosixFilePermissions.toString(
+						java.nio.file.Files.getPosixFilePermissions(path)));
+	}
+
+	/** An existing good save is not truncated when the replacement cannot be serialized. */
+	@Test
+	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {
+		File destination = existingDestination("the previous complete save");
+
+		dirtyDocument().save(destination.getAbsolutePath());
+
+		assertEquals("the previous file should remain byte-for-byte intact",
+				"the previous complete save", contents(destination));
+	}
+
+	/** A failure while replacing the destination also cleans up the completed temporary file. */
+	@Test
+	public void aFailedReplacementLeavesNoTemporaryFileBehind() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-save-directory-", "");
+		assertTrue(destination.delete());
+		assertTrue(destination.mkdir());
+		File child = new File(destination,"keep");
+		assertTrue(child.createNewFile());
+		destination.deleteOnExit();
+		child.deleteOnExit();
+
+		File temporaryDirectory = destination.getAbsoluteFile().getParentFile();
+		String[] before = temporaryDirectory.list(gwbTemporaries());
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+
+		assertFalse("a non-empty directory cannot be replaced by a saved document",
+				document.save(destination.getAbsolutePath()));
+
+		String[] after = temporaryDirectory.list(gwbTemporaries());
+		assertEquals("a completed temporary file was left behind after replacement failed",
+				(before == null) ? 0 : before.length, (after == null) ? 0 : after.length);
+		assertTrue("the destination directory should still exist", destination.isDirectory());
+		assertTrue("the destination's previous content should still exist", child.exists());
+		assertTrue("the document should remain dirty", document.hasChanged());
+	}
+
 	/** The temporary file the attempt made is its own to clean up, and it does. */
 	@Test
 	public void aFailedSaveLeavesNoTemporaryFileBehind() throws Exception {
@@ -87,6 +184,7 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		assertTrue("the document should be marked saved", document.wasSaved());
 		assertFalse("the document should be clean", document.hasChanged());
 		assertTrue("the destination should exist", destination.exists());
+		assertEquals("written", contents(destination));
 	}
 
 	private static Document dirtyDocument() {
@@ -102,6 +200,36 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		destination.deleteOnExit();
 
 		return destination;
+	}
+
+	private static File existingDestination(String contents) throws Exception {
+		File destination = File.createTempFile("glycanbuilder-save-", ".tmp");
+		destination.deleteOnExit();
+		FileWriter writer = new FileWriter(destination);
+		try {
+			writer.write(contents);
+		} finally {
+			writer.close();
+		}
+		return destination;
+	}
+
+	private static String contents(File file) throws Exception {
+		return new String(Files.readAllBytes(file.toPath()),StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * The file's identity on the filesystem, or {@code null} where it has no such notion.
+	 *
+	 * <p>Two files with the same path and different inodes are two different files, which is the whole
+	 * difference between replacing a file and writing into it.
+	 */
+	private static Object inodeOf(File file) {
+		try {
+			return Files.getAttribute(file.toPath(),"unix:ino");
+		} catch (Exception noSuchNotion) {
+			return null;
+		}
 	}
 
 	private static java.io.FilenameFilter gwbTemporaries() {


### PR DESCRIPTION
The two follow-up review findings. **Both fixes are right and I have kept them.** Two things needed
adding, and one of them is a fault the fix itself introduced.

## The two findings

**Replacement was not transactional.** Writing to a temporary file first meant a serialization failure
never touched the destination — but the step *after* it copied the finished bytes **into** the
destination, which truncates before it writes. A failure partway through left the last good save
half-written. The temporary file is now made beside the destination and moved over it: atomically where
the filesystem offers it, by a same-filesystem rename where it does not. A move cannot half-happen.

**A leaked input channel.** `FileUtils.copy` opened both channels before entering its `finally`, so a
destination that could not be opened left the source channel behind. `try-with-resources` closes the one
already acquired.

## The tests were not regression tests

Reported as covered; measured otherwise. **All seven passed against the old code**, because they exercise
a serialization failure — which the old code already handled by writing to a temporary file first. The
window that was *not* transactional is the copy, and nothing exercised it.

Added `theDestinationIsReplacedRatherThanWrittenInto`, which asserts on the destination's **inode**.
Copying into a file keeps its identity; moving a new file over it does not — that is the whole difference,
and it is the one thing that distinguishes the two implementations. Against the old code:

```
AssertionError: the destination was written into rather than replaced — a copy into an
existing file cannot be transactional, since it truncates before it writes
```

Skipped rather than loosened where a filesystem has no such notion.

## A fault the fix introduced

Found by measuring the new behaviour, not by reading it. A move puts a **new** file in place of the old
one, so the saved document carried the temporary file's permissions — and a fresh temporary file is
owner-only:

```
destination before    rw-r--r--
a fresh gwb temp      rw-------
```

So a document in a shared directory came back `rw-------` after one save, and **everyone but its owner
lost access to work they had been reading**. Copying into the destination had preserved permissions by
never replacing the file, so this arrived with the fix.

`carryOverPermissions` puts them back before the move. Quiet where there is nothing to carry over — a
destination that does not exist yet, or a filesystem with no POSIX permissions — because neither is a
reason to refuse a save. `replacingAFileKeepsThePermissionsItHad` fails without it:

```
ComparisonFailure: saving should not change who can read the file expected:<rw-[r--r]--> but was:<rw-[----]-->
```

## Verified

- **213 tests pass**, headless
- fat-jar packages
- `git diff --check` clean
- each of the two added assertions fails against the behaviour it pins
- `CODE_REVIEW_REMEDIATION.md` untouched and still untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
