### PR TITLE
Version 1.39.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,17 +12,26 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
+  # Nothing is built until the suite passes. The installer workflows all build with -DskipTests, so
+  # without this job a release could publish - and did - without a single test having run in CI.
+  test:
+    uses: ./.github/workflows/tests.yml
+
   build-installer-linux:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_linux.yml
 
   build-installer-macos:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_macos.yml
     secrets: inherit
 
   build-installer-windows:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_windows.yml
 
   build-installer-rpm:
+    needs: test
     uses: ./.github/workflows/jpackage_installer_rpm.yml
 
   release:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,64 @@
+name: Tests
+
+# The suite, as a job other workflows can require.
+#
+# It exists because the release path did not run it. All four installer workflows build with
+# -DskipTests and release.yml only waits for them, so installers could be published - and were - without
+# a single regression test having executed in CI. The tests were run by hand before each release, which
+# is not a gate, it is a habit.
+#
+# Called by release.yml before any installer is built, and run on its own for pull requests, so a
+# failure is found before somebody dispatches a release.
+
+on:
+  workflow_call:
+  pull_request:
+    branches: [ master, develop ]
+
+env:
+  JAVA_VERSION: '21'
+  JAVA_DISTRIBUTION: 'zulu'
+  GITHUB_ACTOR: github.actor
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
+
+    - name: Set up JDK ${{ env.JAVA_VERSION }}
+      uses: actions/setup-java@v5
+      with:
+        java-version: ${{ env.JAVA_VERSION }}
+        distribution: ${{ env.JAVA_DISTRIBUTION }}
+        server-id: github
+        server-username: GITHUB_ACTOR
+        server-password: GITHUB_TOKEN
+
+    - name: Cache Maven dependencies
+      uses: actions/cache@v5
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}_m2_${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}_m2
+
+    # Headless, because much of the suite draws. Without it AWT initialization aborts the JVM on a
+    # runner with no display, which reads as a crash rather than as a missing display.
+    - name: Run the test suite
+      run: mvn -B -Djava.awt.headless=true test
+      shell: bash
+
+    # Kept whatever the outcome: a failing release is exactly when somebody needs to see which test
+    # failed, and surefire's own output is what says so.
+    - name: Upload test reports
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: surefire-reports
+        path: target/surefire-reports/
+        if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,72 @@
 ## Change log
