### PR TITLE
Version 1.40.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,12 +39,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Installers only, named rather than excluded. The pattern used to say "everything except the
+      # Windows one", which was true of the four installers while they were the only artifacts in the run
+      # - and stopped being true the moment the test job began uploading its surefire reports into the
+      # same run. Ninety-two report files were downloaded here alongside the five installers, and the
+      # build-logs-* artifacts had always been coming too.
+      #
+      # The Windows installer is matched and downloaded now rather than excluded by name, because the
+      # step that attaches the assets selects by extension and its .msix is not one of them. Saying which
+      # artifacts are wanted is worth more than keeping a list of the ones that are not.
       - name: Download installer artifacts
         uses: actions/download-artifact@v7
         with:
           path: artifacts
           merge-multiple: true
-          pattern: '!glycanbuilder2-installer-windows'
+          pattern: glycanbuilder2-installer-*
 
       - name: List downloaded artifacts
         run: |
@@ -61,7 +70,11 @@ jobs:
             ## Windows
             Install GlycanBuilder2 from the Microsoft Store:
             https://apps.microsoft.com/detail/9pp6bsnx71jl
+          # By extension, not by directory. Either this or the download pattern above would have kept
+          # the surefire reports off the release; a release's assets are worth two locks.
           files: |
-            artifacts/*
+            artifacts/*.deb
+            artifacts/*.rpm
+            artifacts/*.dmg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,41 @@
 ## Change log
+### 1.40.0  (20260815)
+Compositions, found by comparing this library against glycanbuilder2web rather than by the suite.
+**Minor rather than patch**: the Muramic Acid count builds a different residue than it did, so a mass and a
+composition search both change.
+* **A composition containing sialic acid exported as an empty file** (#219), through four releases. The
+  residue type is called `NeuAc` and composition WURCS calls it `Neu5Ac`, and nothing on the road between
+  them translated - so `named()` returned null, the count threw, and the writer reported it and handed back
+  an empty string
+  * **Not fixable by renaming.** `Neu5Ac` is already a residue type of its own, declared in
+    `conf/compositions` - a third residue dictionary that also feeds `ResidueDictionary`. Adding it as a
+    synonym of `NeuAc` shadows the real type: measured, it broke the position rules, and was reverted. So
+    the table lives in the composition encoder, which is also where glycanbuilder2web has always kept its
+    own copy of it, and why that application was never affected
+  * Thirteen of the composition counts write where eleven did, and a sialylated composition writes the same
+    WURCS glycanbuilder2web writes for it
+  * **The test that should have existed** walks every count `CompositionOptions` has. The encoder's own
+    tests ask for a residue *by the encoder's own name*, so only names it already knows can appear in one -
+    which is exactly how this survived: the single assertion that went through the application's path used
+    Hex and HexNAc, the two residues whose names happen to agree. *A test that builds its input the way the
+    code under test likes it will not find a fault on the way in.*
+* **"Muramic Acid" built an N-acetyl muramic acid** (#221). The dialog said Mur and the count built MurNAc -
+  heavier by C₂H₂O - so the mass shown and the composition searched were both for a residue nobody had
+  asked for. Both residues exist and both write; this is the one on the label
+  * **The one change here that alters a number a user sees.** Saved work is unaffected: a composition
+    already saved holds a `MurNAc` residue and still does. Only what the Mur count builds from now on
+    changes
+* **An export that produced nothing says why.** The reason existed and was being thrown away - a writer
+  reports `A composition cannot be written in 'MeH'` before returning an empty string, and the warning that
+  followed could only say that N of M structures "were left blank". Both warnings carry the reasons now
+  * Read from `LogUtils`, where the writers already put it. A narrow arrangement - it works because a writer
+    reports immediately before returning, on the same thread - so the reason is cleared before each
+    structure rather than trusted to be fresh, and the test holds that weak point rather than the happy path
+* **A release attaches installers and nothing else that happens to be in the run.** The download pattern
+  said "everything except the Windows installer", which was true of the four installers until the test job
+  began uploading its surefire reports into the same run - ninety-two report files went to the 1.39.0
+  release. Named rather than excluded now, and the attach step selects by extension
+
 ### 1.39.0  (20260815)
 A code review, a regression 1.37.0 had shipped, and the reason neither had been caught: the release path
 was not running the tests. **Minor rather than patch** - `SecureXml`,

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -102,6 +102,7 @@ Both were found while measuring something else and existed nowhere but this file
 |---|---|---|
 | ~~#132~~ | ~~`v_stripes`/`h_stripes` never painted~~ | **Done.** Three bars, clipped to the outline. The test asserts the drawn image and, separately, that the stripes exist — Tal is green and All is blue, so comparing the pair passes on colour alone |
 | ~~#107~~ | ~~Composition export to WURCS fails~~ | **Done.** `org.glycoinfo.application.glycanbuilder.composition` builds the composition as unlinked nodes and lets `WURCSFactory` canonicalize, which is what glycompconverter does. No new dependency; output pinned against that implementation's, residue by residue |
+| ~~#219~~ | ~~A composition with sialic acid exports as an empty file~~ | **Fixed, on `develop`.** The residue type is `NeuAc` and composition WURCS calls it `Neu5Ac`; nothing translated. Not fixable by renaming — `Neu5Ac` is already a type, from `conf/compositions`. The table lives in the encoder now, where glycanbuilder2web has always kept its own |
 | ~~#127~~ | ~~`MassOptions.ISOTOPE` has no effect~~ | **Done for the neutral mass**, 1.36.0, and closed. Residues, water, hydrogen and the derivatization all follow the choice; measured against literature (Glc 180.156, Man₃GlcNAc₂ 910.82) |
 | ~~#203~~ | ~~An m/z pairs an average neutral mass with a monoisotopic adduct~~ | **Fixed in PR #205, merged to `develop` on 2026-08-15.** `IonCloud` captured an adduct's mass when the ion was set rather than when it was computed, so the choice could not reach it. `computeMZ`/`computeMass` take the flag now and `getIonsMass(boolean)` recomputes the total; a charge given an explicit mass keeps it. The test is on potassium and chloride, with sodium as the control — one stable isotope, so a sodiated m/z was right by accident and a test on the default adduct would have passed before the fix |
 | **#185** | EPS/PS/PDF export writes 0 bytes silently | **Half done.** A failed transcode is now refused by name instead of being written as an empty file — it had been logged and returned as null, and the null was written. The underlying Windows failure does not reproduce here: all five formats write on macOS with the pinned batik 1.19 / fop 2.11. Waiting on a retest from the reporter |
@@ -182,6 +183,13 @@ that still refuses to export.
 #58 (G07957FT layout) · #20 (bracket not symmetric about the reducing end) ·
 #91 (Add-structure menu misaligned) · #6 (fragments carrying a bridge)
 
+**#222** (a sulfate cannot be added to a GlcN) — the working spelling is the plain sulfate at position 2,
+which the exporter combines with the residue's own `2*N` into `2*NSO/3=O/3=O`. It only works from 1.39.0:
+before that the position rules refused it, which is #211's other face. What remains is that the *wrong*
+spelling — at position `N` — attaches and then writes nothing, and the better answer is to refuse the
+attachment. That is a position-rule change, and those have produced two regressions in two days, so it
+waits for the reporter's retest rather than being done in a hurry.
+
 ## P4 — not there yet
 
 | # | Title | Note |
@@ -249,67 +257,83 @@ Contribution questions are answered ahead of the queue, whatever band the code w
 The bands say what a thing costs. This says what to pick up, and it is the bands applied twice: once
 for cost, once for what it costs to leave the tracker saying something untrue.
 
-**1. ~~One sitting of tracker work~~ — done on 2026-08-15.** Nine fixed issues were still open and two
-measured faults were filed nowhere. Both are the same failure, and it is the one this file is most
-emphatic about: *silence outranks severity*. An issue saying a fixed bug is live, and a real fault that
-exists in nobody's tracker, are equally wrong to everyone outside this repository — and they cost an
-hour rather than a week, which is why they came first.
+**The list below is a record of 2026-08-15, kept because the reasoning is worth more than the ticks.**
+Everything on it is done. What is left to pick up is at the bottom.
 
-Ten issues closed with their measurements, #203 and #204 filed, #88 left open on purpose until the fix
-is in a release, #189 answered from the dictionary and #190 pointed at #181.
+1. ~~**One sitting of tracker work.**~~ Nine fixed issues were open and two measured faults were filed
+   nowhere — the same failure, and the one this file is most emphatic about: *silence outranks severity*.
+   Ten issues closed with their measurements, #203 and #204 filed.
+2. ~~**#203, the ion adduct isotope.**~~ The last thing handing someone a wrong number they could not see
+   was wrong.
+3. ~~**#204, a repeat unit's position lost on a round trip.**~~ Dropped on the way in, not out, and one
+   line.
+4. ~~**#29, the bisecting GlcNAc.**~~ Reached every picture, so checked in all four orientations.
+5. ~~**#183, the doubled export error.**~~ Mechanism real; the reported sequence no longer fails, and that
+   was recorded rather than claimed as verified.
+6. ~~**A code review, six work packages.**~~ Taken with the test gate first, because it was why the other
+   five could ship: 1.36.0, 1.37.0 and 1.38.0 all went out with `-DskipTests` in every installer workflow.
+   The XML readers were leaking local files through external entities; save, open and export all reported
+   failures as successes.
+7. ~~**The save path, three rounds of review.**~~ Transactional replacement, a channel leak, then access
+   control — owner, group, ACL and extended attributes, or the file is not replaced at all — then symbolic
+   links, then the boundary where a link chain has no end. One of my judgements was overturned in the
+   middle of it and the correction is on #214.
+8. ~~**#211, a regression 1.37.0 had shipped.**~~ Found by taking glycanbuilder2web forward, not by the
+   suite. An acyl could no longer substitute the amine a residue carries, and a copy silently dropped a
+   residue.
+9. ~~**#219 and #221, composition.**~~ A composition containing sialic acid exported as an empty file
+   through four releases, and "Muramic Acid" built a MurNAc.
 
-**2. ~~#203, the ion adduct isotope~~ — fixed, PR #205.** The last thing in the project that handed
-someone a wrong number they could not see was wrong. P1 by the same rule that put #127 there.
+---
 
-**3. ~~#204, the repeat unit's linkage position lost on a round trip~~ — fixed, PR #206.** It turned out
-to be dropped on the way in rather than on the way out, and to be one line: the closing repeat marker
-was the only one of the two that was never given the position before being added.
+## What is left, and why none of it can be picked up today
 
-**4. ~~#29, the bisecting GlcNAc~~ — fixed, PR #207.** It reached every picture the application draws,
-so it was checked in all four orientations and the plain core comes out unchanged in each. It also
-turned up a mistake in `docs/linkage-positions-and-anomers.md`, corrected on this branch: the
-position-to-side rules in the placement dictionaries apply to substituents only, not to saccharides.
+Thirty issues are open and **none is actionable without either a reply or a decision.** That is worth
+stating plainly rather than leaving the list to imply there is work going begging.
 
-**5. ~~#183, the doubled export error~~ — fixed, PR #208.** The mechanism was real; the reported
-sequence turned out to write back unchanged, so there was nothing to watch fail. Recorded as such rather
-than claimed as verified.
+| what | how many | which |
+|---|---|---|
+| waiting on somebody else | 12 | #17, #57, #58, #66, #83, #185, #16, #183, #189, #190, #123, #222 |
+| waiting on a decision — chemistry or product | 6 | #220, #7, #100, #109, #117, #182 |
+| on hold at the maintainer's request | 2 | #175, #180 |
+| wishes rather than work | 8 | #41, #93, #94, #95, #172, #177, #181, #184 |
+| drawing, P3 | 4 | #6, #20, #58, #91 |
+| structure-model changes, neither small | 2 | #200, #181 |
 
-**6. The waiting list — held until Monday 2026-08-17.** #17, #57, #58, #66, #83, #185, #16 and #183 are
-all waiting on somebody else and several are closable on a reply. A nudge costs a paragraph.
+**The nudges are held until Monday 2026-08-17** — I. Yamada, 2026-08-15. They were written and ready on
+the Saturday; holding them is deliberate, so a quiet weekend on this list is not a stall.
 
-**Not to be sent before Monday 2026-08-17** — I. Yamada, 2026-08-15. The nudges were written and ready on
-the Saturday; holding them is deliberate, so if this list looks stalled on a weekend, it is not.
-
-**~~Then a release~~ — 1.38.0, released 2026-08-15**, and taken ahead of the waiting list because six
-fixes were sitting where nobody could install them, which by this file's own ranking outranks the next
-defect. `master` reads 1.38.0, tagged `v1.38.0` on the merge commit.
-
-**#88, #203, #204 and #29 close with it.** #83 and #183 do **not**: #201 removed an angle the CFG hat
-diamonds never used, which does not answer whether the symbol looks *rotated* — the question the reporter
-was asked — and #183's fix is on a mechanism whose reported sequence no longer fails. Both stay on the
-waiting list. This corrects a list of six I wrote earlier the same day.
-
-Then the rest of P3, and P4 as wishes rather than work: #200 and #181 are both structure-model
-changes and neither is small.
+**#222 is the one that looks actionable and is not.** A sulfate attaches at a GlcN's `N` and then writes
+nothing, and refusing the attachment is the better answer — but that is a change to the position rules,
+and changes of exactly that shape have produced two regressions in two days: 1.37.0's #211, and a synonym
+that shadowed a real residue type on the 15th. It waits for the reporter's retest, which costs nothing.
 
 ---
 
 ## Where this stands, for whoever picks it up next
 
-Re-checked against the tracker on 2026-08-15.
+Re-checked against the tracker on 2026-08-15, after 1.39.0.
 
-**Released**: P1 and P2 are done in the code. 1.36.0 carried the composition WURCS export, the average
-mass and the striped fills; 1.37.0 carried the position rules, the transparent exports and the three
-document-loses-your-work bugs.
+**1.39.0 is out**, and is the first release a test gate stood in front of. `origin/develop` and
+`origin/master` both read it — checked against the remote, not the local refs, which is the check 1.35.0
+was lost by. `v1.39.0` tags the merge commit, `releases/latest` resolves to it, and the run's own log shows
+`test` finishing before any installer started.
 
-**The tracker matches the code again**, as of 2026-08-15. Ten issues closed with their measurements,
-#203 and #204 filed for the two faults that had been measured and never written down anywhere but here.
-The next piece of work is #203.
+**On `develop` and not yet released**: #219 (a composition containing sialic acid), #221 (Mur built a
+MurNAc), the reason an export came out blank, and the release workflow attaching only installers. 226 tests
+pass with all of it.
 
-**1.38.0 is out.** `origin/develop` and `origin/master` both read 1.38.0 — checked against the remote,
-not the local refs, which is the check 1.35.0 was lost by. `v1.38.0` tags the merge commit and is
-reachable from `master`. It carries #199 (#88), #201 (#83's unused angle), #205 (#203), #206 (#204),
-#207 (#29) and #208 (#183), and 181 tests pass with all of them together.
+**Three things worth carrying forward**, each of which cost time to learn:
+
+- **There is a third residue dictionary.** `conf/compositions` defines residue types and they reach
+  `ResidueDictionary`, so `Neu5Ac` is already a type of its own — which is why the sialic acid names could
+  not be fixed with a synonym, and why trying shadowed a real type and broke the position rules.
+- **A test that builds its input the way the code under test likes it will not find a fault on the way in.**
+  The composition encoder's tests asked for residues *by the encoder's own names*, so a composition with
+  sialic acid failed for four releases with a green suite.
+- **Model and IO fixes reach a consumer with the jar; drawing and desktop-UI fixes do not.** Found twice
+  taking glycanbuilder2web forward, and the reason to measure rather than assume when a library layout fix
+  is supposed to have arrived.
 
 **The release page's label is the last step and it is easy to miss.** The workflow publishes as a
 pre-release, and `releases/latest` — which is what `UpdateCheck` asks — skips those, so until somebody marks
@@ -334,6 +358,7 @@ closable:
 | #58 | which part of the layout is wrong |
 | #66 | a retest on 1.36+ and the GWS; it does not reproduce here |
 | #83 | whether the symbol looks *rotated* or merely *placed differently* |
+| #222 | a retest on 1.39.0 with the sulfate at 2 rather than at N — and the advice that sent them to N was mine, corrected on #189 |
 | #185 | a retest on Windows; all five formats write here |
 | #183 | a structure that still refuses to export — the one in the report writes fine now |
 | #16 | whether to split it per modification |

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
 	<groupId>org.eurocarbdb.glycanbuilder</groupId>
 	<artifactId>glycanbuilder2</artifactId>
-	<version>1.39.0</version>
+	<version>1.40.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanBuilder.java
@@ -861,18 +861,29 @@ public class GlycanBuilder extends JFrame implements ActionListener, BaseDocumen
 
 		LinkedList<Glycan> all = doc.getStructures();
 		StringBuilder positions = new StringBuilder();
+		// Why, where whatever refused a structure said so. The count and the positions say that
+		// something went wrong; only this says what, and it was already being thrown away.
+		java.util.LinkedHashSet<String> reasons = new java.util.LinkedHashSet<String>();
 		int index = 0;
 		for( Glycan g : all ) {
 			index++;
 			if( failures.contains(g) ) {
 				if( positions.length()>0 ) positions.append(", ");
 				positions.append(index);
+
+				String why = theDoc.getLastExportFailureReason(g);
+				if( why!=null ) reasons.add(why);
 			}
 		}
 
-		JOptionPane.showMessageDialog(this,
-				failures.size() + " of " + all.size() + " structure(s) could not be exported to " + format
-						+ " and were left blank in the file (position(s): " + positions + ").",
+		StringBuilder message = new StringBuilder();
+		message.append(failures.size()).append(" of ").append(all.size())
+				.append(" structure(s) could not be exported to ").append(format)
+				.append(" and were left blank in the file (position(s): ").append(positions).append(").");
+		for( String why : reasons )
+			message.append("\n\n").append(why);
+
+		JOptionPane.showMessageDialog(this, message.toString(),
 				"Export incomplete", JOptionPane.WARNING_MESSAGE);
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanCanvas.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanCanvas.java
@@ -3603,18 +3603,29 @@ public class GlycanCanvas extends JComponent implements ActionListener,
 		if( failures.isEmpty() ) return;
 
 		StringBuilder positions = new StringBuilder();
+		// Why, where whatever refused a structure said so. The count and the positions say that
+		// something went wrong; only this says what, and it was already being thrown away.
+		java.util.LinkedHashSet<String> reasons = new java.util.LinkedHashSet<String>();
 		int index = 0;
 		for( Glycan g : exported ) {
 			index++;
 			if( failures.contains(g) ) {
 				if( positions.length()>0 ) positions.append(", ");
 				positions.append(index);
+
+				String why = theDoc.getLastExportFailureReason(g);
+				if( why!=null ) reasons.add(why);
 			}
 		}
 
-		JOptionPane.showMessageDialog(theParent,
-				failures.size() + " of " + exported.size() + " structure(s) could not be exported to " + format
-						+ " and were left blank (position(s): " + positions + ").",
+		StringBuilder message = new StringBuilder();
+		message.append(failures.size()).append(" of ").append(exported.size())
+				.append(" structure(s) could not be exported to ").append(format)
+				.append(" and were left blank (position(s): ").append(positions).append(").");
+		for( String why : reasons )
+			message.append("\n\n").append(why);
+
+		JOptionPane.showMessageDialog(theParent, message.toString(),
 				"Export incomplete", JOptionPane.WARNING_MESSAGE);
 	}
 

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/GlycanDocument.java
@@ -70,6 +70,12 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	// nothing for those, so callers need this to warn rather than leave it unnoticed
 	private ArrayList<Glycan> lastExportFailures = new ArrayList<Glycan>();
 
+	// Why each of those produced nothing, where whatever refused it said so. Static because the
+	// encoding runs through static methods; identity-keyed because two structures can be equal and
+	// still be two entries in the document.
+	static private java.util.Map<Glycan,String> lastExportReasons =
+			new java.util.IdentityHashMap<Glycan,String>();
+
 	// ----------------
 
 	/**
@@ -97,6 +103,17 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	 */
 	public ArrayList<Glycan> getLastExportFailures() {
 		return this.lastExportFailures;
+	}
+
+	/**
+	 * Why a structure produced no output on the most recent export, or null where nothing said.
+	 *
+	 * <p>The warning that names which structures came out blank can name the reason too. "A composition
+	 * cannot be written in 'NeuAc'" is the difference between somebody knowing to remove a residue and
+	 * somebody knowing only that something is wrong.
+	 */
+	public String getLastExportFailureReason(Glycan structure) {
+		return lastExportReasons.get(structure);
 	}
 
 	public void clearString() {
@@ -1537,12 +1554,14 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 		if (parser instanceof GWSParser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
 				Glycan structure = i.next();
+				forgetPreviousReason();
 				str += record(parser.writeGlycan(structure, bboxManager), structure, failures);
 				if (i.hasNext()) str += ";";
 			}
 		} else if (parser instanceof WURCS2Parser) {
 			for (Iterator<Glycan> i = structures.iterator(); i.hasNext(); ) {
 				Glycan structure = i.next();
+				forgetPreviousReason();
 				str += record(parser.writeGlycan(structure), structure, failures);
 				if (i.hasNext()) str += "\n";
 			}
@@ -1550,6 +1569,7 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 			// These formats hold one structure, so only the first is written - and the rest are
 			// therefore absent from the file, which is what the caller warns about.
 			Glycan first = structures.isEmpty() ? null : structures.iterator().next();
+			forgetPreviousReason();
 			if (bboxManager != null) { //At the moment this will force conversion to GlycoCT_XML
 				str = record(parser.writeGlycan(first, bboxManager), first, failures);
 			} else {
@@ -1571,9 +1591,39 @@ public class GlycanDocument extends BaseDocument implements SAXUtils.SAXWriter {
 	 * without saying so.
 	 */
 	static private String record(String encoded, Glycan structure, Collection<Glycan> failures) {
-		if (failures != null && structure != null && (encoded == null || encoded.isEmpty()))
+		if (failures != null && structure != null && (encoded == null || encoded.isEmpty())) {
 			failures.add(structure);
+			rememberWhy(structure);
+		}
 		return encoded;
+	}
+
+	/**
+	 * Why a structure produced nothing, in the words of whatever refused it.
+	 *
+	 * <p>The reason exists and was being thrown away. A composition of something the encoder cannot
+	 * name says so - "A composition cannot be written in 'NeuAc'" - and a writer reports it before
+	 * handing back an empty string. The warning that follows the export could then only say that N of M
+	 * structures "were left blank", which tells somebody that something went wrong and nothing about
+	 * what.
+	 *
+	 * <p>Read from {@link LogUtils}, which is where the writers already put it. That is a narrow
+	 * arrangement - it works because a writer reports immediately before returning, on the same thread -
+	 * and it is why the reason is cleared before each structure rather than trusted to be fresh. A
+	 * writer that fails silently leaves no reason, and the warning falls back to what it said before.
+	 */
+	static private void rememberWhy(Glycan structure) {
+		String reason = LogUtils.getLastError();
+		if (reason != null && !reason.trim().isEmpty())
+			lastExportReasons.put(structure, reason.trim());
+	}
+
+	/**
+	 * Clear the last reported error, so that what is read after a structure is written belongs to that
+	 * structure rather than to something earlier.
+	 */
+	static private void forgetPreviousReason() {
+		LogUtils.clearLastError();
 	}
 
 	public void fromString(String str, String format) throws Exception {

--- a/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/CompositionOptions.java
+++ b/src/main/java/org/eurocarbdb/application/glycanbuilder/massutil/CompositionOptions.java
@@ -249,7 +249,10 @@ public class CompositionOptions {
     for( int i=0; i<NEU5ACLAC; i++ ) ret.addAntenna(ResidueDictionary.newResidue("NeuAcLac"));
     for( int i=0; i<KDO; i++ ) ret.addAntenna(ResidueDictionary.newResidue("KDO"));
     for( int i=0; i<KDN; i++ ) ret.addAntenna(ResidueDictionary.newResidue("KDN"));
-    for( int i=0; i<MUR; i++ ) ret.addAntenna(ResidueDictionary.newResidue("MurNAc"));
+    // Muramic acid, which is what the count is called and what the dialog offers. It built a MurNAc
+    // - an N-acetyl heavier by C2H2O - so the mass shown and the composition searched were both for a
+    // residue nobody had asked for. Both residues exist; this is the one named on the label.
+    for( int i=0; i<MUR; i++ ) ret.addAntenna(ResidueDictionary.newResidue("Mur"));
 
     for( int i=0; i<S; i++ ) ret.addAntenna(ResidueDictionary.newResidue("S"));
     for( int i=0; i<P; i++ ) ret.addAntenna(ResidueDictionary.newResidue("P"));

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/composition/CompositionResidue.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/composition/CompositionResidue.java
@@ -16,6 +16,9 @@ package org.glycoinfo.application.glycanbuilder.composition;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 import org.eurocarbdb.MolecularFramework.sugar.Anomer;
@@ -138,7 +141,34 @@ public enum CompositionResidue {
 		for (CompositionResidue residue : values())
 			if (residue.name.equalsIgnoreCase(name)) return residue;
 
-		return null;
+		return BY_RESIDUE_TYPE_NAME.get(name.toLowerCase());
+	}
+
+	/**
+	 * Residue type names that mean one of these and are not spelled like it.
+	 *
+	 * <p>The names above are the ones composition WURCS uses. A residue type is named for the
+	 * application's own dictionary, and for the sialic acids the two disagree: the residue is
+	 * {@code NeuAc}, the composition calls it {@code Neu5Ac}. Nothing translated between them, so a
+	 * composition containing sialic acid - the most ordinary residue there is in an N-glycan - was
+	 * refused outright and exported as an empty file (#219).
+	 *
+	 * <p><b>Not solvable by naming the residue types differently.</b> {@code Neu5Ac} is already a
+	 * residue type of its own, declared in {@code conf/compositions}, so adding it as a synonym of
+	 * {@code NeuAc} shadows a real type - measured, and it broke the position rules where it was tried.
+	 * The translation belongs here, which is also where glycanbuilder2web has kept its own copy of it
+	 * and why that application was unaffected.
+	 *
+	 * <p>Only names that differ are listed. The other eleven residues the composition dialog offers are
+	 * spelled the same on both sides and are found by the loop above.
+	 */
+	private static final Map<String, CompositionResidue> BY_RESIDUE_TYPE_NAME;
+	static {
+		Map<String, CompositionResidue> translated = new HashMap<String, CompositionResidue>();
+		translated.put("neuac", NEU5AC);
+		translated.put("neugc", NEU5GC);
+
+		BY_RESIDUE_TYPE_NAME = Collections.unmodifiableMap(translated);
 	}
 
 	/**

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
@@ -1,0 +1,122 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.GlycanDocument;
+import org.eurocarbdb.application.glycanbuilder.massutil.CompositionOptions;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * That an export which produced nothing says why, and not only that it did.
+ *
+ * <p>The reason existed and was thrown away. A composition of something the encoder cannot name says so
+ * — {@code A composition cannot be written in 'NeuAc'} — and the writer reports it before handing back an
+ * empty string. The warning that followed could then only say that N of M structures "were left blank",
+ * which tells somebody that something went wrong and nothing about what to do.
+ *
+ * <p>The failure used here is a real one rather than a contrived seam: a composition containing sialic
+ * acid cannot be written at all (#219), which is the most ordinary way a user meets this.
+ */
+public class AFailedExportSaysWhyTest {
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** A composition the encoder cannot name is reported as a failure, with the reason attached. */
+	@Test
+	public void aFailureCarriesTheReasonThatCausedIt() throws Exception {
+		GlycanDocument document = documentHolding(compositionWithSialicAcid());
+
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+
+		assertEquals("the composition should have been reported as unexportable",
+				1, document.getLastExportFailures().size());
+
+		String why = document.getLastExportFailureReason(document.getStructures().get(0));
+		assertNotNull("the reason was thrown away", why);
+		assertTrue("the reason should name what could not be written, and says: " + why,
+				why.contains("NeuAc"));
+	}
+
+	/**
+	 * A structure that exported fine has no reason attached.
+	 *
+	 * <p>The reason is read from where the writers report, so the guard that matters is that a reason
+	 * left over from something earlier is not pinned to a structure that succeeded.
+	 */
+	@Test
+	public void somethingThatExportedCarriesNoReason() throws Exception {
+		GlycanDocument document = documentHolding(compositionThatWrites());
+
+		document.exportFromStructure(document.getStructures(), "wurcs2");
+
+		assertTrue("this composition should export", document.getLastExportFailures().isEmpty());
+		assertNull("a structure that exported should carry no reason",
+				document.getLastExportFailureReason(document.getStructures().get(0)));
+	}
+
+	/**
+	 * And a reason from one export does not follow a later one that worked.
+	 *
+	 * <p>This is the arrangement's weak point — the reason comes from the last reported error rather
+	 * than from a value handed back — so it is the thing worth holding.
+	 */
+	@Test
+	public void aReasonDoesNotOutliveTheExportItBelongsTo() throws Exception {
+		GlycanDocument first = documentHolding(compositionWithSialicAcid());
+		first.exportFromStructure(first.getStructures(), "wurcs2");
+		assertNotNull(first.getLastExportFailureReason(first.getStructures().get(0)));
+
+		GlycanDocument second = documentHolding(compositionThatWrites());
+		second.exportFromStructure(second.getStructures(), "wurcs2");
+
+		assertNull("the earlier failure's reason was carried into a later, successful export",
+				second.getLastExportFailureReason(second.getStructures().get(0)));
+	}
+
+	/** Hex3 HexNAc2 Neu5Ac1 — ordinary, and unwritable until #219 is fixed. */
+	private static Glycan compositionWithSialicAcid() throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		counts.HEX = 3;
+		counts.HEXNAC = 2;
+		counts.NEU5AC = 1;
+
+		return counts.getCompositionAsGlycan(neutral());
+	}
+
+	/** Hex3 HexNAc2 — the same composition without the sialic acid, which does write. */
+	private static Glycan compositionThatWrites() throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		counts.HEX = 3;
+		counts.HEXNAC = 2;
+
+		return counts.getCompositionAsGlycan(neutral());
+	}
+
+	private static MassOptions neutral() {
+		MassOptions neutral = new MassOptions();
+		neutral.DERIVATIZATION = MassOptions.NO_DERIVATIZATION;
+		neutral.ION_CLOUD = new IonCloud();
+
+		return neutral;
+	}
+
+	private static GlycanDocument documentHolding(Glycan structure) {
+		GlycanDocument document = new BuilderWorkspace(new GlycanRendererAWT()).getStructures();
+		document.addStructure(structure);
+		document.clearString();
+
+		return document;
+	}
+}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/AFailedExportSaysWhyTest.java
@@ -19,12 +19,12 @@ import org.junit.Test;
  * That an export which produced nothing says why, and not only that it did.
  *
  * <p>The reason existed and was thrown away. A composition of something the encoder cannot name says so
- * — {@code A composition cannot be written in 'NeuAc'} — and the writer reports it before handing back an
+ * — {@code A composition cannot be written in 'MeH'} — and the writer reports it before handing back an
  * empty string. The warning that followed could then only say that N of M structures "were left blank",
  * which tells somebody that something went wrong and nothing about what to do.
  *
- * <p>The failure used here is a real one rather than a contrived seam: a composition containing sialic
- * acid cannot be written at all (#219), which is the most ordinary way a user meets this.
+ * <p>The failure used here is a real one rather than a contrived seam: the composition dialog offers a
+ * methyl hexose and the encoder has no residue for it (#220).
  */
 public class AFailedExportSaysWhyTest {
 
@@ -36,7 +36,7 @@ public class AFailedExportSaysWhyTest {
 	/** A composition the encoder cannot name is reported as a failure, with the reason attached. */
 	@Test
 	public void aFailureCarriesTheReasonThatCausedIt() throws Exception {
-		GlycanDocument document = documentHolding(compositionWithSialicAcid());
+		GlycanDocument document = documentHolding(compositionThatCannotBeWritten());
 
 		document.exportFromStructure(document.getStructures(), "wurcs2");
 
@@ -46,7 +46,7 @@ public class AFailedExportSaysWhyTest {
 		String why = document.getLastExportFailureReason(document.getStructures().get(0));
 		assertNotNull("the reason was thrown away", why);
 		assertTrue("the reason should name what could not be written, and says: " + why,
-				why.contains("NeuAc"));
+				why.contains("MeH"));
 	}
 
 	/**
@@ -74,7 +74,7 @@ public class AFailedExportSaysWhyTest {
 	 */
 	@Test
 	public void aReasonDoesNotOutliveTheExportItBelongsTo() throws Exception {
-		GlycanDocument first = documentHolding(compositionWithSialicAcid());
+		GlycanDocument first = documentHolding(compositionThatCannotBeWritten());
 		first.exportFromStructure(first.getStructures(), "wurcs2");
 		assertNotNull(first.getLastExportFailureReason(first.getStructures().get(0)));
 
@@ -85,12 +85,19 @@ public class AFailedExportSaysWhyTest {
 				second.getLastExportFailureReason(second.getStructures().get(0)));
 	}
 
-	/** Hex3 HexNAc2 Neu5Ac1 — ordinary, and unwritable until #219 is fixed. */
-	private static Glycan compositionWithSialicAcid() throws Exception {
+	/**
+	 * Hex3 HexNAc2 with a methyl hexose, which the encoder has no residue for.
+	 *
+	 * <p>This was written with a sialic acid, which is how the fault was met — and #219 fixed that, so
+	 * the fixture became a composition that exports. Changed to one that still cannot be written rather
+	 * than to a contrived seam: MeH is a real residue the composition dialog offers, and #220 is the
+	 * open question of what a composition should say about it.
+	 */
+	private static Glycan compositionThatCannotBeWritten() throws Exception {
 		CompositionOptions counts = new CompositionOptions();
 		counts.HEX = 3;
 		counts.HEXNAC = 2;
-		counts.NEU5AC = 1;
+		counts.MEHEX = 1;
 
 		return counts.getCompositionAsGlycan(neutral());
 	}

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/EveryCompositionTheDialogOffersWritesTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/EveryCompositionTheDialogOffersWritesTest.java
@@ -1,0 +1,143 @@
+package org.glycoinfo.WURCSFramework.Glycan;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.eurocarbdb.application.glycanbuilder.BuilderWorkspace;
+import org.eurocarbdb.application.glycanbuilder.Glycan;
+import org.eurocarbdb.application.glycanbuilder.Residue;
+import org.eurocarbdb.application.glycanbuilder.massutil.CompositionOptions;
+import org.eurocarbdb.application.glycanbuilder.massutil.IonCloud;
+import org.eurocarbdb.application.glycanbuilder.massutil.MassOptions;
+import org.eurocarbdb.application.glycanbuilder.renderutil.GlycanRendererAWT;
+import org.glycoinfo.application.glycanbuilder.converterWURCS2.WURCS2Parser;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Every composition count, through the road the application actually takes (#219).
+ *
+ * <p>The encoder's own tests ask for a {@code CompositionResidue} <b>by name</b>, so only names the
+ * encoder already knows can appear in one. That is how a composition containing sialic acid came to
+ * export as an empty file and stay that way through four releases: the residue type is called
+ * {@code NeuAc}, the composition calls it {@code Neu5Ac}, and nothing on the road between them
+ * translated. The single assertion that did go through the application's path used Hex and HexNAc —
+ * the two residues whose names happen to agree.
+ *
+ * <p>So this walks every count {@link CompositionOptions} has, sets it, builds the composition the way
+ * the dialog does, and writes it. **A test that constructs its input the way the code under test likes
+ * it will not find a fault on the way in.**
+ */
+public class EveryCompositionTheDialogOffersWritesTest {
+
+	/**
+	 * The counts that should produce a WURCS.
+	 *
+	 * <p>Thirteen: the twelve the web application's dialog offers, and Hep, which the desktop dialog
+	 * offers as well.
+	 */
+	private static final List<String> SHOULD_WRITE = Arrays.asList(
+			"PEN", "HEX", "HEP", "HEXN", "HEXNAC", "DHEX", "DDHEX", "HEXA",
+			"NEU5AC", "NEU5GC", "KDO", "KDN", "MUR");
+
+	/**
+	 * The counts that cannot be written, and are known not to be.
+	 *
+	 * <p>Held here so the list is a statement rather than an absence. {@code 4dPen}, {@code MeH},
+	 * {@code dHexA} and the two lactonised sialic acids have no composition residue to be counted as —
+	 * and, measured, cannot be written as ordinary structures either, so they are not a composition
+	 * fault. The rest are substituents, user-defined residues and the two placeholders. All of it is
+	 * #220.
+	 */
+	private static final List<String> KNOWN_NOT_TO = Arrays.asList(
+			"DPEN", "MEHEX", "DHEXA", "NEU5ACLAC", "NEU5GCLAC",
+			"OR1", "OR2", "OR3", "S", "P", "AC", "PYR", "PC", "KETOSE", "UNKNOWN");
+
+	@BeforeClass
+	public static void loadDictionaries() {
+		new BuilderWorkspace(new GlycanRendererAWT());
+	}
+
+	/** Each of the thirteen writes something. */
+	@Test
+	public void everyOfferedResidueWrites() throws Exception {
+		List<String> silent = new ArrayList<String>();
+		for (String count : SHOULD_WRITE)
+			if (writes(count) == null) silent.add(count + " (" + residueMadeBy(count) + ")");
+
+		assertTrue("these composition counts exported as an empty file: " + silent, silent.isEmpty());
+	}
+
+	/** Sialic acid in particular, since that is the one that was refused and the one users reach for. */
+	@Test
+	public void aSialylatedCompositionWrites() throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		counts.HEX = 5;
+		counts.HEXNAC = 4;
+		counts.NEU5AC = 2;
+		counts.DHEX = 1;
+
+		String written = new WURCS2Parser().writeGlycan(counts.getCompositionAsGlycan(neutral()));
+
+		assertFalse("a sialylated composition exported as an empty file", written.isEmpty());
+		assertTrue("the residues are not the ones expected: " + written,
+				written.startsWith("WURCS=2.0/4,12,11/[Aad21122h-2x_2-6_5*NCC/3=O][axxxxm-1x_1-5]"
+						+ "[axxxxh-1x_1-5_2*NCC/3=O][axxxxh-1x_1-5]/1-1-2-3-3-3-3-4-4-4-4-4/"));
+	}
+
+	/**
+	 * And the ones that cannot be written are still the ones we think they are.
+	 *
+	 * <p>Not an assertion that they should stay broken — it is #220's list, and this fails if one starts
+	 * working, which is the moment to move it into the list above.
+	 */
+	@Test
+	public void theOnesThatCannotAreStillTheOnesWeThinkTheyAre() throws Exception {
+		List<String> nowWriting = new ArrayList<String>();
+		for (String count : KNOWN_NOT_TO)
+			if (writes(count) != null) nowWriting.add(count);
+
+		assertEquals("these now write, and belong in the offered list instead: " + nowWriting,
+				0, nowWriting.size());
+	}
+
+	/** @return Returns what the count wrote, or null where it wrote nothing. */
+	private static String writes(String count) throws Exception {
+		Glycan composition = compositionOf(count);
+		if (composition == null) return null;
+
+		String written = new WURCS2Parser().writeGlycan(composition);
+		return written.isEmpty() ? null : written;
+	}
+
+	private static String residueMadeBy(String count) throws Exception {
+		StringBuilder made = new StringBuilder();
+		for (Residue residue : compositionOf(count).getAllResidues())
+			if (!residue.isReducingEnd() && !residue.isBracket() && residue.getType() != null)
+				made.append(residue.getType().getName());
+
+		return made.toString();
+	}
+
+	private static Glycan compositionOf(String count) throws Exception {
+		CompositionOptions counts = new CompositionOptions();
+		Field field = CompositionOptions.class.getField(count);
+		field.setInt(counts, 1);
+
+		return counts.getCompositionAsGlycan(neutral());
+	}
+
+	private static MassOptions neutral() {
+		MassOptions neutral = new MassOptions();
+		neutral.DERIVATIZATION = MassOptions.NO_DERIVATIZATION;
+		neutral.ION_CLOUD = new IonCloud();
+
+		return neutral;
+	}
+}


### PR DESCRIPTION
Release 1.40.0.

**Minor rather than patch**: the Muramic Acid count builds a different residue than it did, so a mass shown
and a composition searched both change. Nothing else here alters a number a user sees.

226 tests pass. `origin/develop` reads 1.40.0, checked against the remote rather than the local ref.

| # | What | Verified by |
|---|---|---|
| #219 | A composition with sialic acid exported as an empty file | thirteen counts write where eleven did; a sialylated composition writes what glycanbuilder2web writes |
| #221 | "Muramic Acid" built a MurNAc | `Mur` and `MurNAc` write different WURCS; the count builds the one on the label |
| — | An export that produced nothing now says why | the reason reaches both warning dialogs, and does not follow a later export that worked |
| — | A release attaches installers, not the test reports | named download, extension-scoped attach |

### Three things worth reading twice

**This was found by comparing the library against a consumer, not by the suite.** glycanbuilder2web offers
twelve composition residues and converts them with its own table; this library offers eighteen and could
write eleven. The difference was the whole finding.

**The encoder's tests could not have caught it.** They ask for a `CompositionResidue` *by the encoder's own
name*, so only names it already knows can appear in one. The single assertion that went through the
application's path used Hex and HexNAc — the two residues whose names happen to agree. A composition with
sialic acid therefore failed for four releases with a green suite. The new test walks **every** count
`CompositionOptions` has, and keeps the list of the ones that still cannot be written so that is a statement
rather than an absence.

**`Neu5Ac` was already taken.** There is a third residue dictionary — `conf/compositions` — whose types
reach `ResidueDictionary`. Adding `Neu5Ac` as a synonym of `NeuAc`, which looked like the tidy fix, shadowed
a real type and broke the position rules. Measured, reverted, and the translation put in the encoder
instead.

### What is left, and why none of it is in here

Thirty issues are open and **none is actionable without a reply or a decision** — twelve waiting on somebody
else, six on a chemistry or product decision, two on hold, and the rest wishes or structure-model work.
`TRIAGE.md` says so on the page now rather than leaving a list of thirty to imply otherwise.

**#222 is the one that looks actionable and is not.** A sulfate attaches at a GlcN's `N` and then writes
nothing; refusing the attachment is the better answer, but that is a position-rule change, and changes of
that exact shape produced two regressions in two days. It waits for the reporter's retest.

### Closing with this release

#219 and #221. `develop` is not the default branch, so `Closes #N` does not fire on merge, and closing them
by hand earlier would have told each reporter it was done while no installable version had it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
