### PR TITLE
Save into what a link points at, and refuse rather than fall back

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -415,11 +415,16 @@ public abstract class BaseDocument {
     Path tmpfile = null;
 
     try{
-        Path destination = new File(filename).toPath().toAbsolutePath();
+        // Save into what a symbolic link points at, not over the link. Writing to the destination had
+        // always followed it, because that is what opening a file for writing does; replacing the
+        // destination does not, so a save through a link left a regular file where the link had been
+        // and the file it pointed at still holding the previous contents - reported as a success.
+        Path destination = followLinks(new File(filename).toPath().toAbsolutePath());
 
-        // Keep the temporary file beside the destination. A completed file can then replace the old
-        // one with a filesystem move, rather than truncating the old file and copying bytes into it.
-        // A failed copy used to leave the last good save partial or empty.
+        // Keep the temporary file beside the destination - the resolved one, so the move stays on the
+        // same filesystem. A completed file can then replace the old one with a filesystem move, rather
+        // than truncating the old file and copying bytes into it, which left the last good save partial
+        // or empty when the copy failed partway.
         tmpfile = Files.createTempFile(destination.getParent(),"gwb",null);
 
         try (OutputStream out = Files.newOutputStream(tmpfile)) {
@@ -457,26 +462,52 @@ public abstract class BaseDocument {
        that do not support it still move the complete file rather than streaming over the old one.
      */
     private static void replaceFile(Path source, Path destination) throws Exception {
-    if( accessControlCarriedOver(destination,source) ) {
-        try {
-            Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
-                    StandardCopyOption.REPLACE_EXISTING);
-        }
-        catch( AtomicMoveNotSupportedException notAtomicHere ) {
-            Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
-        }
-        return;
+    // Nothing is replaced unless the replacement says what the file it replaces says about who may
+    // read it. This used to fall back to copying the bytes into the destination instead, on the
+    // grounds that a file which is never replaced cannot have its access control changed - which is
+    // true, and beside the point: that copy truncates the destination before it transfers, so a
+    // failure partway through leaves the last good save partial or empty. It is exactly the fault this
+    // whole change set out to remove, kept alive on the one path where attributes are most likely to
+    // fail - a shared file somebody else owns.
+    //
+    // Refusing is the safer of the two, and the argument I made for the fallback was wrong on its own
+    // terms: it also loses work, and it loses it silently. A refusal is visible and recoverable - the
+    // document stays dirty and Save As still works.
+    if( !accessControlCarriedOver(destination,source) )
+        throw new IOException("cannot save over " + destination
+                + " without changing who is allowed to read it");
+
+    try {
+        Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+    catch( AtomicMoveNotSupportedException notAtomicHere ) {
+        Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
+    }
     }
 
-    // The replacement could not be made to say what the file it replaces says about who may read it,
-    // so it does not replace it: the finished bytes are written into the destination instead, which
-    // cannot change its access control because the file is never replaced.
-    //
-    // Atomicity is what that gives up, and it is worth less than quietly changing who can read
-    // somebody's work. Refusing the save outright was the other option and is worse: a user who can
-    // write a file they do not own - a group-writable file in a shared directory - would be unable to
-    // save at all, which is a new way to lose work in exchange for avoiding an old one.
-    FileUtils.copy(source.toFile(),destination.toFile());
+    /**
+       Follow a chain of symbolic links to the path that will actually be written.
+
+       Not {@code toRealPath}, which requires the file to exist: a link pointing at a name that is not
+       there yet is a perfectly ordinary thing to save to, and resolving it by hand handles that as well
+       as a link whose target is relative to the link's own directory.
+
+       @return Returns the path at the end of the chain, or the path given where it is not a link.
+     */
+    private static Path followLinks(Path path) throws IOException {
+    Path resolved = path;
+
+    // A bound rather than a cycle check: a loop of links has no end to find, and thirty-two hops is
+    // past anything real.
+    for( int hops=0; hops<32 && Files.isSymbolicLink(resolved); hops++ ) {
+        Path parent = resolved.getParent();
+        Path target = Files.readSymbolicLink(resolved);
+
+        resolved = ((parent==null) ? target : parent.resolve(target)).toAbsolutePath().normalize();
+    }
+
+    return resolved;
     }
 
     /**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -507,6 +507,15 @@ public abstract class BaseDocument {
         resolved = ((parent==null) ? target : parent.resolve(target)).toAbsolutePath().normalize();
     }
 
+    // Running out of hops is a refusal, not an answer. Returning the link we stopped on made it the
+    // destination, so a loop of links - or a chain longer than the bound - had one of its links replaced
+    // by the saved file while the real file kept the previous contents, and the save reported success.
+    // Measured: a two-link cycle came back saved=true with one link destroyed; a thirty-three link chain
+    // came back saved=true with an intermediate link replaced and the target untouched.
+    if( Files.isSymbolicLink(resolved) )
+        throw new IOException("cannot find what " + path
+                + " points at: more than 32 symbolic links to follow, or a loop of them");
+
     return resolved;
     }
 

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -254,6 +254,67 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		assertEquals("written", contents(target.toFile()));
 	}
 
+	/**
+	 * A loop of links is refused, and both links are still links afterwards.
+	 *
+	 * <p>Bounding the search at thirty-two hops and then returning whatever it had stopped on made that
+	 * link the destination. Measured: a two-link cycle came back {@code saved=true} with one of the links
+	 * replaced by the saved file. Running out of hops is a refusal, not an answer.
+	 */
+	@Test
+	public void aLoopOfLinksIsRefused() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-loop-");
+		java.nio.file.Path first = directory.resolve("first.gws");
+		java.nio.file.Path second = directory.resolve("second.gws");
+		try {
+			java.nio.file.Files.createSymbolicLink(first, second.getFileName());
+			java.nio.file.Files.createSymbolicLink(second, first.getFileName());
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+
+		assertFalse("a loop of links has no file at the end of it to save into",
+				document.save(first.toString()));
+		assertTrue("the first link should still be a link",
+				java.nio.file.Files.isSymbolicLink(first));
+		assertTrue("the second link should still be a link",
+				java.nio.file.Files.isSymbolicLink(second));
+		assertTrue("the document should remain dirty", document.hasChanged());
+	}
+
+	/** And so is a chain longer than the bound, with every link and the file at the end left alone. */
+	@Test
+	public void aChainLongerThanTheBoundIsRefused() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-chain-");
+		java.nio.file.Path target = directory.resolve("target.gws");
+		java.nio.file.Files.write(target, "the previous save".getBytes(StandardCharsets.UTF_8));
+
+		java.nio.file.Path[] links = new java.nio.file.Path[33];
+		try {
+			for (int index = links.length - 1; index >= 0; index--) {
+				links[index] = directory.resolve("link-" + index + ".gws");
+				java.nio.file.Path next = (index == links.length - 1) ? target : links[index + 1];
+				java.nio.file.Files.createSymbolicLink(links[index], next.getFileName());
+			}
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+
+		assertFalse("a chain past the bound should be refused rather than cut short",
+				document.save(links[0].toString()));
+		for (java.nio.file.Path link : links)
+			assertTrue(link + " should still be a link", java.nio.file.Files.isSymbolicLink(link));
+		assertEquals("the file at the end of the chain should be untouched",
+				"the previous save", contents(target.toFile()));
+		assertTrue("the document should remain dirty", document.hasChanged());
+	}
+
 	/** An existing good save is not truncated when the replacement cannot be serialized. */
 	@Test
 	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -201,6 +201,59 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 						.list().contains("glycanbuilder.test"));
 	}
 
+	/**
+	 * Saving to a symbolic link writes into what it points at, and leaves the link a link.
+	 *
+	 * <p>Opening a file for writing follows a link, so copying into the destination always did. Replacing
+	 * the destination does not: measured, a save to {@code link.gws} reported success, left a regular
+	 * file where the link had been, and left the {@code target.gws} it pointed at holding the previous
+	 * contents. The document the user believed they had saved was not the one on disk.
+	 */
+	@Test
+	public void savingThroughASymbolicLinkWritesIntoItsTarget() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-link-");
+		java.nio.file.Path target = directory.resolve("target.gws");
+		java.nio.file.Path link = directory.resolve("link.gws");
+		java.nio.file.Files.write(target, "the previous save".getBytes(StandardCharsets.UTF_8));
+		try {
+			java.nio.file.Files.createSymbolicLink(link, target.getFileName());
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue("the save should have succeeded", document.save(link.toString()));
+
+		assertTrue("the link should still be a link", java.nio.file.Files.isSymbolicLink(link));
+		assertEquals("the file the link points at should hold the new contents",
+				"written", contents(target.toFile()));
+	}
+
+	/** And a chain of links resolves all the way, rather than one hop. */
+	@Test
+	public void savingThroughAChainOfLinksReachesTheEnd() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-link-");
+		java.nio.file.Path target = directory.resolve("target.gws");
+		java.nio.file.Path middle = directory.resolve("middle.gws");
+		java.nio.file.Path link = directory.resolve("link.gws");
+		java.nio.file.Files.write(target, "the previous save".getBytes(StandardCharsets.UTF_8));
+		try {
+			java.nio.file.Files.createSymbolicLink(middle, target.getFileName());
+			java.nio.file.Files.createSymbolicLink(link, middle.getFileName());
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(link.toString()));
+
+		assertTrue("both links should still be links", java.nio.file.Files.isSymbolicLink(link)
+				&& java.nio.file.Files.isSymbolicLink(middle));
+		assertEquals("written", contents(target.toFile()));
+	}
+
 	/** An existing good save is not truncated when the replacement cannot be serialized. */
 	@Test
 	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {


### PR DESCRIPTION
Both findings stand. **The P1 is a correction to a judgement I made and argued for**, so I want to be
plain about that rather than bury it.

## P1 — the fallback is gone

When the destination's access control cannot be reproduced on the replacement, the save now **fails and
the document stays dirty**. It used to copy the bytes into the destination instead.

My argument for that fallback was: a file which is never replaced cannot have its access control changed.
True, and beside the point — `FileUtils.copy` truncates the destination before it transfers, so a failure
partway through leaves the last good save partial or empty. That is the fault this entire change set out
to remove, kept alive on **the one path where attributes are most likely to fail**: a shared file somebody
else owns.

And the reason I gave for preferring it does not hold. I wrote that refusing was worse because it was "a
new way to lose work". The fallback also loses work, and loses it *silently*. A refusal is visible and
recoverable: the document stays dirty and Save As still works. The review is right.

## P2 — saving through a symbolic link

Opening a file for writing follows a link, so copying into the destination always did. Replacing the
destination does not.

```
before   before=true saved=true after=false linkBytes=new targetBytes=old
after    before=true saved=true after=true  linkBytes=new targetBytes=new
```

The link had become a regular file, the file it pointed at kept the previous contents, and the save
reported success — so the document the user believed they had saved was not the one on disk.

`followLinks` resolves the chain before the temporary file is made, so the temporary file lands beside the
**real** file and the move stays on one filesystem. Resolved by hand rather than with `toRealPath`, which
requires the file to exist — a link pointing at a name that is not there yet is an ordinary thing to save
to — and which would not handle a target relative to the link's own directory. Bounded at thirty-two hops,
because a loop of links has no end to find.

## What the four new assertions cover, and what they do not

| assertion | fails without the change |
|---|---|
| `savingThroughASymbolicLinkWritesIntoItsTarget` | yes — "the link should still be a link" |
| `savingThroughAChainOfLinksReachesTheEnd` | yes |
| the removal of the fallback | **nothing left to observe** — the copy path is gone from the file |
| a failed replacement leaves the document dirty | already held by the existing directory-destination test |

**I could not force a carry-over failure portably.** Making one happen needs a destination owned by
another user, which needs a privilege the test does not have. So the refusal is verified by the fallback no
longer existing rather than by a test that drives it, and I would rather say that than dress up a weaker
test as coverage.

## Also noted from the review, and agreed

- **ACLs are not directly verified on macOS.** The carry-over calls `AclFileAttributeView` and the view is
  absent on this filesystem, so that branch is exercised on Windows and NFSv4 and nowhere in this suite.
  The extended-attribute assertion covers the same shape of loss on a POSIX filesystem.
- **The 214 vs 216 count** is network-dependent tests being excluded, not a discrepancy.

## Verified

- **218 tests pass**, headless
- fat-jar packages
- `git diff --check` clean
- `CODE_REVIEW_REMEDIATION.md` untouched and still untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)