+### 1.39.0  (20260815)
+A code review, a regression 1.37.0 had shipped, and the reason neither had been caught: the release path
+was not running the tests. **Minor rather than patch** - `SecureXml`,
+`GlycanBuilder.saveToItsOwnFile` and `GlycanBuilder.exportSequenceTo` are new public API, and saving,
+exporting, reading XML and attaching a substituent all now refuse or allow things they did not. A
+consumer relying on any of those would see the change.
+* **The tests gate the release** (work package F, taken first). All four installer workflows build with
+  `-DskipTests` and `release.yml` only waited for them, so 1.36.0, 1.37.0 and 1.38.0 were all published
+  without a single regression test having run in CI. The suite was run by hand beforehand, which is a
+  habit rather than a gate
+  * `tests.yml` runs it headless, uploads surefire's reports whatever the outcome, and every installer
+    job now `needs: test`. It also runs on pull requests to `master` and `develop`, so a failure is found
+    before somebody dispatches a release rather than during one
+  * Taken before the five faults below because it is why they could ship. Fixing them without the gate
+    would leave the next one the same road
+* **The XML readers read only the document they were given** (#E). Both resolved external entities, so a
+  document could name a file and have its contents substituted into the parse. Measured, with an entity
+  pointing at a temporary file: `XMLUtils.read` returned the file's contents and `SAXUtils.read` handed
+  them to the handler. The same configuration issues network requests from a document, so the reach was
+  never the local disk alone
+  * Not the XXE work in 1.35.2 - that was `GlycoCTParser` refusing a `DOCTYPE` for one format, and left
+    these two helpers, which everything else goes through
+  * Nothing this application reads as XML declares a `DOCTYPE`, so the strongest setting was also the
+    compatible one: one is refused outright, which removes entity substitution rather than restricting
+    it. It fails closed - a parser that cannot be told to be safe is not returned
+* **A save that did not happen is not reported as one**, through the model and through the caller. Two
+  faults needing two fixes: `save` called `setFilename` before writing anything, and that sets
+  `was_saved` and clears `has_changed` as a side effect; and `onSave` discarded the result and returned
+  true, which is the branch "Save changes?" takes on exit, so an I/O failure let the application close
+  over work that had never been written
+  * **The destination is replaced rather than written into.** Copying the finished bytes into it
+    truncates first, so a failure partway through left the last good save partial or empty. A temporary
+    file beside the destination is moved over it instead, atomically where the filesystem offers it
+  * **A replacement says what the file it replaces said about who may read it** - mode, owner, group, the
+    ACL and any extended attributes. A move puts a new file in place of the old one, and a fresh
+    temporary file is owner-only: measured, a destination at `rw-r--r--` came back `rw-------`, and a
+    group set for a team came back changed with an identical mode. Where that cannot be reproduced the
+    save fails and the document stays dirty, rather than falling back to a copy that could truncate
+  * **A save through a symbolic link writes into what it points at.** Opening a file for writing follows
+    a link; replacing it does not, so a save left a regular file where the link had been and the real
+    file holding the previous contents - reported as a success. A loop of links, or a chain longer than
+    thirty-two, is refused with every link left as it was
+  * The temporary file is cleaned up on every path, and `FileUtils.copy` no longer leaks the source
+    channel when the destination cannot be opened
+* **A file that will not read does not take the open document with it** (#C). `open` caught the parse
+  failure and called `init()`, which clears the document, so a malformed file lost whatever was on screen
+  and "Open additional document..." destroyed the document it was meant to be adding to. Nothing needed
+  tidying: the parse builds a list of its own and only then hands it over
+* **A failed sequence export says so** (#D). It returned true regardless, so an export that wrote nothing
+  reported success - and made a liar of the warning that follows it, whose purpose is to say which
+  structures did not come out. The graphical formats had always returned their real result
+* **An acyl may substitute the amine a residue already carries** (#211), which 1.37.0 had begun refusing.
+  `GlcN`'s 2 is left out of its linkage positions because the amine is there, and the position rules
+  enforced that list against every child - so acylating the amine, which is how a GlcNAc is built up a
+  step at a time, stopped working. Measured: `GlcN.addChild(Ac, '2')` wrote exactly GlcNAc's WURCS on
+  1.35.2 and 1.36.0, and was refused on 1.37.0 and 1.38.0
+  * *"Glc + 2N → GlcN + 2Ac → GlcNAc となり、Glc の C2 位の OH が、NHAc に置換され、GlcNAc となります"* -
+    I. Yamada, 2026-08-15. The position names the site, and what sits there is the group being modified,
+    which is how the exporter has always read it
+  * Both halves of the rule are read from the dictionary rather than derived - the IUPAC name says where
+    the nitrogen is, and the type offers `N` among its positions when it has room. `GlcNAc` does not, so
+    its 2 stays shut. This corner has now taught twice that chemistry reasoned about instead of declared
+    comes out wrong here; the bridge exemption was the first time
+* **Copying a structure copies all of it** (#211). `cloneSubtree` rebuilt the copy through `addChild`, so
+  a structure holding two children at one position lost one during the copy - silently, and
+  `Glycan.clone()` is copy-and-paste, undo and redo. A copy makes no new claim about a molecule; reading a
+  file was always on that side of the line and copying belongs there too
+
 ### 1.38.0  (20260815)
 The tracker was re-checked against the code first, and the gap between them turned out to be the largest
 thing on the list: nine issues were marked fixed and still open, and two faults that had been measured

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -274,19 +274,23 @@ position-to-side rules in the placement dictionaries apply to substituents only,
 sequence turned out to write back unchanged, so there was nothing to watch fail. Recorded as such rather
 than claimed as verified.
 
-**6. The waiting list — the next piece of work.** #17, #57, #58, #66, #83, #185, #16 are all waiting on
-somebody else and several are closable on a reply. A nudge costs a paragraph, and #183 has just joined
-them.
+**6. The waiting list — held until Monday 2026-08-17.** #17, #57, #58, #66, #83, #185, #16 and #183 are
+all waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
 
-**Then a release.** Six fixes are on `develop` and none of them has reached anybody: #88, #83's dead
-angle, and the four from 2026-08-15. That is the whole of P1 and P2 sitting where no user can install
-it, which by this file's own ranking is worth more than the next defect on the list.
+**Not to be sent before Monday 2026-08-17** — I. Yamada, 2026-08-15. The nudges were written and ready on
+the Saturday; holding them is deliberate, so if this list looks stalled on a weekend, it is not.
+
+**~~Then a release~~ — 1.38.0, released 2026-08-15**, and taken ahead of the waiting list because six
+fixes were sitting where nobody could install them, which by this file's own ranking outranks the next
+defect. `master` reads 1.38.0, tagged `v1.38.0` on the merge commit.
+
+**#88, #203, #204 and #29 close with it.** #83 and #183 do **not**: #201 removed an angle the CFG hat
+diamonds never used, which does not answer whether the symbol looks *rotated* — the question the reporter
+was asked — and #183's fix is on a mechanism whose reported sequence no longer fails. Both stay on the
+waiting list. This corrects a list of six I wrote earlier the same day.
 
 Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
 changes and neither is small.
-
-**When the next release goes out**, it already has two fixes waiting on `develop` (#199, #201) and the
-version bump belongs immediately before the merge to `master`, not before that.
 
 ---
 
@@ -302,25 +306,23 @@ document-loses-your-work bugs.
 #203 and #204 filed for the two faults that had been measured and never written down anywhere but here.
 The next piece of work is #203.
 
-**On `develop`, waiting for the next release**: #199 (#88, the bridge label's margin) and #201 (#83's
-unused angle). `pom.xml` still reads 1.37.0 on both branches, correctly — the bump belongs immediately
-before the merge to `master`.
+**1.38.0 is out.** `origin/develop` and `origin/master` both read 1.38.0 — checked against the remote,
+not the local refs, which is the check 1.35.0 was lost by. `v1.38.0` tags the merge commit and is
+reachable from `master`. It carries #199 (#88), #201 (#83's unused angle), #205 (#203), #206 (#204),
+#207 (#29) and #208 (#183), and 181 tests pass with all of them together.
 
-**Releases are in order**, checked against the API rather than the release page: nothing is a
-pre-release, `releases/latest` resolves to v1.37.0, and 1.36.0 and 1.37.0 each carry the same five
-installers as every release before them. What is missing on all of them is the Windows `.msix`, which
-is uploaded by hand and is what #180 is about.
+**The release page's label is the last step and it is easy to miss.** The workflow publishes as a
+pre-release, and `releases/latest` — which is what `UpdateCheck` asks — skips those, so until somebody marks
+it Latest the newest release is invisible to the update check. v1.38.0 was marked by hand; verified through
+the API, since the release page and `gh release list` have both misreported this.
 
-**On `develop`, waiting only for a release**: #199 (#88's bridge margin), #201 (#83's unused angle),
-#205 (#203), #206 (#204), #207 (#29) and #208 (#183). 181 tests pass with all of them together.
-`pom.xml` still reads 1.37.0, correctly — the bump belongs immediately before the merge to `master`.
+Every release carries the same five installers. What is missing on all of them is the Windows `.msix`,
+which is uploaded by hand and is what #180 is about.
 
-**Four issues are fixed and still open on purpose**: #203, #204, #29 and #183. `develop` is not the
-default branch, so "Closes #N" did not fire on merge, and closing them by hand would tell each reporter
-it is done while no version they can install has it. They close with the release, alongside #88. This is
-the same judgement as #88's, applied consistently rather than issue by issue.
+**Still with the maintainer, for every release**: `mvn deploy` from `master` at the versioned commit,
+and the Windows `.msix` to Partner Center. Neither is a step to take unasked.
 
-**Open pull request**: #202, this file and the layout document.
+**No open pull requests.**
 
 **Waiting on somebody else**, and worth a look before starting anything new — several of these may be
 closable:
@@ -337,10 +339,13 @@ closable:
 | #16 | whether to split it per modification |
 | #189 | whether they mean GlcNS or a sulfate on an already-acetylated nitrogen — a chemistry question, and the only thing left on it |
 | #190 | the WURCS or GlycoCT for G13093, for whoever takes #181 |
-| #88 | nothing — it is fixed, and waits only for a release to close against |
 | #123 | the contributor said about a week, from 2026-08-14 |
 
-**Deliberately not started**: #175 (jdom2) and taking glycanbuilder2web to 1.37.0 are both on hold at
+**Held until Monday 2026-08-17**: the nudges in the table above. Written and ready on Saturday the 15th, at
+the maintainer's request — see step 6 of "The order to take them in". A quiet weekend on this list is
+deliberate.
+
+**Deliberately not started**: #175 (jdom2) and taking glycanbuilder2web to 1.38.0 are both on hold at
 the maintainer's request.
 
 **The reducing-end note in "Before ranking anything, verify it" is the trap most likely to waste your

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.38.0</version>
+	<version>1.39.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -319,20 +319,25 @@ public abstract class BaseDocument {
        be parsed
        @see #read
      */
-    public boolean open(File file, boolean merge, boolean warning) 
+    public boolean open(File file, boolean merge, boolean warning)
     {
+    FileInputStream fis = null;
     try {
-        FileInputStream fis = new FileInputStream(file);
-        
+        fis = new FileInputStream(file);
+
         // read structure
         try {
         read(fis,merge);
         }
         catch(Exception e) {
-        	System.err.println("Got exception: "+e.getMessage());
-        init();
+        // What is already open is not the file's fault. This used to call init(), which cleared the
+        // current document before returning false - so a malformed file took the work that was on
+        // screen with it, and "Open additional document..." destroyed the document it was supposed
+        // to be adding to. GlycanDocument.fromString parses into a list of its own before it touches
+        // this document, so there is nothing half-read to tidy up after.
+        System.err.println("Got exception: "+e.getMessage());
         if( warning )
-            throw e;        
+            throw e;
         return false;
         }
 
@@ -359,8 +364,21 @@ public abstract class BaseDocument {
     catch( Exception e ) {
         LogUtils.report(e);
         return false;
-    }    
-    }    
+    }
+    finally {
+        // Closed either way. It used to be left to the garbage collector, so a failed open held the
+        // file open for as long as the collector took to notice - which on Windows is the difference
+        // between being able to delete or replace it and not.
+        if( fis!=null ) {
+            try {
+                fis.close();
+            }
+            catch( Exception cannotClose ) {
+                LogUtils.report(cannotClose);
+            }
+        }
+    }
+    }
 
     protected void read(InputStream is, boolean merge) throws Exception {
     	System.err.println("in read");

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -385,28 +385,40 @@ public abstract class BaseDocument {
      */
     public boolean save(String filename) {
 
+    // The document is told it has been saved only once it has been. setFilename sets was_saved and
+    // clears has_changed as a side effect, and calling it first meant that an unwritable destination,
+    // a full disk or a serialization failure returned false while leaving the document marked saved
+    // and clean - so the asterisk went away, Save went grey, and the next close let the work go
+    // without asking. The write is what decides; the bookkeeping follows it.
+    File tmpfile = null;
+
     try{
-    	setFilename(filename);
-    	
-        // write to tmp file
-        File tmpfile = File.createTempFile("gwb",null);
-        write(new FileOutputStream(tmpfile));
+        // write to tmp file, so nothing touches the destination until a whole document exists
+        tmpfile = File.createTempFile("gwb",null);
 
-        // copy to dest file and delete tmp file
+        FileOutputStream out = new FileOutputStream(tmpfile);
+        try {
+            write(out);
+        }
+        finally {
+            out.close();
+        }
+
+        // copy to dest file
         FileUtils.copy(tmpfile,new File(filename));
-        tmpfile.delete();
 
-        //
-        
-        
-        //
+        setFilename(filename);
         fireDocumentInit();
         return true;
     }
     catch( Exception e ) {
         LogUtils.report(e);
         return false;
-    }        
+    }
+    finally {
+        // Ours, and gone either way. It used to be left behind on every failing path.
+        if( tmpfile!=null ) tmpfile.delete();
+    }
     }
     
     /**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -415,11 +415,16 @@ public abstract class BaseDocument {
     Path tmpfile = null;
 
     try{
-        Path destination = new File(filename).toPath().toAbsolutePath();
+        // Save into what a symbolic link points at, not over the link. Writing to the destination had
+        // always followed it, because that is what opening a file for writing does; replacing the
+        // destination does not, so a save through a link left a regular file where the link had been
+        // and the file it pointed at still holding the previous contents - reported as a success.
+        Path destination = followLinks(new File(filename).toPath().toAbsolutePath());
 
-        // Keep the temporary file beside the destination. A completed file can then replace the old
-        // one with a filesystem move, rather than truncating the old file and copying bytes into it.
-        // A failed copy used to leave the last good save partial or empty.
+        // Keep the temporary file beside the destination - the resolved one, so the move stays on the
+        // same filesystem. A completed file can then replace the old one with a filesystem move, rather
+        // than truncating the old file and copying bytes into it, which left the last good save partial
+        // or empty when the copy failed partway.
         tmpfile = Files.createTempFile(destination.getParent(),"gwb",null);
 
         try (OutputStream out = Files.newOutputStream(tmpfile)) {
@@ -457,26 +462,52 @@ public abstract class BaseDocument {
        that do not support it still move the complete file rather than streaming over the old one.
      */
     private static void replaceFile(Path source, Path destination) throws Exception {
-    if( accessControlCarriedOver(destination,source) ) {
-        try {
-            Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
-                    StandardCopyOption.REPLACE_EXISTING);
-        }
-        catch( AtomicMoveNotSupportedException notAtomicHere ) {
-            Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
-        }
-        return;
+    // Nothing is replaced unless the replacement says what the file it replaces says about who may
+    // read it. This used to fall back to copying the bytes into the destination instead, on the
+    // grounds that a file which is never replaced cannot have its access control changed - which is
+    // true, and beside the point: that copy truncates the destination before it transfers, so a
+    // failure partway through leaves the last good save partial or empty. It is exactly the fault this
+    // whole change set out to remove, kept alive on the one path where attributes are most likely to
+    // fail - a shared file somebody else owns.
+    //
+    // Refusing is the safer of the two, and the argument I made for the fallback was wrong on its own
+    // terms: it also loses work, and it loses it silently. A refusal is visible and recoverable - the
+    // document stays dirty and Save As still works.
+    if( !accessControlCarriedOver(destination,source) )
+        throw new IOException("cannot save over " + destination
+                + " without changing who is allowed to read it");
+
+    try {
+        Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+    catch( AtomicMoveNotSupportedException notAtomicHere ) {
+        Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
+    }
     }
 
-    // The replacement could not be made to say what the file it replaces says about who may read it,
-    // so it does not replace it: the finished bytes are written into the destination instead, which
-    // cannot change its access control because the file is never replaced.
-    //
-    // Atomicity is what that gives up, and it is worth less than quietly changing who can read
-    // somebody's work. Refusing the save outright was the other option and is worse: a user who can
-    // write a file they do not own - a group-writable file in a shared directory - would be unable to
-    // save at all, which is a new way to lose work in exchange for avoiding an old one.
-    FileUtils.copy(source.toFile(),destination.toFile());
+    /**
+       Follow a chain of symbolic links to the path that will actually be written.
+
+       Not {@code toRealPath}, which requires the file to exist: a link pointing at a name that is not
+       there yet is a perfectly ordinary thing to save to, and resolving it by hand handles that as well
+       as a link whose target is relative to the link's own directory.
+
+       @return Returns the path at the end of the chain, or the path given where it is not a link.
+     */
+    private static Path followLinks(Path path) throws IOException {
+    Path resolved = path;
+
+    // A bound rather than a cycle check: a loop of links has no end to find, and thirty-two hops is
+    // past anything real.
+    for( int hops=0; hops<32 && Files.isSymbolicLink(resolved); hops++ ) {
+        Path parent = resolved.getParent();
+        Path target = Files.readSymbolicLink(resolved);
+
+        resolved = ((parent==null) ? target : parent.resolve(target)).toAbsolutePath().normalize();
+    }
+
+    return resolved;
     }
 
     /**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -21,6 +21,10 @@ package org.eurocarbdb.application.glycanbuilder;
 
 import java.awt.*;
 import java.io.*;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
 
 import org.eurocarbdb.application.glycanbuilder.logutility.LogUtils;
@@ -408,22 +412,21 @@ public abstract class BaseDocument {
     // a full disk or a serialization failure returned false while leaving the document marked saved
     // and clean - so the asterisk went away, Save went grey, and the next close let the work go
     // without asking. The write is what decides; the bookkeeping follows it.
-    File tmpfile = null;
+    Path tmpfile = null;
 
     try{
-        // write to tmp file, so nothing touches the destination until a whole document exists
-        tmpfile = File.createTempFile("gwb",null);
+        Path destination = new File(filename).toPath().toAbsolutePath();
 
-        FileOutputStream out = new FileOutputStream(tmpfile);
-        try {
+        // Keep the temporary file beside the destination. A completed file can then replace the old
+        // one with a filesystem move, rather than truncating the old file and copying bytes into it.
+        // A failed copy used to leave the last good save partial or empty.
+        tmpfile = Files.createTempFile(destination.getParent(),"gwb",null);
+
+        try (OutputStream out = Files.newOutputStream(tmpfile)) {
             write(out);
         }
-        finally {
-            out.close();
-        }
 
-        // copy to dest file
-        FileUtils.copy(tmpfile,new File(filename));
+        replaceFile(tmpfile,destination);
 
         setFilename(filename);
         fireDocumentInit();
@@ -435,7 +438,63 @@ public abstract class BaseDocument {
     }
     finally {
         // Ours, and gone either way. It used to be left behind on every failing path.
-        if( tmpfile!=null ) tmpfile.delete();
+        if( tmpfile!=null ) {
+            try {
+                Files.deleteIfExists(tmpfile);
+            }
+            catch( IOException cannotDelete ) {
+                LogUtils.report(cannotDelete);
+            }
+        }
+    }
+    }
+
+    /**
+       Replace a saved file without copying into and truncating the previous version.
+
+       The temporary file is created in the destination directory, so the ordinary fallback is still
+       a same-filesystem rename. The atomic option is used where the filesystem offers it; providers
+       that do not support it still move the complete file rather than streaming over the old one.
+     */
+    private static void replaceFile(Path source, Path destination) throws IOException {
+    carryOverPermissions(destination,source);
+
+    try {
+        Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING);
+    }
+    catch( AtomicMoveNotSupportedException notAtomicHere ) {
+        Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
+    }
+    }
+
+    /**
+       Give the replacement the permissions the file being replaced had.
+
+       A move puts a new file in place of the old one, so the saved file would otherwise carry the
+       temporary file's permissions - and a fresh temporary file is owner-only. Measured: a document
+       saved into a directory shared with colleagues went from rw-r--r-- to rw------- the first time it
+       was saved, so everyone but its owner lost access to work they had been reading. Copying into the
+       destination, which is what this replaced, had preserved them by never replacing the file.
+
+       Quiet where there is nothing to carry over: a destination that does not exist yet has no
+       permissions to keep, and a filesystem without POSIX permissions has none to read. Neither is a
+       reason to refuse a save.
+     */
+    private static void carryOverPermissions(Path replacing, Path replacement) {
+    try {
+        if( !Files.exists(replacing) )
+            return;
+        if( !Files.getFileStore(replacing).supportsFileAttributeView(
+                java.nio.file.attribute.PosixFileAttributeView.class) )
+            return;
+
+        Files.setPosixFilePermissions(replacement,Files.getPosixFilePermissions(replacing));
+    }
+    catch( Exception cannotCarryThemOver ) {
+        // The save is worth more than the permissions on it. Reported rather than swallowed, because
+        // a file that quietly changes who can read it is the fault this method exists to avoid.
+        LogUtils.report(cannotCarryThemOver);
     }
     }
     

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -507,6 +507,15 @@ public abstract class BaseDocument {
         resolved = ((parent==null) ? target : parent.resolve(target)).toAbsolutePath().normalize();
     }
 
+    // Running out of hops is a refusal, not an answer. Returning the link we stopped on made it the
+    // destination, so a loop of links - or a chain longer than the bound - had one of its links replaced
+    // by the saved file while the real file kept the previous contents, and the save reported success.
+    // Measured: a two-link cycle came back saved=true with one link destroyed; a thirty-three link chain
+    // came back saved=true with an intermediate link replaced and the target untouched.
+    if( Files.isSymbolicLink(resolved) )
+        throw new IOException("cannot find what " + path
+                + " points at: more than 32 symbolic links to follow, or a loop of them");
+
     return resolved;
     }
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/BaseDocument.java
@@ -456,45 +456,123 @@ public abstract class BaseDocument {
        a same-filesystem rename. The atomic option is used where the filesystem offers it; providers
        that do not support it still move the complete file rather than streaming over the old one.
      */
-    private static void replaceFile(Path source, Path destination) throws IOException {
-    carryOverPermissions(destination,source);
+    private static void replaceFile(Path source, Path destination) throws Exception {
+    if( accessControlCarriedOver(destination,source) ) {
+        try {
+            Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
+                    StandardCopyOption.REPLACE_EXISTING);
+        }
+        catch( AtomicMoveNotSupportedException notAtomicHere ) {
+            Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
+        }
+        return;
+    }
 
-    try {
-        Files.move(source,destination,StandardCopyOption.ATOMIC_MOVE,
-                StandardCopyOption.REPLACE_EXISTING);
-    }
-    catch( AtomicMoveNotSupportedException notAtomicHere ) {
-        Files.move(source,destination,StandardCopyOption.REPLACE_EXISTING);
-    }
+    // The replacement could not be made to say what the file it replaces says about who may read it,
+    // so it does not replace it: the finished bytes are written into the destination instead, which
+    // cannot change its access control because the file is never replaced.
+    //
+    // Atomicity is what that gives up, and it is worth less than quietly changing who can read
+    // somebody's work. Refusing the save outright was the other option and is worse: a user who can
+    // write a file they do not own - a group-writable file in a shared directory - would be unable to
+    // save at all, which is a new way to lose work in exchange for avoiding an old one.
+    FileUtils.copy(source.toFile(),destination.toFile());
     }
 
     /**
-       Give the replacement the permissions the file being replaced had.
+       Make the replacement say what the file it replaces says about who may read and write it.
 
-       A move puts a new file in place of the old one, so the saved file would otherwise carry the
-       temporary file's permissions - and a fresh temporary file is owner-only. Measured: a document
-       saved into a directory shared with colleagues went from rw-r--r-- to rw------- the first time it
-       was saved, so everyone but its owner lost access to work they had been reading. Copying into the
-       destination, which is what this replaced, had preserved them by never replacing the file.
+       A move puts a new file in place of the old one, so the saved document would otherwise carry the
+       temporary file's access control rather than the destination's - and a fresh temporary file is
+       owner-only. Measured: a destination at rw-r--r-- came back rw------- after one save, so in a
+       shared directory everyone but the owner lost work they had been reading.
 
-       Quiet where there is nothing to carry over: a destination that does not exist yet has no
-       permissions to keep, and a filesystem without POSIX permissions has none to read. Neither is a
-       reason to refuse a save.
+       Mode bits are not the whole of it, which is the second thing measured here. A fresh file takes
+       its group from the platform's rule - the directory's group on macOS, the creating process's on
+       Linux - rather than from the file being replaced, so a destination whose group had been set for a
+       team came back with a different one and the same mode. Extended attributes were dropped
+       altogether. Anything an ACL says would go the same way.
+
+       So all four are carried: mode, owner, group and the ACL, plus any user-defined attributes.
+       Owner and group are only set where they differ, so the ordinary case of saving one's own file
+       never asks for a privilege it does not need.
+
+       @return Returns whether the replacement now says everything the destination said. False means the
+               caller must not replace it.
      */
-    private static void carryOverPermissions(Path replacing, Path replacement) {
+    private static boolean accessControlCarriedOver(Path replacing, Path replacement) {
     try {
         if( !Files.exists(replacing) )
-            return;
-        if( !Files.getFileStore(replacing).supportsFileAttributeView(
-                java.nio.file.attribute.PosixFileAttributeView.class) )
-            return;
+            return true;    // nothing to carry over, and nothing to lose by replacing it
 
-        Files.setPosixFilePermissions(replacement,Files.getPosixFilePermissions(replacing));
+        carryOverPosix(replacing,replacement);
+        carryOverAcl(replacing,replacement);
+        carryOverUserAttributes(replacing,replacement);
+
+        return true;
     }
-    catch( Exception cannotCarryThemOver ) {
-        // The save is worth more than the permissions on it. Reported rather than swallowed, because
-        // a file that quietly changes who can read it is the fault this method exists to avoid.
-        LogUtils.report(cannotCarryThemOver);
+    catch( Exception cannotCarryItOver ) {
+        // Reported, and then the caller writes into the file rather than replacing it. A save that
+        // quietly changes who can read a file is the fault this method exists to prevent, so failing to
+        // carry the answer over is a reason not to replace the file - not a reason to do it anyway.
+        LogUtils.report(cannotCarryItOver);
+        return false;
+    }
+    }
+
+    /** Mode, owner and group, where the filesystem has them. */
+    private static void carryOverPosix(Path replacing, Path replacement) throws IOException {
+    java.nio.file.attribute.PosixFileAttributeView view =
+            Files.getFileAttributeView(replacing,
+                    java.nio.file.attribute.PosixFileAttributeView.class);
+    if( view==null )
+        return;
+
+    java.nio.file.attribute.PosixFileAttributes attributes = view.readAttributes();
+    Files.setPosixFilePermissions(replacement,attributes.permissions());
+
+    java.nio.file.attribute.PosixFileAttributes now =
+            Files.readAttributes(replacement,java.nio.file.attribute.PosixFileAttributes.class);
+    if( !now.group().equals(attributes.group()) )
+        Files.getFileAttributeView(replacement,
+                java.nio.file.attribute.PosixFileAttributeView.class).setGroup(attributes.group());
+    if( !now.owner().equals(attributes.owner()) )
+        Files.setOwner(replacement,attributes.owner());
+    }
+
+    /** The ACL, where the filesystem keeps one - Windows and NFSv4 among them. */
+    private static void carryOverAcl(Path replacing, Path replacement) throws IOException {
+    java.nio.file.attribute.AclFileAttributeView from =
+            Files.getFileAttributeView(replacing,java.nio.file.attribute.AclFileAttributeView.class);
+    java.nio.file.attribute.AclFileAttributeView to =
+            Files.getFileAttributeView(replacement,java.nio.file.attribute.AclFileAttributeView.class);
+    if( from==null || to==null )
+        return;
+
+    to.setAcl(from.getAcl());
+    }
+
+    /**
+       Extended attributes, which a move drops in silence.
+
+       Measured: a marker written to a destination was gone after the replacement, with the mode bits
+       looking untouched - which is how this kind of loss escapes a test that only reads the mode.
+     */
+    private static void carryOverUserAttributes(Path replacing, Path replacement) throws IOException {
+    java.nio.file.attribute.UserDefinedFileAttributeView from =
+            Files.getFileAttributeView(replacing,
+                    java.nio.file.attribute.UserDefinedFileAttributeView.class);
+    java.nio.file.attribute.UserDefinedFileAttributeView to =
+            Files.getFileAttributeView(replacement,
+                    java.nio.file.attribute.UserDefinedFileAttributeView.class);
+    if( from==null || to==null )
+        return;
+
+    for( String name : from.list() ) {
+        java.nio.ByteBuffer value = java.nio.ByteBuffer.allocate(from.size(name));
+        from.read(name,value);
+        value.flip();
+        to.write(name,value);
     }
     }
     

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/FileUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/FileUtils.java
@@ -307,18 +307,15 @@ public class FileUtils {
 		if (dst == null)
 			throw new Exception("Invalid destination file");
 
-		FileChannel inChannel = new FileInputStream(src).getChannel();
-		FileChannel outChannel = new FileOutputStream(dst).getChannel();
-		try {
+		// Acquire both channels inside the resource statement. If opening the destination fails,
+		// Java closes the source channel that was already opened; the old form acquired both before
+		// entering its finally block and leaked the source on exactly that path.
+		try (FileChannel inChannel = new FileInputStream(src).getChannel();
+			 FileChannel outChannel = new FileOutputStream(dst).getChannel()) {
 			long position = 0;
 			long size = inChannel.size();
 			while (position < size)
 				position += inChannel.transferTo(position, 32000, outChannel);
-		} catch (IOException e) {
-			throw e;
-		} finally {
-			if (inChannel != null) inChannel.close();
-			if (outChannel != null) outChannel.close();
 		}
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -817,10 +817,11 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 
 			// esporta il documento su file
 			if( theDoc.isSequenceFormat(format) ) {
-				if( theDoc.exportTo(filename,format) ) {
-					setLastExportedFile(filename);
-					warnAboutExportFailures(theDoc, format);
-				}
+				if( !exportSequenceTo(theDoc,filename,format) )
+					return false;
+
+				setLastExportedFile(filename);
+				warnAboutExportFailures(theDoc, format);
 				return true;
 			}
 			else if( SVGUtils.export((GlycanRendererAWT) theWorkspace.getGlycanRenderer(),filename,theDoc.getStructures(),theWorkspace.getGraphicOptions().SHOW_MASSES,theWorkspace.getGraphicOptions().SHOW_REDEND,format) ) {
@@ -829,6 +830,24 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 			}        
 		}
 		return false;
+	}
+
+	/**
+	 * Write the document out in a sequence format, and say whether it was written.
+	 *
+	 * <p>Separated from {@link #onExportTo(String)} so the answer can be tested without a file chooser.
+	 * It used to be discarded and {@code true} returned regardless, so an export that wrote nothing
+	 * reported success - which also made a liar of the warning that follows it, whose whole purpose is
+	 * to tell a user what did not come out. The graphical formats in the same method had always
+	 * returned their real result.
+	 *
+	 * <p>The caller records the file as exported and warns about partial failures <em>only</em> on
+	 * true, so a failed export leaves no trace of having worked.
+	 *
+	 * @return Returns whether the document was written.
+	 */
+	public static boolean exportSequenceTo(GlycanDocument doc, String filename, String format) {
+		return doc!=null && doc.exportTo(filename,format);
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -666,17 +666,36 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 	public boolean onSave(BaseDocument doc, boolean ask_filename) {
 		if( doc==null ) return false;
 
-		// controlla se e' possibile salvare il file nella stessa posizione da cui e' stato aperto
-		File cur = doc.getFile();                
-		if( cur!=null && cur.canWrite() ) {
-			// salvo il documento su file
-			doc.save(cur.getAbsolutePath());       
-			return true;
-		}
+		Boolean saved = saveToItsOwnFile(doc);
+		if( saved!=null ) return saved.booleanValue();
 
 		// non e' stato possibile salvare il file nella posizione da cui e' stato aperto. Richiedo il salvataggio con scelta file
-		if( ask_filename ) return onSaveAs(doc);        
+		if( ask_filename ) return onSaveAs(doc);
 		return false;
+	}
+
+	/**
+	 * Write the document back to the file it came from, if it has one that can be written.
+	 *
+	 * <p>Separated from {@link #onSave(BaseDocument, boolean)} so the decision can be tested without a
+	 * window: everything above it is a file chooser, and everything about it that was wrong was here.
+	 * The result used to be discarded and {@code true} returned regardless, so an I/O failure read as a
+	 * successful save - and this is the branch "Save changes?" takes on exit, so answering Yes to it let
+	 * the application close over work that had not been written.
+	 *
+	 * <p>No second file chooser on failure: the document has a writable file, and asking again where to
+	 * put it would be answering a different question.
+	 *
+	 * @return Returns whether the save succeeded, or {@code null} when the document has no writable
+	 *         file of its own and the caller should offer Save As instead.
+	 */
+	public static Boolean saveToItsOwnFile(BaseDocument doc) {
+		// controlla se e' possibile salvare il file nella stessa posizione da cui e' stato aperto
+		File cur = (doc==null) ? null : doc.getFile();
+		if( cur==null || !cur.canWrite() )
+			return null;
+
+		return Boolean.valueOf(doc.save(cur.getAbsolutePath()));
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1338,6 +1338,35 @@ public class Residue {
        @return <code>true</code> if the operation was successful
 	 */
 	public boolean addChild(Residue child, Collection<Bond> bonds) {
+		return attachChild(child,bonds,true);
+	}
+
+	/**
+	 * Attach a child that is being copied from a structure that already holds it.
+	 *
+	 * <p>A copy makes no new claim about a molecule, so the rules that decide what <em>may</em> be
+	 * attached do not apply to it: the question was settled when the original was made. Copying through
+	 * {@link #addChild} instead meant that a structure the rules would now refuse lost a residue on the
+	 * way through - silently, since a clone has nowhere to report - and {@code Glycan.clone()} is
+	 * copy-and-paste, undo and redo (#211).
+	 *
+	 * <p>Measured on a Glc carrying two substituents at position 2: 1.35.2 and 1.36.0 copied both,
+	 * 1.37.0 and 1.38.0 copied one and said nothing.
+	 *
+	 * <p>The distinction is between validating a change and reproducing a fact. Reading a file has
+	 * always been on the second side of it - a document containing such a structure still opens - and
+	 * copying belongs there too.
+	 */
+	protected boolean copyChild(Residue child, Collection<Bond> bonds) {
+		return attachChild(child,bonds,false);
+	}
+
+	/**
+	 * @param checkPosition
+	 *            whether the position rules apply. False when copying, where the structure already
+	 *            exists and nothing is being claimed.
+	 */
+	private boolean attachChild(Residue child, Collection<Bond> bonds, boolean checkPosition) {
 		if( child==null )
 			return false;
 
@@ -1346,8 +1375,8 @@ public class Residue {
 			if( !child.hasChildren() )
 				return false;
 
-			Linkage link = child.children_linkages.get(0);     
-			return addChild(link.getChildResidue(),link.getBonds());
+			Linkage link = child.children_linkages.get(0);
+			return attachChild(link.getChildResidue(),link.getBonds(),checkPosition);
 		}
 
 		//TODO: Investigate this further, this stop structures with repeat units from being copied 
@@ -1361,7 +1390,7 @@ public class Residue {
 
 		// cannot add a reducing end
 		if( child.isReducingEnd() && !child.canHaveParent() )
-			return this.addChild(child.firstChild(),bonds);
+			return this.attachChild(child.firstChild(),bonds,checkPosition);
 
 		// add labile back to lcleavage
 		if( isLCleavage() && cleaved_residue.getTypeName().equals(child.getTypeName()) ) {
@@ -1373,7 +1402,7 @@ public class Residue {
 		// one this child can be given (#34). Checked here as well as in canAddChild because this
 		// does not consult it - the two have grown apart, and adding is the path that makes the
 		// structure
-		if( positionIsNotAvailable(child,bonds) )
+		if( checkPosition && positionIsNotAvailable(child,bonds) )
 			return false;
 
 		// check for available space
@@ -2012,7 +2041,7 @@ public class Residue {
 
 		// clone children
 		for( Linkage l : children_linkages ){
-			clone.addChild(l.getChildResidue().cloneSubtree(stop_el,stop,startRep),l.getBonds());
+			clone.copyChild(l.getChildResidue().cloneSubtree(stop_el,stop,startRep),l.getBonds());
 
 		}
 
@@ -2036,7 +2065,7 @@ public class Residue {
 
 		// clone children
 		for( Linkage l : children_linkages )
-			clone.addChild(l.getChildResidue().cloneSubtreeAdd(add_el,toadd,toadd_bonds,startRep),l.getBonds());  
+			clone.copyChild(l.getChildResidue().cloneSubtreeAdd(add_el,toadd,toadd_bonds,startRep),l.getBonds());  
 
 				// add child where necessary
 				if( this==add_el && toadd!=null ) {

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/Residue.java
@@ -1578,10 +1578,75 @@ public class Residue {
 		if( isBridge )
 			return !positionHeldByAChild(position,child);
 
+		// Nor is substituting this residue's own nitrogen. GlcN's 2 is left out of the list because
+		// the amine is there, and acylating that amine is how a GlcNAc is built up a step at a time:
+		// "Glc の C2 位の OH が、NHAc に置換され、GlcNAc となります" (I. Yamada, 2026-08-15). The
+		// position names the site, and what sits there is the group being modified - which is how the
+		// exporter has always read it, writing exactly GlcNAc's WURCS for a GlcN with an Ac at 2, up
+		// until 1.37.0 refused the attachment (#211).
+		if( substitutesOwnNitrogen(position,child) )
+			return !positionHeldByAChild(position,child);
+
 		for( char available : availableLinkagePositions() )
 			if( available==position ) return true;
 
 		return false;
+	}
+
+	/**
+	 * Whether attaching this child at this position means substituting the nitrogen this residue
+	 * already carries there, rather than claiming the carbon.
+	 *
+	 * <p>Both halves are read from the dictionary rather than reasoned about, which is the rule this
+	 * corner has taught twice now - the type's list is not a general test of what may attach, and
+	 * chemistry that is derived rather than declared has been wrong here before:
+	 *
+	 * <ul>
+	 *   <li><b>Where the nitrogen is</b>: the type's IUPAC name spells the built-in group and its
+	 *       position - {@code Glc$2N} is a free amine at 2, {@code Glc$2NAc} an N-acetyl at 2,
+	 *       {@code Neu$5NAc} one at 5.</li>
+	 *   <li><b>Whether it has room</b>: the type offers {@code N} among its linkage positions when it
+	 *       does. GlcN and NeuAc offer it; GlcNAc does not, so its 2 stays closed and a methyl there
+	 *       is still refused.</li>
+	 * </ul>
+	 *
+	 * <p>Only a substituent qualifies. A monosaccharide at a nitrogen would be a glycosidic bond to
+	 * something that is not a hydroxyl, and nothing measured here supports it.
+	 */
+	private boolean substitutesOwnNitrogen(char position, Residue child) {
+		if( child==null || !child.isSubstituent() || type==null )
+			return false;
+		if( position!=nitrogenPosition() )
+			return false;
+
+		for( char offered : type.getLinkagePositions() )
+			if( offered=='N' ) return true;
+
+		return false;
+	}
+
+	/**
+	 * The position at which this residue's type declares a nitrogen of its own, or {@code '\0'}.
+	 *
+	 * <p>Taken from the IUPAC name's group suffix: the digit in front of an {@code N} names the
+	 * position, as in {@code Glc$2N}, {@code Glc$2NAc} and {@code Neu$5NAc}. A type that declares no
+	 * group - {@code Mur$}, {@code Neu$} - has no such position, and keeps the plain carbon in its
+	 * list instead.
+	 */
+	private char nitrogenPosition() {
+		if( type==null || !type.hasIupacName() )
+			return '\0';
+
+		String name = type.getIupacName();
+		int at = name.indexOf('$');
+		if( at<0 )
+			return '\0';
+
+		for( int i=at+1; i<name.length()-1; i++ )
+			if( Character.isDigit(name.charAt(i)) && name.charAt(i+1)=='N' )
+				return name.charAt(i);
+
+		return '\0';
 	}
 
 	/**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SAXUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SAXUtils.java
@@ -381,8 +381,7 @@ public class SAXUtils {
        @throws Exception on errors
      */
     public static void read(InputStream is, DefaultHandler h) throws Exception {
-    SAXParser parser = SAXParserFactory.newInstance().newSAXParser();
-    parser.parse(is,h);
+    SecureXml.newSAXParser().parse(is,h);
     }
     
     /**

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SecureXml.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/SecureXml.java
@@ -1,0 +1,117 @@
+package org.eurocarbdb.application.glycanbuilder.util;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+/**
+ * The XML readers this application uses, configured to read only the document it was given.
+ *
+ * <p>A default JAXP parser resolves external entities, so a document can name a file and have its
+ * contents substituted into the parse. Measured on this project before this class existed: an entity
+ * pointing at a temporary file was expanded and the file's contents came back through both
+ * {@link XMLUtils#read(String)} and {@link SAXUtils#read}. The same configuration will issue network
+ * requests from a document, so the reach is not limited to the local disk.
+ *
+ * <p>Everything this application reads as XML - workspaces, configuration, fragment definitions,
+ * sequences pasted in by a user - goes through those two helpers, and none of it uses a
+ * {@code DOCTYPE}. So the strongest setting is also the compatible one: a document type declaration is
+ * refused outright, which removes entity substitution rather than restricting it.
+ *
+ * <p><b>It fails closed.</b> A parser that cannot be told to be safe is not returned - an unsupported
+ * feature is thrown rather than logged and stepped over, because a reader that quietly falls back to
+ * the default configuration is the fault this class exists to remove.
+ *
+ * <p>Java 8 and the Java 21 runtime the installers carry both support all of these.
+ */
+public final class SecureXml {
+
+	/** Rejects a document type declaration, and with it every entity that could be declared in one. */
+	private static final String DISALLOW_DOCTYPE =
+			"http://apache.org/xml/features/disallow-doctype-decl";
+
+	/** Belt and braces behind the DOCTYPE refusal, for a parser that honours these instead. */
+	private static final String EXTERNAL_GENERAL_ENTITIES =
+			"http://xml.org/sax/features/external-general-entities";
+	private static final String EXTERNAL_PARAMETER_ENTITIES =
+			"http://xml.org/sax/features/external-parameter-entities";
+	private static final String LOAD_EXTERNAL_DTD =
+			"http://apache.org/xml/features/nonvalidating/load-external-dtd";
+
+	private SecureXml() {
+	}
+
+	/**
+	 * A DOM builder that reads only what it is handed.
+	 *
+	 * @throws Exception
+	 *             when the parser cannot be configured safely. Deliberately not caught here: the
+	 *             caller gets no parser rather than an unsafe one.
+	 */
+	public static DocumentBuilder newDocumentBuilder() throws Exception {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+
+		factory.setFeature(DISALLOW_DOCTYPE, true);
+		factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+		factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+		factory.setFeature(LOAD_EXTERNAL_DTD, false);
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setXIncludeAware(false);
+		factory.setExpandEntityReferences(false);
+
+		// Belongs to the factory rather than the builder, and is only honoured by some
+		// implementations - which is why it sits behind the DOCTYPE refusal rather than in front of it.
+		trySetAttribute(factory, XMLConstants.ACCESS_EXTERNAL_DTD);
+		trySetAttribute(factory, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+
+		return factory.newDocumentBuilder();
+	}
+
+	/**
+	 * A SAX parser that reads only what it is handed.
+	 *
+	 * @throws Exception
+	 *             when the parser cannot be configured safely.
+	 */
+	public static SAXParser newSAXParser() throws Exception {
+		SAXParserFactory factory = SAXParserFactory.newInstance();
+
+		factory.setFeature(DISALLOW_DOCTYPE, true);
+		factory.setFeature(EXTERNAL_GENERAL_ENTITIES, false);
+		factory.setFeature(EXTERNAL_PARAMETER_ENTITIES, false);
+		factory.setFeature(LOAD_EXTERNAL_DTD, false);
+		factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+		factory.setXIncludeAware(false);
+
+		SAXParser parser = factory.newSAXParser();
+		trySetProperty(parser, XMLConstants.ACCESS_EXTERNAL_DTD);
+		trySetProperty(parser, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
+
+		return parser;
+	}
+
+	/**
+	 * Deny an external-access property, where the implementation has one.
+	 *
+	 * <p>The one place something is allowed to be unsupported, and it is safe for it to be: the
+	 * DOCTYPE refusal above has already removed the declaration these properties would restrict. An
+	 * implementation that does not recognise the name has nothing to restrict either.
+	 */
+	private static void trySetAttribute(DocumentBuilderFactory factory, String name) {
+		try {
+			factory.setAttribute(name, "");
+		} catch (IllegalArgumentException notSupported) {
+			// see above
+		}
+	}
+
+	private static void trySetProperty(SAXParser parser, String name) {
+		try {
+			parser.setProperty(name, "");
+		} catch (Exception notSupported) {
+			// see above
+		}
+	}
+}

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/util/XMLUtils.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/util/XMLUtils.java
@@ -48,9 +48,7 @@ public class XMLUtils {
      */
     static public Document newDocument() {
     try {
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        return builder.newDocument();
+        return SecureXml.newDocumentBuilder().newDocument();
     }    
     catch(Exception e) {
         LogUtils.report(e);
@@ -63,10 +61,7 @@ public class XMLUtils {
      */
     static public Document read(String data) {
     try {        
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        
-        return builder.parse(new ByteArrayInputStream(data.getBytes()));
+        return SecureXml.newDocumentBuilder().parse(new ByteArrayInputStream(data.getBytes()));
     }
     catch(Exception e) {
         LogUtils.report(e);
@@ -79,10 +74,7 @@ public class XMLUtils {
      */
     static public Document read(byte[] data) {
     try {        
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        
-        return builder.parse(new ByteArrayInputStream(data));
+        return SecureXml.newDocumentBuilder().parse(new ByteArrayInputStream(data));
     }
     catch(Exception e) {
         LogUtils.report(e);
@@ -95,10 +87,7 @@ public class XMLUtils {
      */
     static public Document read(InputStream is) {
     try {        
-        DocumentBuilderFactory factory =  DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-
-        return builder.parse(is);
+        return SecureXml.newDocumentBuilder().parse(is);
     }
     catch(Exception e) {
         LogUtils.report(e);

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedOpenKeepsWhatIsOpenTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedOpenKeepsWhatIsOpenTest.java
@@ -1,0 +1,130 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileWriter;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That a file which cannot be read does not take the open document with it.
+ *
+ * <p>{@code open} caught the parse failure and called {@code init()} before returning {@code false},
+ * which clears the document. So choosing a malformed file lost whatever was on screen, and
+ * "Open additional document…" destroyed the very document it was supposed to be adding to.
+ *
+ * <p>Nothing needs tidying up after a failure: {@code GlycanDocument.fromString} parses into a list of
+ * its own and only then hands it over, so a failed parse has not touched the document at all.
+ * {@code init()} was cleaning up after something that had not happened.
+ *
+ * <p>Companion to {@link SavedWorkIsNotLostTest}, which holds the successful paths — a fix here must
+ * not buy a failing open at the cost of a working one.
+ */
+public class AFailedOpenKeepsWhatIsOpenTest {
+
+	private static final String A_GLYCAN = "freeEnd--?b1D-GlcNAc,p$MONO,perMe,Na,0,freeEnd";
+
+	/** Not a sequence in any format the reader knows. */
+	private static final String MALFORMED = "this is not a glycan sequence {{{";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A normal Open of a malformed file leaves the current document alone. */
+	@Test
+	public void aFailedOpenKeepsTheCurrentDocument() throws Exception {
+		File good = gwsFile(A_GLYCAN);
+		GlycanDocument document = documentHolding(good);
+		String sequenceBefore = document.toString();
+
+		assertFalse("a malformed file should not open", open(document, gwsFile(MALFORMED), false));
+
+		assertEquals("the structure that was open should still be there",
+				1, document.getStructures().size());
+		assertEquals("and unchanged", sequenceBefore, document.toString());
+		assertEquals("the filename should not have moved", good.getAbsolutePath(),
+				document.getFileName());
+		assertTrue("the document should still count as saved", document.wasSaved());
+		assertFalse("and still count as unchanged", document.hasChanged());
+	}
+
+	/**
+	 * And so does a merge, which is the case the report was about.
+	 *
+	 * <p>"Open additional document…" is asking to add something. Failing to add it is not a reason to
+	 * remove what was there.
+	 */
+	@Test
+	public void aFailedMergeKeepsTheCurrentDocument() throws Exception {
+		File good = gwsFile(A_GLYCAN);
+		GlycanDocument document = documentHolding(good);
+		String sequenceBefore = document.toString();
+
+		assertFalse("a malformed file should not merge", open(document, gwsFile(MALFORMED), true));
+
+		assertEquals("the structure that was open should still be there",
+				1, document.getStructures().size());
+		assertEquals("and unchanged", sequenceBefore, document.toString());
+		assertEquals("the filename should not have moved", good.getAbsolutePath(),
+				document.getFileName());
+		assertTrue("the document should still count as saved", document.wasSaved());
+		assertFalse("a failed merge is not a change", document.hasChanged());
+	}
+
+	/** A missing file is the same answer, and must not clear anything either. */
+	@Test
+	public void aMissingFileKeepsTheCurrentDocument() throws Exception {
+		GlycanDocument document = documentHolding(gwsFile(A_GLYCAN));
+
+		File missing = File.createTempFile("glycanbuilder-open-", ".gws");
+		assertTrue(missing.delete());
+
+		assertFalse("a file that is not there should not open", open(document, missing, false));
+		assertEquals("the structure that was open should still be there",
+				1, document.getStructures().size());
+	}
+
+	/**
+	 * {@code open} reports a failure by returning false, and by throwing when asked to warn. Both are
+	 * exercised, since only the second reaches the caller as an exception and both used to clear the
+	 * document on the way.
+	 */
+	private static boolean open(GlycanDocument document, File file, boolean merge) {
+		try {
+			return document.open(file, merge, true);
+		} catch (Exception refused) {
+			return false;
+		}
+	}
+
+	private static GlycanDocument documentHolding(File file) throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue("the fixture did not open", document.open(file, false, true));
+		assertEquals("the fixture should hold one structure", 1, document.getStructures().size());
+
+		return document;
+	}
+
+	private static File gwsFile(String contents) throws Exception {
+		File file = File.createTempFile("glycanbuilder-open-", ".gws");
+		file.deleteOnExit();
+
+		FileWriter writer = new FileWriter(file);
+		try {
+			writer.write(contents);
+		} finally {
+			writer.close();
+		}
+
+		return file;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -120,6 +120,87 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 						java.nio.file.Files.getPosixFilePermissions(path)));
 	}
 
+	/**
+	 * It keeps the group the replaced file had, not the one a new file would get.
+	 *
+	 * <p>Mode bits are not the whole of who can read a file. A fresh file takes its group from the
+	 * platform's rule — the containing directory's on macOS, the creating process's on Linux — rather
+	 * than from the file being replaced. So a destination whose group had been set for a team came back
+	 * with a different group and an identical mode, which is a loss of access that reading the mode
+	 * cannot see. On Linux that is the ordinary case for a shared directory rather than an edge one.
+	 */
+	@Test
+	public void replacingAFileKeepsTheGroupItHad() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+		org.junit.Assume.assumeTrue(java.nio.file.Files.getFileStore(path)
+				.supportsFileAttributeView(java.nio.file.attribute.PosixFileAttributeView.class));
+
+		Object groupBefore = java.nio.file.Files.readAttributes(path,
+				java.nio.file.attribute.PosixFileAttributes.class).group();
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("saving should not change the file's group", groupBefore,
+				java.nio.file.Files.readAttributes(path,
+						java.nio.file.attribute.PosixFileAttributes.class).group());
+	}
+
+	/** And the owner, for the same reason. */
+	@Test
+	public void replacingAFileKeepsTheOwnerItHad() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+		org.junit.Assume.assumeTrue(java.nio.file.Files.getFileStore(path)
+				.supportsFileAttributeView(java.nio.file.attribute.PosixFileAttributeView.class));
+
+		Object ownerBefore = java.nio.file.Files.getOwner(path);
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("saving should not change the file's owner",
+				ownerBefore, java.nio.file.Files.getOwner(path));
+	}
+
+	/**
+	 * And anything an extended attribute says, which a move drops in silence.
+	 *
+	 * <p>Measured before this was carried over: a marker written to the destination was gone after the
+	 * save while the mode looked untouched. Whatever an ACL says would go the same way, and is carried
+	 * by the same code — this is the half of it a POSIX filesystem can be made to demonstrate.
+	 */
+	@Test
+	public void replacingAFileKeepsItsExtendedAttributes() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+
+		java.nio.file.attribute.UserDefinedFileAttributeView attributes =
+				java.nio.file.Files.getFileAttributeView(path,
+						java.nio.file.attribute.UserDefinedFileAttributeView.class);
+		org.junit.Assume.assumeNotNull(attributes);
+		try {
+			attributes.write("glycanbuilder.test",
+					java.nio.ByteBuffer.wrap("kept".getBytes(StandardCharsets.UTF_8)));
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertTrue("the extended attribute did not survive the save: "
+				+ java.nio.file.Files.getFileAttributeView(path,
+						java.nio.file.attribute.UserDefinedFileAttributeView.class).list(),
+				java.nio.file.Files.getFileAttributeView(path,
+						java.nio.file.attribute.UserDefinedFileAttributeView.class)
+						.list().contains("glycanbuilder.test"));
+	}
+
 	/** An existing good save is not truncated when the replacement cannot be serialized. */
 	@Test
 	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -254,6 +254,67 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		assertEquals("written", contents(target.toFile()));
 	}
 
+	/**
+	 * A loop of links is refused, and both links are still links afterwards.
+	 *
+	 * <p>Bounding the search at thirty-two hops and then returning whatever it had stopped on made that
+	 * link the destination. Measured: a two-link cycle came back {@code saved=true} with one of the links
+	 * replaced by the saved file. Running out of hops is a refusal, not an answer.
+	 */
+	@Test
+	public void aLoopOfLinksIsRefused() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-loop-");
+		java.nio.file.Path first = directory.resolve("first.gws");
+		java.nio.file.Path second = directory.resolve("second.gws");
+		try {
+			java.nio.file.Files.createSymbolicLink(first, second.getFileName());
+			java.nio.file.Files.createSymbolicLink(second, first.getFileName());
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+
+		assertFalse("a loop of links has no file at the end of it to save into",
+				document.save(first.toString()));
+		assertTrue("the first link should still be a link",
+				java.nio.file.Files.isSymbolicLink(first));
+		assertTrue("the second link should still be a link",
+				java.nio.file.Files.isSymbolicLink(second));
+		assertTrue("the document should remain dirty", document.hasChanged());
+	}
+
+	/** And so is a chain longer than the bound, with every link and the file at the end left alone. */
+	@Test
+	public void aChainLongerThanTheBoundIsRefused() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-chain-");
+		java.nio.file.Path target = directory.resolve("target.gws");
+		java.nio.file.Files.write(target, "the previous save".getBytes(StandardCharsets.UTF_8));
+
+		java.nio.file.Path[] links = new java.nio.file.Path[33];
+		try {
+			for (int index = links.length - 1; index >= 0; index--) {
+				links[index] = directory.resolve("link-" + index + ".gws");
+				java.nio.file.Path next = (index == links.length - 1) ? target : links[index + 1];
+				java.nio.file.Files.createSymbolicLink(links[index], next.getFileName());
+			}
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+
+		assertFalse("a chain past the bound should be refused rather than cut short",
+				document.save(links[0].toString()));
+		for (java.nio.file.Path link : links)
+			assertTrue(link + " should still be a link", java.nio.file.Files.isSymbolicLink(link));
+		assertEquals("the file at the end of the chain should be untouched",
+				"the previous save", contents(target.toFile()));
+		assertTrue("the document should remain dirty", document.hasChanged());
+	}
+
 	/** An existing good save is not truncated when the replacement cannot be serialized. */
 	@Test
 	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -201,6 +201,59 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 						.list().contains("glycanbuilder.test"));
 	}
 
+	/**
+	 * Saving to a symbolic link writes into what it points at, and leaves the link a link.
+	 *
+	 * <p>Opening a file for writing follows a link, so copying into the destination always did. Replacing
+	 * the destination does not: measured, a save to {@code link.gws} reported success, left a regular
+	 * file where the link had been, and left the {@code target.gws} it pointed at holding the previous
+	 * contents. The document the user believed they had saved was not the one on disk.
+	 */
+	@Test
+	public void savingThroughASymbolicLinkWritesIntoItsTarget() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-link-");
+		java.nio.file.Path target = directory.resolve("target.gws");
+		java.nio.file.Path link = directory.resolve("link.gws");
+		java.nio.file.Files.write(target, "the previous save".getBytes(StandardCharsets.UTF_8));
+		try {
+			java.nio.file.Files.createSymbolicLink(link, target.getFileName());
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue("the save should have succeeded", document.save(link.toString()));
+
+		assertTrue("the link should still be a link", java.nio.file.Files.isSymbolicLink(link));
+		assertEquals("the file the link points at should hold the new contents",
+				"written", contents(target.toFile()));
+	}
+
+	/** And a chain of links resolves all the way, rather than one hop. */
+	@Test
+	public void savingThroughAChainOfLinksReachesTheEnd() throws Exception {
+		java.nio.file.Path directory = java.nio.file.Files.createTempDirectory("glycanbuilder-link-");
+		java.nio.file.Path target = directory.resolve("target.gws");
+		java.nio.file.Path middle = directory.resolve("middle.gws");
+		java.nio.file.Path link = directory.resolve("link.gws");
+		java.nio.file.Files.write(target, "the previous save".getBytes(StandardCharsets.UTF_8));
+		try {
+			java.nio.file.Files.createSymbolicLink(middle, target.getFileName());
+			java.nio.file.Files.createSymbolicLink(link, middle.getFileName());
+		} catch (Exception notSupportedHere) {
+			org.junit.Assume.assumeNoException(notSupportedHere);
+		}
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(link.toString()));
+
+		assertTrue("both links should still be links", java.nio.file.Files.isSymbolicLink(link)
+				&& java.nio.file.Files.isSymbolicLink(middle));
+		assertEquals("written", contents(target.toFile()));
+	}
+
 	/** An existing good save is not truncated when the replacement cannot be serialized. */
 	@Test
 	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -1,0 +1,155 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.swing.filechooser.FileFilter;
+
+import org.eurocarbdb.application.glycanbuilder.BaseDocument;
+import org.junit.Test;
+
+/**
+ * That a save which did not happen is not reported as one.
+ *
+ * <p>{@code save} called {@code setFilename} before writing anything, and {@code setFilename} sets
+ * {@code was_saved} and clears {@code has_changed} as a side effect. So an unwritable destination, a
+ * full disk or a serialization failure returned {@code false} while leaving the document marked saved
+ * and clean: the asterisk went away, Save went grey, and the next close let the work go without asking.
+ *
+ * <p>The failure is injected through {@code write}, which is the seam a real one arrives at — no
+ * filesystem is filled and no permissions are relied on.
+ */
+public class AFailedSaveKeepsTheDocumentDirtyTest {
+
+	/** A write that fails leaves the save reporting failure. */
+	@Test
+	public void aFailedWriteIsAFailedSave() throws Exception {
+		Document document = dirtyDocument();
+
+		assertFalse("a save whose write threw should return false",
+				document.save(destination().getAbsolutePath()));
+	}
+
+	/** And leaves the document exactly as dirty, as named and as unsaved as it was. */
+	@Test
+	public void aFailedSaveChangesNothingAboutTheDocument() throws Exception {
+		Document document = dirtyDocument();
+		String nameBefore = document.getFileName();
+		boolean savedBefore = document.wasSaved();
+
+		document.save(destination().getAbsolutePath());
+
+		assertTrue("the document should still be dirty", document.hasChanged());
+		assertEquals("the filename should not have moved to the destination",
+				nameBefore, document.getFileName());
+		assertEquals("wasSaved should not have changed", savedBefore, document.wasSaved());
+	}
+
+	/** The destination is not created, let alone truncated, by a save that could not be written. */
+	@Test
+	public void aFailedSaveLeavesTheDestinationAlone() throws Exception {
+		File destination = destination();
+
+		dirtyDocument().save(destination.getAbsolutePath());
+
+		assertFalse("the destination should not have been written", destination.exists());
+	}
+
+	/** The temporary file the attempt made is its own to clean up, and it does. */
+	@Test
+	public void aFailedSaveLeavesNoTemporaryFileBehind() throws Exception {
+		File temporaryDirectory = new File(System.getProperty("java.io.tmpdir"));
+		String[] before = temporaryDirectory.list(gwbTemporaries());
+
+		dirtyDocument().save(destination().getAbsolutePath());
+
+		String[] after = temporaryDirectory.list(gwbTemporaries());
+		assertEquals("a temporary file was left behind",
+				(before == null) ? 0 : before.length, (after == null) ? 0 : after.length);
+	}
+
+	/** And a save that works still does everything it did: the name, the flags, the file. */
+	@Test
+	public void aSuccessfulSaveStillTakesTheFilenameAndGoesClean() throws Exception {
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		File destination = destination();
+
+		assertTrue("the save should have succeeded", document.save(destination.getAbsolutePath()));
+
+		assertEquals(destination.getAbsolutePath(), document.getFileName());
+		assertTrue("the document should be marked saved", document.wasSaved());
+		assertFalse("the document should be clean", document.hasChanged());
+		assertTrue("the destination should exist", destination.exists());
+	}
+
+	private static Document dirtyDocument() {
+		Document document = new Document();
+		document.setChanged(true);
+		return document;
+	}
+
+	/** A path in the temporary directory that nothing has created. */
+	private static File destination() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-save-", ".tmp");
+		assertTrue(destination.delete());
+		destination.deleteOnExit();
+
+		return destination;
+	}
+
+	private static java.io.FilenameFilter gwbTemporaries() {
+		return new java.io.FilenameFilter() {
+			@Override
+			public boolean accept(File directory, String name) {
+				return name.startsWith("gwb");
+			}
+		};
+	}
+
+	/** The smallest document there can be, with a write that can be told to fail. */
+	private static final class Document extends BaseDocument {
+
+		private boolean failOnWrite = true;
+
+		@Override
+		public void write(OutputStream os) throws Exception {
+			if (failOnWrite) throw new Exception("the disk said no");
+			os.write("written".getBytes("UTF-8"));
+		}
+
+		@Override
+		public int size() {
+			return 1;
+		}
+
+		@Override
+		public String getName() {
+			return "Test document";
+		}
+
+		@Override
+		public void initData() {
+		}
+
+		@Override
+		public void fromString(String str, boolean merge) throws Exception {
+		}
+
+		@Override
+		public Collection<FileFilter> getFileFormats() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public FileFilter getAllFileFormats() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveKeepsTheDocumentDirtyTest.java
@@ -5,7 +5,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileWriter;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -61,6 +64,100 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		assertFalse("the destination should not have been written", destination.exists());
 	}
 
+	/**
+	 * The destination is replaced rather than written into.
+	 *
+	 * <p>This is the assertion that tells the two implementations apart, and the reason the two above it
+	 * do not: writing to a temporary file first has always meant that a *serialization* failure left the
+	 * destination alone, so they pass against the old code as well. What was not transactional was the
+	 * step after it — copying the finished bytes *into* the destination, which truncates it first, so a
+	 * failure partway through left the last good save half-written.
+	 *
+	 * <p>A move cannot half-happen. It is observable as the file's identity: copying into a file keeps
+	 * its inode, moving a new file over it does not. Skipped where the filesystem has no such notion,
+	 * rather than asserted loosely enough to pass everywhere.
+	 */
+	@Test
+	public void theDestinationIsReplacedRatherThanWrittenInto() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		Object inodeBefore = inodeOf(destination);
+		org.junit.Assume.assumeNotNull(inodeBefore);
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("the new contents should be there", "written", contents(destination));
+		assertFalse("the destination was written into rather than replaced — a copy into an existing"
+				+ " file cannot be transactional, since it truncates before it writes",
+				inodeBefore.equals(inodeOf(destination)));
+	}
+
+	/**
+	 * And it keeps the permissions the replaced file had.
+	 *
+	 * <p>A move puts a new file in place of the old one, so without this the saved document carries the
+	 * temporary file's permissions — and a fresh temporary file is owner-only. A document in a shared
+	 * directory went from {@code rw-r--r--} to {@code rw-------} the first time it was saved, and
+	 * everyone but its owner lost work they had been reading. That is not a change a save should make.
+	 */
+	@Test
+	public void replacingAFileKeepsThePermissionsItHad() throws Exception {
+		File destination = existingDestination("the previous complete save");
+		java.nio.file.Path path = destination.toPath();
+		org.junit.Assume.assumeTrue(java.nio.file.Files.getFileStore(path)
+				.supportsFileAttributeView(java.nio.file.attribute.PosixFileAttributeView.class));
+
+		java.nio.file.Files.setPosixFilePermissions(path,
+				java.nio.file.attribute.PosixFilePermissions.fromString("rw-r--r--"));
+
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+		assertTrue(document.save(destination.getAbsolutePath()));
+
+		assertEquals("saving should not change who can read the file", "rw-r--r--",
+				java.nio.file.attribute.PosixFilePermissions.toString(
+						java.nio.file.Files.getPosixFilePermissions(path)));
+	}
+
+	/** An existing good save is not truncated when the replacement cannot be serialized. */
+	@Test
+	public void aFailedSaveDoesNotDamageThePreviousFile() throws Exception {
+		File destination = existingDestination("the previous complete save");
+
+		dirtyDocument().save(destination.getAbsolutePath());
+
+		assertEquals("the previous file should remain byte-for-byte intact",
+				"the previous complete save", contents(destination));
+	}
+
+	/** A failure while replacing the destination also cleans up the completed temporary file. */
+	@Test
+	public void aFailedReplacementLeavesNoTemporaryFileBehind() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-save-directory-", "");
+		assertTrue(destination.delete());
+		assertTrue(destination.mkdir());
+		File child = new File(destination,"keep");
+		assertTrue(child.createNewFile());
+		destination.deleteOnExit();
+		child.deleteOnExit();
+
+		File temporaryDirectory = destination.getAbsoluteFile().getParentFile();
+		String[] before = temporaryDirectory.list(gwbTemporaries());
+		Document document = dirtyDocument();
+		document.failOnWrite = false;
+
+		assertFalse("a non-empty directory cannot be replaced by a saved document",
+				document.save(destination.getAbsolutePath()));
+
+		String[] after = temporaryDirectory.list(gwbTemporaries());
+		assertEquals("a completed temporary file was left behind after replacement failed",
+				(before == null) ? 0 : before.length, (after == null) ? 0 : after.length);
+		assertTrue("the destination directory should still exist", destination.isDirectory());
+		assertTrue("the destination's previous content should still exist", child.exists());
+		assertTrue("the document should remain dirty", document.hasChanged());
+	}
+
 	/** The temporary file the attempt made is its own to clean up, and it does. */
 	@Test
 	public void aFailedSaveLeavesNoTemporaryFileBehind() throws Exception {
@@ -87,6 +184,7 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		assertTrue("the document should be marked saved", document.wasSaved());
 		assertFalse("the document should be clean", document.hasChanged());
 		assertTrue("the destination should exist", destination.exists());
+		assertEquals("written", contents(destination));
 	}
 
 	private static Document dirtyDocument() {
@@ -102,6 +200,36 @@ public class AFailedSaveKeepsTheDocumentDirtyTest {
 		destination.deleteOnExit();
 
 		return destination;
+	}
+
+	private static File existingDestination(String contents) throws Exception {
+		File destination = File.createTempFile("glycanbuilder-save-", ".tmp");
+		destination.deleteOnExit();
+		FileWriter writer = new FileWriter(destination);
+		try {
+			writer.write(contents);
+		} finally {
+			writer.close();
+		}
+		return destination;
+	}
+
+	private static String contents(File file) throws Exception {
+		return new String(Files.readAllBytes(file.toPath()),StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * The file's identity on the filesystem, or {@code null} where it has no such notion.
+	 *
+	 * <p>Two files with the same path and different inodes are two different files, which is the whole
+	 * difference between replacing a file and writing into it.
+	 */
+	private static Object inodeOf(File file) {
+		try {
+			return Files.getAttribute(file.toPath(),"unix:ino");
+		} catch (Exception noSuchNotion) {
+			return null;
+		}
 	}
 
 	private static java.io.FilenameFilter gwbTemporaries() {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveStopsTheCloseTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSaveStopsTheCloseTest.java
@@ -1,0 +1,133 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.OutputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.swing.filechooser.FileFilter;
+
+import org.eurocarbdb.application.glycanbuilder.BaseDocument;
+import org.eurocarbdb.application.glycanbuilder.GlycanBuilder;
+import org.junit.Test;
+
+/**
+ * That a failed Save is reported to whoever asked for it.
+ *
+ * <p>The Save branch for a document with a writable file called {@code save} and then returned
+ * {@code true} regardless of what it said. This is the branch "Save changes to …?" takes when a user
+ * answers Yes on exit, so an I/O failure read as a successful save and the application was allowed to
+ * close over work that had never been written.
+ *
+ * <p>Two separate faults needed two separate fixes and need two separate tests: the model marking an
+ * unwritten document as saved ({@code AFailedSaveKeepsTheDocumentDirtyTest}) and this, the caller
+ * throwing the answer away. Fixing either alone leaves the other.
+ *
+ * <p>Tested through {@code GlycanBuilder.saveToItsOwnFile}, which is the decision without the window
+ * around it. Constructing the frame would need a display and would test the file chooser.
+ */
+public class AFailedSaveStopsTheCloseTest {
+
+	/** A save that fails is reported as failing. */
+	@Test
+	public void aFailedSaveIsReportedAsFailed() throws Exception {
+		Document document = savedDocumentIn(existingWritableFile());
+
+		assertEquals("a failed save should be reported as false",
+				Boolean.FALSE, GlycanBuilder.saveToItsOwnFile(document));
+	}
+
+	/** And one that works, as working. */
+	@Test
+	public void aSuccessfulSaveIsReportedAsSuccessful() throws Exception {
+		Document document = savedDocumentIn(existingWritableFile());
+		document.failOnWrite = false;
+
+		assertEquals(Boolean.TRUE, GlycanBuilder.saveToItsOwnFile(document));
+	}
+
+	/**
+	 * A document with no file of its own is neither, and says so: the caller offers Save As.
+	 *
+	 * <p>This is the case the discarded return value had been written for, and it still works — which
+	 * is the half that says the fix did not turn every failure into a file chooser.
+	 */
+	@Test
+	public void aDocumentWithNoFileAsksTheCallerToChooseOne() {
+		assertNull("a document with no writable file should fall through to Save As",
+				GlycanBuilder.saveToItsOwnFile(new Document()));
+	}
+
+	/** And so is no document at all. */
+	@Test
+	public void noDocumentAsksNothing() {
+		assertNull(GlycanBuilder.saveToItsOwnFile(null));
+	}
+
+	/** A document that believes it came from this file, so {@code getFile} hands it back. */
+	private static Document savedDocumentIn(File file) {
+		Document document = new Document();
+		document.setFilename(file.getAbsolutePath());
+		document.setChanged(true);
+
+		return document;
+	}
+
+	private static File existingWritableFile() throws Exception {
+		File file = File.createTempFile("glycanbuilder-close-", ".tmp");
+		file.deleteOnExit();
+
+		FileWriter writer = new FileWriter(file);
+		try {
+			writer.write("something that was already there");
+		} finally {
+			writer.close();
+		}
+
+		return file;
+	}
+
+	/** The smallest document there can be, with a write that can be told to fail. */
+	private static final class Document extends BaseDocument {
+
+		private boolean failOnWrite = true;
+
+		@Override
+		public void write(OutputStream os) throws Exception {
+			if (failOnWrite) throw new Exception("the disk said no");
+			os.write("written".getBytes("UTF-8"));
+		}
+
+		@Override
+		public int size() {
+			return 1;
+		}
+
+		@Override
+		public String getName() {
+			return "Test document";
+		}
+
+		@Override
+		public void initData() {
+		}
+
+		@Override
+		public void fromString(String str, boolean merge) throws Exception {
+		}
+
+		@Override
+		public Collection<FileFilter> getFileFormats() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public FileFilter getAllFileFormats() {
+			return null;
+		}
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSequenceExportSaysSoTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedSequenceExportSaysSoTest.java
@@ -1,0 +1,82 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.GlycanBuilder;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an export to a sequence format reports what happened.
+ *
+ * <p>The sequence branch of Export To called {@code exportTo} and returned {@code true} regardless of
+ * what it said, so an export that wrote nothing reported success. The graphical formats in the same
+ * method had always returned their real result — only the sequence formats lied.
+ *
+ * <p>It also made a liar of the warning that follows a successful export, whose whole purpose is to
+ * tell a user which structures did not come out.
+ *
+ * <p>The failure is a destination that cannot be written — a directory — rather than a permission bit,
+ * so it is deterministic and needs no privileged setup.
+ */
+public class AFailedSequenceExportSaysSoTest {
+
+	private static final String A_GLYCAN = "freeEnd--?b1D-GlcNAc,p--4b1D-Gal,p$MONO,Und,0,0,freeEnd";
+
+	@BeforeClass
+	public static void newWorkspace() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** An export that cannot be written is reported as failed. */
+	@Test
+	public void anExportThatCannotBeWrittenIsReportedAsFailed() throws Exception {
+		assertFalse("a sequence export to an unwritable destination should be reported as false",
+				GlycanBuilder.exportSequenceTo(documentWithAGlycan(),
+						aDirectory().getAbsolutePath(), "wurcs2"));
+	}
+
+	/** And one that works, as working — the half that says the fix did not refuse everything. */
+	@Test
+	public void anExportThatWorksIsReportedAsWorking() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-export-", ".wurcs");
+		destination.deleteOnExit();
+
+		assertTrue("an ordinary sequence export should be reported as true",
+				GlycanBuilder.exportSequenceTo(documentWithAGlycan(),
+						destination.getAbsolutePath(), "wurcs2"));
+		assertTrue("and should have written something", destination.length() > 0);
+	}
+
+	/** No document is no export. */
+	@Test
+	public void noDocumentIsNoExport() throws Exception {
+		File destination = File.createTempFile("glycanbuilder-export-", ".wurcs");
+		destination.deleteOnExit();
+
+		assertFalse(GlycanBuilder.exportSequenceTo(null, destination.getAbsolutePath(), "wurcs2"));
+	}
+
+	private static GlycanDocument documentWithAGlycan() throws Exception {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		assertTrue(document.importFromString(A_GLYCAN, "gws"));
+
+		return document;
+	}
+
+	/** A destination that is not a file, which is the simplest write failure to arrange. */
+	private static File aDirectory() throws Exception {
+		File directory = File.createTempFile("glycanbuilder-export-", "");
+		assertTrue(directory.delete());
+		assertTrue(directory.mkdir());
+		directory.deleteOnExit();
+
+		return directory;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AcylatingTheAmineIsNotClaimingTheCarbonTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AcylatingTheAmineIsNotClaimingTheCarbonTest.java
@@ -1,0 +1,123 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an acyl at the position of a residue's own amine substitutes the nitrogen rather than claiming
+ * the carbon (#211).
+ *
+ * <p>{@code GlcN}'s 2 is left out of its linkage positions because the amine is there, and 1.37.0
+ * began enforcing that list against every child — so acylating the amine, which is how a GlcNAc is
+ * built up a step at a time, was refused. The exporter had always read it the other way and wrote
+ * exactly GlcNAc's WURCS for it.
+ *
+ * <p><i>"Glc + 2N -&gt; GlcN + 2Ac -&gt; GlcNAc となり、Glc の C2 位の OH が、NHAc に置換され、GlcNAc
+ * となります"</i> — I. Yamada, 2026-08-15. The position names the site; what sits there is the group
+ * being modified.
+ *
+ * <p><b>Both halves of the rule are read from the dictionary</b>, not derived: the type's IUPAC name
+ * says where the nitrogen is ({@code Glc$2N}, {@code Glc$2NAc}), and the type offers {@code N} among
+ * its positions when that nitrogen has room. This corner has now taught twice over that chemistry
+ * which is reasoned about rather than declared comes out wrong — the bridge exemption was the first
+ * time.
+ */
+public class AcylatingTheAmineIsNotClaimingTheCarbonTest {
+
+	/** What a GlcNAc weighs as a sequence, whichever way it was spelled. */
+	private static final String GLCNAC = "WURCS=2.0/1,1,0/[a2122h-1x_1-5_2*NCC/3=O]/1/";
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/**
+	 * The case that regressed: an acetyl on a glucosamine's amine, written as position 2.
+	 *
+	 * <p>Refused on 1.37.0 and 1.38.0; attached and correct on every version before them.
+	 */
+	@Test
+	public void anAcetylOnAGlucosaminesAmineAttaches() throws Exception {
+		Residue glcN = ResidueDictionary.newResidue("GlcN");
+
+		assertTrue("acylating the amine at 2 was refused",
+				glcN.addChild(ResidueDictionary.newResidue("Ac"), '2'));
+	}
+
+	/**
+	 * And it is a GlcNAc, not merely attached.
+	 *
+	 * <p>The assertion that matters: the exporter combines the residue's own {@code 2*N} with the
+	 * acetyl into {@code 2*NCC/3=O}, so the stepwise spelling and the named residue write the same
+	 * sequence. Attaching without that would be a worse outcome than refusing.
+	 */
+	@Test
+	public void andItWritesTheSameWURCSAsTheNamedResidue() throws Exception {
+		Residue glcN = ResidueDictionary.newResidue("GlcN");
+		glcN.addChild(ResidueDictionary.newResidue("Ac"), '2');
+
+		assertEquals("the named residue does not write what was expected",
+				GLCNAC, write(ResidueDictionary.newResidue("GlcNAc")));
+		assertEquals("a GlcN acylated at 2 should write the same sequence as a GlcNAc",
+				GLCNAC, write(glcN));
+	}
+
+	/**
+	 * A nitrogen that is already acylated keeps its position closed.
+	 *
+	 * <p>GlcNAc omits 2 <em>and</em> offers no {@code N}, which is the dictionary saying the nitrogen
+	 * is spoken for. This is the half that stops the fix from becoming "substituents may go anywhere".
+	 */
+	@Test
+	public void anAmideNitrogenStaysClosed() throws Exception {
+		assertFalse("GlcNAc's 2 carries the N-acetyl and should stay closed",
+				ResidueDictionary.newResidue("GlcNAc").addChild(
+						ResidueDictionary.newResidue("Me"), '2'));
+	}
+
+	/**
+	 * Only a substituent qualifies. A monosaccharide there would be a glycosidic bond to something
+	 * that is not a hydroxyl, and nothing measured supports it.
+	 */
+	@Test
+	public void aSugarAtTheNitrogenIsStillRefused() throws Exception {
+		assertFalse("a Gal at the amine's position should be refused",
+				ResidueDictionary.newResidue("GlcN").addChild(
+						ResidueDictionary.newResidue("Gal"), '2'));
+	}
+
+	/**
+	 * The exemption is for the nitrogen's own position and nothing else: a position the sugar does not
+	 * have is still refused, and so is a second child at the nitrogen.
+	 */
+	@Test
+	public void theExemptionReachesNoFurther() throws Exception {
+		assertFalse("a pentose has no 6",
+				ResidueDictionary.newResidue("Xyl").addChild(
+						ResidueDictionary.newResidue("Me"), '6'));
+
+		Residue glcN = ResidueDictionary.newResidue("GlcN");
+		assertTrue(glcN.addChild(ResidueDictionary.newResidue("Ac"), '2'));
+		assertFalse("the amine already carries one, and a carbon carries one bond",
+				glcN.addChild(ResidueDictionary.newResidue("Me"), '2'));
+	}
+
+	private static String write(Residue residue) throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		root.addChild(residue);
+
+		return new WURCS2Parser().writeGlycan(new Glycan(root, false, MassOptions.empty()));
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CopyingLosesNothingTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/CopyingLosesNothingTest.java
@@ -1,0 +1,104 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.dataset.ResidueDictionary;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That copying a structure copies all of it (#211).
+ *
+ * <p>{@code cloneSubtree} rebuilt the copy through {@code addChild}, so once #34 taught {@code addChild}
+ * to refuse a position another child holds, a structure holding two children at one position lost one
+ * <em>on the way through the copy</em> — and a clone has nowhere to report, so it said nothing.
+ * {@code Glycan.clone()} takes the same route, which is copy-and-paste, undo and redo.
+ *
+ * <p>Measured before the fix: 1.35.2 and 1.36.0 copied both children, 1.37.0 and 1.38.0 copied one.
+ *
+ * <p><b>The distinction is between validating a change and reproducing a fact.</b> A copy makes no new
+ * claim about a molecule — the question was settled when the original was made — so the rules that
+ * decide what may be attached do not apply to it. Reading a file has always been on that side of the
+ * line: #34 kept documents containing such a structure openable. Copying belongs there too.
+ */
+public class CopyingLosesNothingTest {
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** Two substituents at one position survive a subtree copy. */
+	@Test
+	public void aSubtreeCopyKeepsBothChildrenAtOnePosition() throws Exception {
+		Residue glc = glcWithSubstituentsAt('2', "N", "Ac");
+		assertEquals("the structure under test was not built", 2, glc.getNoChildren());
+
+		assertEquals("the copy lost a substituent", 2, glc.cloneSubtree().getNoChildren());
+	}
+
+	/** And so do more than two — nothing here counts to two. */
+	@Test
+	public void andMoreThanTwo() throws Exception {
+		Residue glc = glcWithSubstituentsAt('2', "N", "Ac", "Me");
+		assertEquals("the structure under test was not built", 3, glc.getNoChildren());
+
+		assertEquals("the copy lost a substituent", 3, glc.cloneSubtree().getNoChildren());
+	}
+
+	/**
+	 * And the whole document copies to the same sequence, which is the form the loss reached a user in:
+	 * copy-and-paste and undo both go through {@code Glycan.clone()}.
+	 */
+	@Test
+	public void aDocumentCopyWritesTheSameSequence() throws Exception {
+		Glycan structure = wrap(glcWithSubstituentsAt('2', "N", "Ac"));
+
+		assertEquals("copying the document changed it",
+				structure.toString(), structure.clone().toString());
+	}
+
+	/**
+	 * Copying does not become a way to build what the rules refuse: the copy is faithful, and adding to
+	 * it afterwards is still checked.
+	 */
+	@Test
+	public void copyingIsNotAWayAroundTheRules() throws Exception {
+		Residue copy = glcWithSubstituentsAt('2', "N", "Ac").cloneSubtree();
+
+		assertEquals("a further substituent at the same position should still be refused",
+				false, copy.addChild(ResidueDictionary.newResidue("Me"), '2'));
+	}
+
+	/**
+	 * A Glc carrying several substituents at one position.
+	 *
+	 * <p>Built the way the canvas does it — attach, then set the position — because {@code addChild}
+	 * with the position stated is exactly what refuses the second one. That is the state a document read
+	 * from a file arrives in, and #34 was explicit that such a file still opens.
+	 */
+	private static Residue glcWithSubstituentsAt(char position, String... substituents)
+			throws Exception {
+		Residue glc = ResidueDictionary.newResidue("Glc");
+
+		for (String each : substituents) {
+			Residue substituent = ResidueDictionary.newResidue(each);
+			glc.addChild(substituent);
+			substituent.getParentLinkage().setLinkagePositions(new char[] {position});
+		}
+
+		return glc;
+	}
+
+	private static Glycan wrap(Residue residue) throws Exception {
+		Residue root = ResidueDictionary.createReducingEnd("freeEnd");
+		root.addChild(residue);
+
+		return new Glycan(root, false, MassOptions.empty());
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/XmlReadersRefuseExternalEntitiesTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/XmlReadersRefuseExternalEntitiesTest.java
@@ -1,0 +1,129 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.charset.StandardCharsets;
+
+import org.eurocarbdb.application.glycanbuilder.util.SAXUtils;
+import org.eurocarbdb.application.glycanbuilder.util.XMLUtils;
+import org.junit.Test;
+import org.w3c.dom.Document;
+import org.xml.sax.Attributes;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * That neither XML reader will fetch what a document points at.
+ *
+ * <p>A default JAXP parser resolves external entities, so a document can name a file and have its
+ * contents substituted into the parse. Measured before the fix, with an entity pointing at a temporary
+ * file: both {@link XMLUtils#read(String)} and {@link SAXUtils#read} expanded it and handed back the
+ * file's contents. The same configuration will issue network requests from a document, so the reach was
+ * never limited to the local disk.
+ *
+ * <p>The sentinel is written to a temporary file and looked for by name, so the test proves the
+ * substitution did not happen rather than that some particular error was produced. No network and no
+ * listening socket: an entity with a {@code file:} URI is the whole of it.
+ */
+public class XmlReadersRefuseExternalEntitiesTest {
+
+	private static final String SENTINEL = "glycanbuilder-xxe-sentinel-4f2a";
+
+	/** The DOM reader refuses it, by its existing contract of reporting and returning null. */
+	@Test
+	public void theDomReaderDoesNotFetchTheFile() throws Exception {
+		Document parsed = XMLUtils.read(xmlNaming(fileHoldingTheSentinel()));
+
+		assertNull("the DOM reader accepted a document with an external entity", parsed);
+	}
+
+	/** The SAX reader throws, and the handler is given nothing first. */
+	@Test
+	public void theSaxReaderDoesNotFetchTheFile() throws Exception {
+		final StringBuilder seen = new StringBuilder();
+		String xml = xmlNaming(fileHoldingTheSentinel());
+
+		boolean threw = false;
+		try {
+			SAXUtils.read(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)),
+					new DefaultHandler() {
+						@Override
+						public void characters(char[] ch, int start, int length) {
+							seen.append(ch, start, length);
+						}
+					});
+		} catch (Exception refused) {
+			threw = true;
+		}
+
+		assertTrue("the SAX reader accepted a document with an external entity", threw);
+		assertFalse("the handler was given the file's contents before the parse failed: " + seen,
+				seen.toString().contains(SENTINEL));
+	}
+
+	/**
+	 * And ordinary XML still reads, which is the half that says the hardening did not cost anything.
+	 *
+	 * <p>Nothing this application reads as XML declares a {@code DOCTYPE} — workspaces, configuration,
+	 * fragment definitions — which is why refusing one outright was available as the strongest setting
+	 * and the compatible one at the same time.
+	 */
+	@Test
+	public void ordinaryXmlStillReads() throws Exception {
+		Document parsed = XMLUtils.read(
+				"<?xml version=\"1.0\"?><Workspace><Glycan>ordinary</Glycan></Workspace>");
+
+		assertNotNull("an ordinary document should still parse", parsed);
+		assertEquals("Workspace", parsed.getDocumentElement().getNodeName());
+		assertEquals("ordinary", parsed.getDocumentElement().getTextContent());
+	}
+
+	/** And through SAX as well. */
+	@Test
+	public void ordinaryXmlStillReadsThroughSax() throws Exception {
+		final StringBuilder seen = new StringBuilder();
+
+		SAXUtils.read(new ByteArrayInputStream(
+						"<?xml version=\"1.0\"?><Workspace><Glycan>ordinary</Glycan></Workspace>"
+								.getBytes(StandardCharsets.UTF_8)),
+				new DefaultHandler() {
+					@Override
+					public void characters(char[] ch, int start, int length) {
+						seen.append(ch, start, length);
+					}
+
+					@Override
+					public void startElement(String uri, String local, String name, Attributes a) {
+					}
+				});
+
+		assertEquals("ordinary", seen.toString().trim());
+	}
+
+	/** A file the parse must not be able to reach. */
+	private static File fileHoldingTheSentinel() throws Exception {
+		File secret = File.createTempFile("glycanbuilder-xxe-", ".txt");
+		secret.deleteOnExit();
+
+		FileWriter writer = new FileWriter(secret);
+		try {
+			writer.write(SENTINEL);
+		} finally {
+			writer.close();
+		}
+
+		return secret;
+	}
+
+	private static String xmlNaming(File secret) {
+		return "<?xml version=\"1.0\"?>"
+				+ "<!DOCTYPE root [<!ENTITY leak SYSTEM \"" + secret.toURI() + "\">]>"
+				+ "<root><taken>&leak;</taken></root>";
+	}
+}


### PR DESCRIPTION
Release 1.39.0.

**Minor rather than patch.** `SecureXml`, `GlycanBuilder.saveToItsOwnFile` and
`GlycanBuilder.exportSequenceTo` are new public API, and saving, exporting, reading XML and attaching a
substituent all now refuse or allow things they did not. A consumer relying on any of those would see the
change — the same reasoning 1.37.0 was released under.

220 tests pass. `origin/develop` reads 1.39.0, checked against the remote rather than the local ref.

| What | Verified by |
|---|---|
| Tests gate the release (F) | this PR's own `test` job, and every installer job now `needs: test` |
| XML readers refuse external entities (E) | a sentinel in a temporary file, reachable before and not after |
| A failed save is not reported as success (A, B) | 16 assertions on the save path |
| The destination is replaced, not truncated | the destination's inode changes — a copy would keep it |
| Access control survives a save | mode, owner, group and an extended attribute, each asserted |
| A save through a link writes into its target | `linkBytes=new targetBytes=old` → `new`/`new` |
| A loop or over-long chain of links is refused | every link left as it was, document still dirty |
| A failed open keeps the open document (C) | the document comes back holding nothing without the fix |
| A failed sequence export says so (D) | an unwritable destination reported as false |
| An acyl may substitute an amine (#211) | `GlcN + Ac@2` writes exactly GlcNAc's WURCS again |
| Copying a structure copies all of it (#211) | three substituents at one position survive a clone |

### Three things worth reading twice

**The release path was not running the tests.** 1.36.0, 1.37.0 and 1.38.0 were all published with
`-DskipTests` in every installer workflow and nothing else running the suite. That is why a regression
shipped in 1.37.0 and sat through 1.38.0. Work package F was taken first for that reason: fixing the
faults without the gate leaves the next one the same road.

**1.37.0's regression was mine, and it was found by taking glycanbuilder2web forward.** The position rules
began enforcing a residue type's list against every child, which stopped an acyl attaching to the amine at
`GlcN`'s 2 — the ordinary way a GlcNAc is built up a step at a time, and something the exporter has always
written correctly. The fix reads both halves of the rule from the dictionary rather than deriving them,
because this corner has now twice punished chemistry that was reasoned about instead of declared.

**The save fix went through three rounds of review, and one of my judgements was wrong.** I had it fall
back to copying into the destination when access control could not be carried over, arguing that refusing
was worse. The fallback truncates, so it also loses work and loses it silently, on exactly the path where
attributes are most likely to fail. A refusal is visible and recoverable. That is now what happens.

### Still open, deliberately

#88, #83, #203, #204, #29, #183 and #211 close with this release — `develop` is not the default branch, so
`Closes #N` does not fire on merge, and closing them by hand earlier would have told each reporter it was
done while no installable version had it.

The waiting-list nudges are held until Monday 2026-08-17 at the maintainer's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
