### PR TITLE
Attach installers to a release, not whatever else is lying around

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,17 @@ jobs:
             ## Windows
             Install GlycanBuilder2 from the Microsoft Store:
             https://apps.microsoft.com/detail/9pp6bsnx71jl
+          # Attach installers by extension. `artifacts/*` attached whatever the
+          # download step happened to fetch, and once tests.yml began running as
+          # part of the release that included the surefire-reports artifact --
+          # v1.39.0 went out with 92 test reports hanging off it. Naming the
+          # extensions keeps a release to the things people install, whatever
+          # else future jobs leave in the directory.
+          #
+          # Windows is deliberately absent: it ships through the Microsoft Store.
           files: |
-            artifacts/*
+            artifacts/*.dmg
+            artifacts/*.deb
+            artifacts/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
v1.39.0 went out with **92 surefire test reports** attached beside the five packages. The stray assets have since been removed from that release; this stops it recurring.

## Cause

`release.yml` downloads artifacts with a negation:

```yaml
pattern: "!glycanbuilder2-installer-windows"
```

which means *everything except Windows*. That was fine until `tests.yml` became part of the release path — the `surefire-reports` artifact then matched too, and `files: artifacts/*` published all of it.

Adding the test gate was the right change; this is just its unintended edge.

## Fix

```diff
           files: |
-            artifacts/*
+            artifacts/*.dmg
+            artifacts/*.deb
+            artifacts/*.rpm
```

The filter is on what gets **attached**, not on what gets downloaded, so it holds whatever a future job leaves in `artifacts/` and does not depend on what the upload steps happen to name themselves.

I first tried tightening the download `pattern` to an allowlist and found it matched nothing — the artifacts are called `glycanbuilder2-installer-linux-debian`, `glycanbuilder2-installer-linux-rpm-${{ matrix.distro }}` and so on, not the shorter names I had assumed. Filtering by extension avoids that class of mistake entirely.

Windows stays absent by design: it ships through the Microsoft Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)