### PR TITLE
Write the compositions the dialog offers, build the muramic acid it names, and say why when one cannot be written

### DIFF
--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -861,18 +861,29 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 
 		LinkedList<Glycan> all = doc.getStructures();
 		StringBuilder positions = new StringBuilder();
+		// Why, where whatever refused a structure said so. The count and the positions say that
+		// something went wrong; only this says what, and it was already being thrown away.
+		java.util.LinkedHashSet<String> reasons = new java.util.LinkedHashSet<String>();
 		int index = 0;
 		for( Glycan g : all ) {
 			index++;
 			if( failures.contains(g) ) {
 				if( positions.length()>0 ) positions.append(", ");
 				positions.append(index);
+
+				String why = theDoc.getLastExportFailureReason(g);
+				if( why!=null ) reasons.add(why);
 			}
 		}
 
-		JOptionPane.showMessageDialog(this,
-				failures.size() + " of " + all.size() + " structure(s) could not be exported to " + format
-						+ " and were left blank in the file (position(s): " + positions + ").",
+		StringBuilder message = new StringBuilder();
+		message.append(failures.size()).append(" of ").append(all.size())
+				.append(" structure(s) could not be exported to ").append(format)
+				.append(" and were left blank in the file (position(s): ").append(positions).append(").");
+		for( String why : reasons )
+			message.append("\n\n").append(why);
+
+		JOptionPane.showMessageDialog(this, message.toString(),
 				"Export incomplete", JOptionPane.WARNING_MESSAGE);
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanCanvas.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanCanvas.java
@@ -3603,18 +3603,29 @@ public class GlycanCanvas extends JComponent implements ActionListener,
 		if( failures.isEmpty() ) return;
 
 		StringBuilder positions = new StringBuilder();
+		// Why, where whatever refused a structure said so. The count and the positions say that
+		// something went wrong; only this says what, and it was already being thrown away.
+		java.util.LinkedHashSet<String> reasons = new java.util.LinkedHashSet<String>();
 		int index = 0;
 		for( Glycan g : exported ) {
 			index++;
 			if( failures.contains(g) ) {
 				if( positions.length()>0 ) positions.append(", ");
 				positions.append(index);
+
+				String why = theDoc.getLastExportFailureReason(g);
+				if( why!=null ) reasons.add(why);
 			}
 		}
 
-		JOptionPane.showMessageDialog(theParent,
-				failures.size() + " of " + exported.size() + " structure(s) could not be exported to " + format
-						+ " and were left blank (position(s): " + positions + ").",
+		StringBuilder message = new StringBuilder();
+		message.append(failures.size()).append(" of ").append(exported.size())
+				.append(" structure(s) could not be exported to ").append(format)
+				.append(" and were left blank (position(s): ").append(positions).append(").");
+		for( String why : reasons )
+			message.append("\n\n").append(why);
+
+		JOptionPane.showMessageDialog(theParent, message.toString(),
 				"Export incomplete", JOptionPane.WARNING_MESSAGE);
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
@@ -70,6 +70,12 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	// nothing for those, so callers need this to warn rather than leave it unnoticed
 	private ArrayList<Glycan> lastExportFailures = new ArrayList<Glycan>();
 
+	// Why each of those produced nothing, where whatever refused it said so. Static because the
+	// encoding runs through static methods; identity-keyed because two structures can be equal and
+	// still be two entries in the document.
+	static private java.util.Map<Glycan,String> lastExportReasons =
+			new java.util.IdentityHashMap<Glycan,String>();
+
 	// ----------------
 
 	/**
@@ -97,6 +103,17 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	 */
 	public ArrayList<Glycan> getLastExportFailures() {
 		return this.lastExportFailures;
+	}
+
+	/**
+	 * Why a structure produced no output on the most recent export, or null where nothing said.
+	 *
+	 * <p>The warning that names which structures came out blank can name the reason too. "A composition
+	 * cannot be written in 'NeuAc'" is the difference between somebody knowing to remove a residue and
+	 * somebody knowing only that something is wrong.
+	 */
+	public String getLastExportFailureReason(Glycan structure) {
+		return lastExportReasons.get(structure);
 	}
 
 	public void clearString() {
@@ -1537,12 +1554,14 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 		if (parser instanceof GWSParser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
 				Glycan structure = i.next();
+				forgetPreviousReason();
 				str += record(parser.writeGlycan(structure, bboxManager), structure, failures);
 				if (i.hasNext()) str += ";";
 			}
 		} else if (parser instanceof WURCS2Parser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
 				Glycan structure = i.next();
+				forgetPreviousReason();
 				str += record(parser.writeGlycan(structure), structure, failures);
 				if (i.hasNext()) str += "\n";
 			}
@@ -1550,6 +1569,7 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 			// These formats hold one structure, so only the first is written - and the rest are
 			// therefore absent from the file, which is what the caller warns about.
 			Glycan first = structures.isEmpty() ? null : structures.iterator().next();
+			forgetPreviousReason();
 			if (bboxManager != null) { //At the moment this will force conversion to GlycoCT_XML
 				str = record(parser.writeGlycan(first, bboxManager), first, failures);
 			} else {
@@ -1571,9 +1591,39 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	 * without saying so.
 	 */
 	static private String record(String encoded, Glycan structure, Collection<Glycan> failures) {
-		if (failures != null && structure != null && (encoded == null || encoded.isEmpty()))
+		if (failures != null && structure != null && (encoded == null || encoded.isEmpty())) {
 			failures.add(structure);
+			rememberWhy(structure);
+		}
 		return encoded;
+	}
+
+	/**
+	 * Why a structure produced nothing, in the words of whatever refused it.
+	 *
+	 * <p>The reason exists and was being thrown away. A composition of something the encoder cannot
+	 * name says so - "A composition cannot be written in 'NeuAc'" - and a writer reports it before
+	 * handing back an empty string. The warning that follows the export could then only say that N of M
+	 * structures "were left blank", which tells somebody that something went wrong and nothing about
+	 * what.
+	 *
+	 * <p>Read from {@link LogUtils}, which is where the writers already put it. That is a narrow
+	 * arrangement - it works because a writer reports immediately before returning, on the same thread -
+	 * and it is why the reason is cleared before each structure rather than trusted to be fresh. A
+	 * writer that fails silently leaves no reason, and the warning falls back to what it said before.
+	 */
+	static private void rememberWhy(Glycan structure) {
+		String reason = LogUtils.getLastError();
+		if (reason != null && !reason.trim().isEmpty())
+			lastExportReasons.put(structure, reason.trim());
+	}
+
+	/**
+	 * Clear the last reported error, so that what is read after a structure is written belongs to that
+	 * structure rather than to something earlier.
+	 */
+	static private void forgetPreviousReason() {
+		LogUtils.clearLastError();
 	}
 
 	public void fromString(String str, String format) throws Exception {

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/CompositionOptions.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/CompositionOptions.java
@@ -249,7 +249,10 @@ public class CompositionOptions {
     for( int i=0; i<NEU5ACLAC; i++ ) ret.addAntenna(ResidueDictionary.newResidue("NeuAcLac"));
     for( int i=0; i<KDO; i++ ) ret.addAntenna(ResidueDictionary.newResidue("KDO"));
     for( int i=0; i<KDN; i++ ) ret.addAntenna(ResidueDictionary.newResidue("KDN"));
-    for( int i=0; i<MUR; i++ ) ret.addAntenna(ResidueDictionary.newResidue("MurNAc"));
+    // Muramic acid, which is what the count is called and what the dialog offers. It built a MurNAc
+    // - an N-acetyl heavier by C2H2O - so the mass shown and the composition searched were both for a
+    // residue nobody had asked for. Both residues exist; this is the one named on the label.
+    for( int i=0; i<MUR; i++ ) ret.addAntenna(ResidueDictionary.newResidue("Mur"));
 
     for( int i=0; i<S; i++ ) ret.addAntenna(ResidueDictionary.newResidue("S"));
     for( int i=0; i<P; i++ ) ret.addAntenna(ResidueDictionary.newResidue("P"));

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/composition/CompositionResidue.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/composition/CompositionResidue.java
@@ -16,6 +16,9 @@ package org.glycoinfo.application.glycanbuilder.composition;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 import org.eurocarbdb.MolecularFramework.sugar.Anomer;
@@ -138,7 +141,34 @@ public enum CompositionResidue {
 		for (CompositionResidue residue : values())
 			if (residue.name.equalsIgnoreCase(name)) return residue;
 
-		return null;
+		return BY_RESIDUE_TYPE_NAME.get(name.toLowerCase());
+	}
+
+	/**
+	 * Residue type names that mean one of these and are not spelled like it.
+	 *
+	 * <p>The names above are the ones composition WURCS uses. A residue type is named for the
+	 * application's own dictionary, and for the sialic acids the two disagree: the residue is
+	 * {@code NeuAc}, the composition calls it {@code Neu5Ac}. Nothing translated between them, so a
+	 * composition containing sialic acid - the most ordinary residue there is in an N-glycan - was
+	 * refused outright and exported as an empty file (#219).
+	 *
+	 * <p><b>Not solvable by naming the residue types differently.</b> {@code Neu5Ac} is already a
+	 * residue type of its own, declared in {@code conf/compositions}, so adding it as a synonym of
+	 * {@code NeuAc} shadows a real type - measured, and it broke the position rules where it was tried.
+	 * The translation belongs here, which is also where glycanbuilder2web has kept its own copy of it
+	 * and why that application was unaffected.
+	 *
+	 * <p>Only names that differ are listed. The other eleven residues the composition dialog offers are
+	 * spelled the same on both sides and are found by the loop above.
+	 */
+	private static final Map<String, CompositionResidue> BY_RESIDUE_TYPE_NAME;
+	static {
+		Map<String, CompositionResidue> translated = new HashMap<String, CompositionResidue>();
+		translated.put("neuac", NEU5AC);
+		translated.put("neugc", NEU5GC);
+
+		BY_RESIDUE_TYPE_NAME = Collections.unmodifiableMap(translated);
 	}
 
 	/**

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
@@ -1,0 +1,122 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.CompositionOptions;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an export which produced nothing says why, and not only that it did.
+ *
+ * <p>The reason existed and was thrown away. A composition of something the encoder cannot name says so
+ * — {@code A composition cannot be written in 'NeuAc'} — and the writer reports it before handing back an
+ * empty string. The warning that followed could then only say that N of M structures "were left blank",
+ * which tells somebody that something went wrong and nothing about what to do.
+ *
+ * <p>The failure used here is a real one rather than a contrived seam: a composition containing sialic
+ * acid cannot be written at all (#219), which is the most ordinary way a user meets this.
+ */
+public class AFailedExportSaysWhyTest {
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A composition the encoder cannot name is reported as a failure, with the reason attached. */
+	@Test
+	public void aFailureCarriesTheReasonThatCausedIt() throws Exception {
+		GlycanDocument document = documentHolding(compositionWithSialicAcid());
+
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+
+		assertEquals("the composition should have been reported as unexportable",
+				1, document.getLastExportFailures().size());
+
+		String why = document.getLastExportFailureReason(document.getStructures().get(0));
+		assertNotNull("the reason was thrown away", why);
+		assertTrue("the reason should name what could not be written, and says: " + why,
+				why.contains("NeuAc"));
+	}
+
+	/**
+	 * A structure that exported fine has no reason attached.
+	 *
+	 * <p>The reason is read from where the writers report, so the guard that matters is that a reason
+	 * left over from something earlier is not pinned to a structure that succeeded.
+	 */
+	@Test
+	public void somethingThatExportedCarriesNoReason() throws Exception {
+		GlycanDocument document = documentHolding(compositionThatWrites());
+
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+
+		assertTrue("this composition should export", document.getLastExportFailures().isEmpty());
+		assertNull("a structure that exported should carry no reason",
+				document.getLastExportFailureReason(document.getStructures().get(0)));
+	}
+
+	/**
+	 * And a reason from one export does not follow a later one that worked.
+	 *
+	 * <p>This is the arrangement's weak point — the reason comes from the last reported error rather
+	 * than from a value handed back — so it is the thing worth holding.
+	 */
+	@Test
+	public void aReasonDoesNotOutliveTheExportItBelongsTo() throws Exception {
+		GlycanDocument first = documentHolding(compositionWithSialicAcid());
+		first.exportFromStructure(first.getStructures(), "wurcs2");
+		assertNotNull(first.getLastExportFailureReason(first.getStructures().get(0)));
+
+		GlycanDocument second = documentHolding(compositionThatWrites());
+		second.exportFromStructure(second.getStructures(), "wurcs2");
+
+		assertNull("the earlier failure's reason was carried into a later, successful export",
+				second.getLastExportFailureReason(second.getStructures().get(0)));
+	}
+
+	/** Hex3 HexNAc2 Neu5Ac1 — ordinary, and unwritable until #219 is fixed. */
+	private static Glycan compositionWithSialicAcid() throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		counts.HEX = 3;
+		counts.HEXNAC = 2;
+		counts.NEU5AC = 1;
+
+		return counts.getCompositionAsGlycan(neutral());
+	}
+
+	/** Hex3 HexNAc2 — the same composition without the sialic acid, which does write. */
+	private static Glycan compositionThatWrites() throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		counts.HEX = 3;
+		counts.HEXNAC = 2;
+
+		return counts.getCompositionAsGlycan(neutral());
+	}
+
+	private static MassOptions neutral() {
+		MassOptions neutral = new MassOptions();
+		neutral.DERIVATIZATION = MassOptions.NO_DERIVATIZATION;
+		neutral.ION_CLOUD = new IonCloud();
+
+		return neutral;
+	}
+
+	private static GlycanDocument documentHolding(Glycan structure) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.clearString();
+
+		return document;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
@@ -19,12 +19,12 @@ import org.junit.Test;
  * That an export which produced nothing says why, and not only that it did.
  *
  * <p>The reason existed and was thrown away. A composition of something the encoder cannot name says so
- * — {@code A composition cannot be written in 'NeuAc'} — and the writer reports it before handing back an
+ * — {@code A composition cannot be written in 'MeH'} — and the writer reports it before handing back an
  * empty string. The warning that followed could then only say that N of M structures "were left blank",
  * which tells somebody that something went wrong and nothing about what to do.
  *
- * <p>The failure used here is a real one rather than a contrived seam: a composition containing sialic
- * acid cannot be written at all (#219), which is the most ordinary way a user meets this.
+ * <p>The failure used here is a real one rather than a contrived seam: the composition dialog offers a
+ * methyl hexose and the encoder has no residue for it (#220).
  */
 public class AFailedExportSaysWhyTest {
 
@@ -36,7 +36,7 @@ public class AFailedExportSaysWhyTest {
 	/** A composition the encoder cannot name is reported as a failure, with the reason attached. */
 	@Test
 	public void aFailureCarriesTheReasonThatCausedIt() throws Exception {
-		GlycanDocument document = documentHolding(compositionWithSialicAcid());
+		GlycanDocument document = documentHolding(compositionThatCannotBeWritten());
 
 		document.exportFromStructure(document.getStructures(), "wurcs2");
 
@@ -46,7 +46,7 @@ public class AFailedExportSaysWhyTest {
 		String why = document.getLastExportFailureReason(document.getStructures().get(0));
 		assertNotNull("the reason was thrown away", why);
 		assertTrue("the reason should name what could not be written, and says: " + why,
-				why.contains("NeuAc"));
+				why.contains("MeH"));
 	}
 
 	/**
@@ -74,7 +74,7 @@ public class AFailedExportSaysWhyTest {
 	 */
 	@Test
 	public void aReasonDoesNotOutliveTheExportItBelongsTo() throws Exception {
-		GlycanDocument first = documentHolding(compositionWithSialicAcid());
+		GlycanDocument first = documentHolding(compositionThatCannotBeWritten());
 		first.exportFromStructure(first.getStructures(), "wurcs2");
 		assertNotNull(first.getLastExportFailureReason(first.getStructures().get(0)));
 
@@ -85,12 +85,19 @@ public class AFailedExportSaysWhyTest {
 				second.getLastExportFailureReason(second.getStructures().get(0)));
 	}
 
-	/** Hex3 HexNAc2 Neu5Ac1 — ordinary, and unwritable until #219 is fixed. */
-	private static Glycan compositionWithSialicAcid() throws Exception {
+	/**
+	 * Hex3 HexNAc2 with a methyl hexose, which the encoder has no residue for.
+	 *
+	 * <p>This was written with a sialic acid, which is how the fault was met — and #219 fixed that, so
+	 * the fixture became a composition that exports. Changed to one that still cannot be written rather
+	 * than to a contrived seam: MeH is a real residue the composition dialog offers, and #220 is the
+	 * open question of what a composition should say about it.
+	 */
+	private static Glycan compositionThatCannotBeWritten() throws Exception {
 		CompositionOptions counts = new CompositionOptions();
 		counts.HEX = 3;
 		counts.HEXNAC = 2;
-		counts.NEU5AC = 1;
+		counts.MEHEX = 1;
 
 		return counts.getCompositionAsGlycan(neutral());
 	}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/EveryCompositionTheDialogOffersWritesTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/EveryCompositionTheDialogOffersWritesTest.java
@@ -1,0 +1,143 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.massutil.CompositionOptions;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Every composition count, through the road the application actually takes (#219).
+ *
+ * <p>The encoder's own tests ask for a {@code CompositionResidue} <b>by name</b>, so only names the
+ * encoder already knows can appear in one. That is how a composition containing sialic acid came to
+ * export as an empty file and stay that way through four releases: the residue type is called
+ * {@code NeuAc}, the composition calls it {@code Neu5Ac}, and nothing on the road between them
+ * translated. The single assertion that did go through the application's path used Hex and HexNAc —
+ * the two residues whose names happen to agree.
+ *
+ * <p>So this walks every count {@link CompositionOptions} has, sets it, builds the composition the way
+ * the dialog does, and writes it. **A test that constructs its input the way the code under test likes
+ * it will not find a fault on the way in.**
+ */
+public class EveryCompositionTheDialogOffersWritesTest {
+
+	/**
+	 * The counts that should produce a WURCS.
+	 *
+	 * <p>Thirteen: the twelve the web application's dialog offers, and Hep, which the desktop dialog
+	 * offers as well.
+	 */
+	private static final List<String> SHOULD_WRITE = Arrays.asList(
+			"PEN", "HEX", "HEP", "HEXN", "HEXNAC", "DHEX", "DDHEX", "HEXA",
+			"NEU5AC", "NEU5GC", "KDO", "KDN", "MUR");
+
+	/**
+	 * The counts that cannot be written, and are known not to be.
+	 *
+	 * <p>Held here so the list is a statement rather than an absence. {@code 4dPen}, {@code MeH},
+	 * {@code dHexA} and the two lactonised sialic acids have no composition residue to be counted as —
+	 * and, measured, cannot be written as ordinary structures either, so they are not a composition
+	 * fault. The rest are substituents, user-defined residues and the two placeholders. All of it is
+	 * #220.
+	 */
+	private static final List<String> KNOWN_NOT_TO = Arrays.asList(
+			"DPEN", "MEHEX", "DHEXA", "NEU5ACLAC", "NEU5GCLAC",
+			"OR1", "OR2", "OR3", "S", "P", "AC", "PYR", "PC", "KETOSE", "UNKNOWN");
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** Each of the thirteen writes something. */
+	@Test
+	public void everyOfferedResidueWrites() throws Exception {
+		List<String> silent = new ArrayList<String>();
+		for (String count : SHOULD_WRITE)
+			if (writes(count) == null) silent.add(count + " (" + residueMadeBy(count) + ")");
+
+		assertTrue("these composition counts exported as an empty file: " + silent, silent.isEmpty());
+	}
+
+	/** Sialic acid in particular, since that is the one that was refused and the one users reach for. */
+	@Test
+	public void aSialylatedCompositionWrites() throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		counts.HEX = 5;
+		counts.HEXNAC = 4;
+		counts.NEU5AC = 2;
+		counts.DHEX = 1;
+
+		String written = new WURCS2Parser().writeGlycan(counts.getCompositionAsGlycan(neutral()));
+
+		assertFalse("a sialylated composition exported as an empty file", written.isEmpty());
+		assertTrue("the residues are not the ones expected: " + written,
+				written.startsWith("WURCS=2.0/4,12,11/[Aad21122h-2x_2-6_5*NCC/3=O][axxxxm-1x_1-5]"
+						+ "[axxxxh-1x_1-5_2*NCC/3=O][axxxxh-1x_1-5]/1-1-2-3-3-3-3-4-4-4-4-4/"));
+	}
+
+	/**
+	 * And the ones that cannot be written are still the ones we think they are.
+	 *
+	 * <p>Not an assertion that they should stay broken — it is #220's list, and this fails if one starts
+	 * working, which is the moment to move it into the list above.
+	 */
+	@Test
+	public void theOnesThatCannotAreStillTheOnesWeThinkTheyAre() throws Exception {
+		List<String> nowWriting = new ArrayList<String>();
+		for (String count : KNOWN_NOT_TO)
+			if (writes(count) != null) nowWriting.add(count);
+
+		assertEquals("these now write, and belong in the offered list instead: " + nowWriting,
+				0, nowWriting.size());
+	}
+
+	/** @return Returns what the count wrote, or null where it wrote nothing. */
+	private static String writes(String count) throws Exception {
+		Glycan composition = compositionOf(count);
+		if (composition == null) return null;
+
+		String written = new WURCS2Parser().writeGlycan(composition);
+		return written.isEmpty() ? null : written;
+	}
+
+	private static String residueMadeBy(String count) throws Exception {
+		StringBuilder made = new StringBuilder();
+		for (Residue residue : compositionOf(count).getAllResidues())
+			if (!residue.isReducingEnd() && !residue.isBracket() && residue.getType() != null)
+				made.append(residue.getType().getName());
+
+		return made.toString();
+	}
+
+	private static Glycan compositionOf(String count) throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		Field field = CompositionOptions.class.getField(count);
+		field.setInt(counts, 1);
+
+		return counts.getCompositionAsGlycan(neutral());
+	}
+
+	private static MassOptions neutral() {
+		MassOptions neutral = new MassOptions();
+		neutral.DERIVATIZATION = MassOptions.NO_DERIVATIZATION;
+		neutral.ION_CLOUD = new IonCloud();
+
+		return neutral;
+	}
+}


### PR DESCRIPTION
Three composition faults, all found by comparing this library against glycanbuilder2web rather than by the
suite. Closes #219 and #221; #220 keeps the questions that are still questions.

**226 tests pass.**

## A composition containing sialic acid exported as an empty file (#219)

Through four releases. The residue type is called `NeuAc`, composition WURCS calls it `Neu5Ac`, and nothing
on the road between them translated — `named()` matched on the composition name alone, so it returned null,
`count` threw, and `writeGlycan` reported it and handed back `""`.

**Naming the residue types differently is not available.** `Neu5Ac` is already a residue type of its own,
declared in `conf/compositions` — a third dictionary that also feeds `ResidueDictionary`, which I did not
know about until this. Adding `Neu5Ac` as a synonym of `NeuAc` shadows the real type: measured, it broke
`PositionRulesLiveInTheModelTest`, and was reverted. So the translation goes in the encoder, which is also
where glycanbuilder2web keeps its own copy of the same table — and why that application was never affected.

Two names differ; the other eleven are spelled the same on both sides. **Thirteen counts write where eleven
did**, and a sialylated composition writes the same WURCS glycanbuilder2web writes for it:

```
WURCS=2.0/4,12,11/[Aad21122h-2x_2-6_5*NCC/3=O][axxxxm-1x_1-5][axxxxh-1x_1-5_2*NCC/3=O][axxxxh-1x_1-5]/1-1-2-3-3-3-3-4-4-4-4-4/…
```

## "Muramic Acid / Mur" built a MurNAc (#221)

The dialog said Mur and `CompositionOptions.MUR` built an N-acetyl muramic acid — heavier by C₂H₂O, so the
mass shown and the composition searched were both for a residue nobody asked for. Both residues exist and
both write; this is the one on the label.

```
Mur     [a2122h-1x_1-5_2*N_3*OCC^RC/4O/3=O]         a free amine at 2
MurNAc  [a2122h-1x_1-5_2*NCC/3=O_3*OCC^RC/4O/3=O]   an N-acetyl at 2
```

**This is the one change here that alters a number a user sees.** Saved work is unaffected — a composition
already saved holds a `MurNAc` residue and still does; only what the Mur count builds from now on changes.

## An export that produced nothing now says why

The reason existed and was being thrown away. `A composition cannot be written in 'MeH'` is reported by the
writer before it returns an empty string; the warning that followed could only say that N of M structures
"were left blank", which tells somebody something is wrong and nothing about what to do. Both warnings —
the frame's and the canvas's — carry the reasons now.

Read from `LogUtils`, which is where the writers already put it. That is a **narrow** arrangement: it works
because a writer reports immediately before returning, on the same thread, and it is why the reason is
cleared before each structure rather than trusted to be fresh. The test holds that weak point — that a
reason from one export does not follow a later one that worked — rather than the happy path.

## The test that should have existed

`EveryCompositionTheDialogOffersWritesTest` walks **every** count `CompositionOptions` has.

The encoder's own tests ask for a `CompositionResidue` **by name**, so only names the encoder already knows
can appear in one. That is exactly how this survived four releases: the single assertion that did go
through the application's path used Hex and HexNAc — the two residues whose names happen to agree.

*A test that constructs its input the way the code under test likes it will not find a fault on the way in.*

It also keeps the list of counts that **cannot** be written, so that is a statement rather than an absence,
and fails if one starts working — which is the moment to move it.

## One fixture repointed, and why it is worth a line

`AFailedExportSaysWhyTest` used a sialylated composition as its example of something unwritable. #219 makes
that writable, so the test failed on the very fix it was written beside. It uses a methyl hexose now —
still a real residue the dialog offers, still #220 — rather than a contrived seam.

No version bump: this is a sub-branch for `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
