### PR TITLE
Attach installers to a release, and nothing else that happens to be in the run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Installers only, named rather than excluded. The pattern used to say "everything except the
+      # Windows one", which was true of the four installers while they were the only artifacts in the run
+      # - and stopped being true the moment the test job began uploading its surefire reports into the
+      # same run. Ninety-two report files were downloaded here alongside the five installers, and the
+      # build-logs-* artifacts had always been coming too.
+      #
+      # The Windows installer is matched and downloaded now rather than excluded by name, because the
+      # step that attaches the assets selects by extension and its .msix is not one of them. Saying which
+      # artifacts are wanted is worth more than keeping a list of the ones that are not.
       - name: Download installer artifacts
         uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
-          pattern: '!glycanbuilder2-installer-windows'
+          pattern: glycanbuilder2-installer-*
 
       - name: List downloaded artifacts
         run: |
@@ -61,7 +70,11 @@ jobs:
             ## Windows
             Install GlycanBuilder2 from the Microsoft Store:
             https://apps.microsoft.com/detail/9pp6bsnx71jl
+          # By extension, not by directory. Either this or the download pattern above would have kept
+          # the surefire reports off the release; a release's assets are worth two locks.
           files: |
-            artifacts/*
+            artifacts/*.deb
+            artifacts/*.rpm
+            artifacts/*.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
A defect I introduced with the test gate, found while checking the 1.39.0 release.

## What happened

The release job downloaded artifacts with `pattern: '!glycanbuilder2-installer-windows'` — "everything except the Windows installer" — and attached `artifacts/*`. That was true of the four installers while they were the only artifacts in the run. Adding `tests.yml` put a `surefire-reports` artifact in the same run.

From the 1.39.0 release run's own log:

```
artifacts/GlycanBuilder2-1.39.0.ARM64.dmg
artifacts/GlycanBuilder2-1.39.0.X64.dmg
artifacts/TEST-org.glycoinfo.WURCSFramework.Glycan.ABridgeLabelHasRoomTest.xml
...  92 report files in total
```

The `build-logs-*` artifacts had always been coming too — the negation never excluded those either, so this was latent before the test job made it visible.

## The fix, twice over

| | |
|---|---|
| download | names what it wants, `glycanbuilder2-installer-*`, instead of listing what it does not |
| attach | selects `*.deb`, `*.rpm`, `*.dmg` instead of `artifacts/*` |

Either alone would have been enough. A release's assets are worth two locks.

The Windows artifact is matched and downloaded now rather than excluded by name, because the attach step selects by extension and its `.msix` is not one of them. It is still not attached, and is still collected by hand for the Store.

## One thing I could not settle

I tried `glycanbuilder2-installer-!(windows)` first and replaced it: whether `download-artifact`'s matcher treats `!(...)` as extglob across a hyphen is not checkable here without spending a release run on it. Naming what is wanted needs no such bet.

**The reading I could not reconcile is settled.** `gh release view` showed 97 assets on v1.39.0 and two
later reads of `GET /releases/tags/v1.39.0` showed 5 with no report files. Both were right: the 92 report
files *were* attached, and the maintainer removed them by hand between the reads. So the first alarm was
correct and the later reads were of the cleaned release, not a stale view. v1.39.0 now carries the five
installers and nothing else — verified against the API.

Workflow only; no product code, so the suite is unchanged at 220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
