### PR TITLE
Better handling of WURCS conversion errors

### DIFF
--- a/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/converterWURCS2/WURCS2Parser.java
@@ -61,7 +61,7 @@ public class WURCS2Parser implements GlycanParser{
 	}
 	
 	public Glycan readGlycan(String str, MassOptions mass_opt) throws Exception{
-		if(str.equals("") || !str.contains("WURCS")) throw new Exception(str + " is wrong format");
+		if(str.equals("") || !str.contains("WURCS")) throw new WURCSToGlycanException(str + " is wrong format");
 		mass_opt.setDerivatization("Und");
 		mass_opt.ION_CLOUD.set("Na", 0);
 
@@ -86,13 +86,16 @@ public class WURCS2Parser implements GlycanParser{
 			WURCSSequence2ToGlycan seq22glycan = new WURCSSequence2ToGlycan();
 			seq22glycan.start(new WURCSFactory(graph), mass_opt);
 			glycan = seq22glycan.getGlycan();
-		} catch (RuntimeException undescribed) {
+		} catch (WURCSToGlycanException ex) {
+			throw ex;
+		} catch (Exception undescribed) {
 			// The conversion's own failures come out as raw NullPointerExceptions and
 			// StringIndexOutOfBounds - "String index out of range: 8" for a substituent placed at
 			// position 9 of a hexose, say - which name nothing and read as crashes rather than as
 			// answers (#123). This is the one door every WURCS enters through, so the translation
 			// happens here: what kind of failure, on which sequence, with the original underneath
 			// for whoever needs the trace.
+			// undescribed.printStackTrace();
 			throw new WURCSToGlycanException("could not convert this WURCS to a structure ("
 					+ undescribed.getClass().getSimpleName()
 					+ (undescribed.getMessage() != null ? ": " + undescribed.getMessage() : "")
@@ -138,7 +141,7 @@ public class WURCS2Parser implements GlycanParser{
 	private static void refuseCycles(Residue residue, java.util.Set<Residue> visited) throws Exception {
 		if (residue == null) return;
 		if (!visited.add(residue))
-			throw new Exception("this WURCS makes two connections between the same residues"
+			throw new WURCSToGlycanException("this WURCS makes two connections between the same residues"
 					+ " (a ring through a bridge), which cannot be represented yet");
 
 		for (org.eurocarbdb.application.glycanbuilder.linkage.Linkage linkage : residue.getChildrenLinkages())

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/WURCSToGlycanException.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/WURCSToGlycanException.java
@@ -9,6 +9,9 @@ public class WURCSToGlycanException extends WURCSException{
 	 */
 	private static final long serialVersionUID = 1L;
 
+	public static final String badResidueMessage = "Failed to convert residue";
+	public static final String badSubstituentMessage = "Failed to convert substituent";
+
 	public WURCSToGlycanException(String a_strMessage, Throwable a_oCause) {
 		super(a_strMessage, a_oCause);
 	}
@@ -18,4 +21,13 @@ public class WURCSToGlycanException extends WURCSException{
 		// TODO 自動生成されたコンストラクター・スタブ
 	}
 
+	public WURCSToGlycanException(String a_strMessage, String seq, Throwable a_oCause) {
+		super(a_strMessage + ": " + seq, a_oCause);
+	}
+
+	public WURCSToGlycanException(String a_strMessage, String seq) {
+		super(a_strMessage + ": " + seq);
+	}
+
 }
+

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/GLINToLinkage.java
@@ -137,7 +137,7 @@ public class GLINToLinkage {
 		this.analyzeDonorGLIN(_gres);
 	}
 
-	private void analyzeAcceptorGLIN(GRES _gres) {
+	private void analyzeAcceptorGLIN(GRES _gres) throws Exception {
 		for(GLIN acceptorGLIN : _gres.getAcceptorGLINs()) {
 			//if(acceptorGLIN.isRepeat()) this.analyzeStartSideRep(acceptorGLIN);
 			if(acceptorGLIN.isRepeat()) this.analyzeAcceptorSideRep(acceptorGLIN);
@@ -156,7 +156,7 @@ public class GLINToLinkage {
 		}
 	}
 
-	private void analyzeDonorGLIN(GRES _gres) {
+	private void analyzeDonorGLIN(GRES _gres) throws Exception {
 		for(GLIN donorGLIN : _gres.getDonorGLINs()) {
 			if(donorGLIN.getDonor().size() > 1) continue;
 			//if(donorGLIN.isRepeat()) this.analyzeEndSideRep(donorGLIN);
@@ -174,12 +174,12 @@ public class GLINToLinkage {
 		if(acceptorLinkages.size() == 2) checkDualLinkage(getParentLinkage(), _gres);
 	}
 
-	protected void analyzeGLINforChild(GLIN _acceptorGLIN) {
+	protected void analyzeGLINforChild(GLIN _acceptorGLIN) throws Exception {
 		char[] a_caPositions = this.makeLinkagePosiiton(_acceptorGLIN.getAcceptorPositions());
 		this.donorLinkages.add(new Linkage(this.acceptorRES, null, a_caPositions));
 	}
 
-	protected void analyzeGLINforParent(GLIN _donorGLIN) {
+	protected void analyzeGLINforParent(GLIN _donorGLIN) throws Exception {
 		char[] a_caPositions = this.makeLinkagePosiiton(_donorGLIN.getAcceptorPositions());
 		char[] a_cdPositions = this.makeLinkagePosiiton(_donorGLIN.getDonorPositions());
 		Linkage linkage = null;
@@ -190,19 +190,16 @@ public class GLINToLinkage {
 			this.acceptorLinkages.add(linkage);
 		}else {
 			SUBSTAnalyzer a_oSUBSTAnalyzer = new SUBSTAnalyzer();
-			try {
-				Residue a_oSUB = a_oSUBSTAnalyzer.MAPToBridge(_donorGLIN);
-				linkage = new Linkage(a_oSUB, this.acceptorRES, a_cdPositions);
-				linkage.setAnomericCarbon(a_cdPositions[0]);
-				//linkage.setSubstituent(a_oSUB);
+			
+			Residue a_oSUB = a_oSUBSTAnalyzer.MAPToBridge(_donorGLIN);
+			linkage = new Linkage(a_oSUB, this.acceptorRES, a_cdPositions);
+			linkage.setAnomericCarbon(a_cdPositions[0]);
+			//linkage.setSubstituent(a_oSUB);
 
-				this.a_oBridgeLinkage = linkage;
+			this.a_oBridgeLinkage = linkage;
 
-				linkage = new Linkage(null, a_oSUB, a_caPositions);
-				this.acceptorLinkages.add(linkage);
-			} catch (Exception e) {
-				LogUtils.report(e);
-			}
+			linkage = new Linkage(null, a_oSUB, a_caPositions);
+			this.acceptorLinkages.add(linkage);
 		}
 
 		// probability annotation
@@ -227,7 +224,7 @@ public class GLINToLinkage {
 	 * definite position where the sequence had said it was unknown. Here the sides are read for
 	 * what they are - the acceptor side names the antenna, the donor side its candidates.</p>
 	 */
-	private void analyzeReverseAntennaGLIN(GLIN _acceptorGLIN) {
+	private void analyzeReverseAntennaGLIN(GLIN _acceptorGLIN) throws Exception {
 		if(_acceptorGLIN.getDonor().size() < 2) {
 			// not an antenna after all: leave it to the reading that does not swap the sides
 			this.analyzeGLINforParent(_acceptorGLIN);

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/SUBSTAnalyzer.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/SUBSTAnalyzer.java
@@ -85,8 +85,14 @@ public class SUBSTAnalyzer {
 		if(_glin.getMAP().equals("")) return null;
 
 		MAPAnalyzer mapAnalyzer = new MAPAnalyzer();
-		mapAnalyzer.start(_glin.getMAP());
+		try {
+			mapAnalyzer.start(_glin.getMAP());
+		} catch (NullPointerException ex) {
+			throw new WURCSToGlycanException("Failed to convert cross-linked substituent: " + _glin.getMAP(), ex);
+		}
 		BaseCrossLinkedTemplate crossTemp = mapAnalyzer.getCrossTemplate();
+		if (crossTemp == null)
+			throw new WURCSToGlycanException("Failed to convert cross-linked substituent: " + _glin.getMAP());
 
 		return new Residue(CrossLinkedSubstituentDictionary.getCrossLinkedSubstituent(crossTemp.getIUPACnotation()));
 	}
@@ -102,7 +108,7 @@ public class SUBSTAnalyzer {
 
 		ResidueType substituentType = SubstituentMAPDictionary.findResidueTypeByMAP(_glin.getMAP());
 		if(substituentType == null)
-			throw new Exception("This MAP is not support in the GlycanBuilder2:" + _glin.getMAP());
+			throw new WURCSToGlycanException(WURCSToGlycanException.badSubstituentMessage,_glin.getMAP());
 
 		return ResidueDictionary.newResidue(substituentType.getName());
 	}
@@ -121,7 +127,7 @@ public class SUBSTAnalyzer {
 
 		ResidueType substituentType = SubstituentMAPDictionary.findResidueTypeByMAP(_subst.getMAP());
 		if(substituentType == null)
-			throw new Exception("This MAP is not support in the GlycanBuilder2:" + _subst.getMAP());
+			throw new WURCSToGlycanException(WURCSToGlycanException.badSubstituentMessage,_subst.getMAP());
 
 		String subNotation = positions[0] + "*" + substituentType.getName();
 
@@ -136,13 +142,17 @@ public class SUBSTAnalyzer {
 			substituentType = SubstituentMAPDictionary.findResidueTypeByMAP(
 					_subst.getMAP().replaceFirst("N", "O"));
 			if(substituentType == null)
-				throw new Exception("This MAP is not support in the GlycanBuilder2:" + _subst.getMAP());
+				throw new WURCSToGlycanException(WURCSToGlycanException.badSubstituentMessage,_subst.getMAP());
 		}
 
 		linkage.setLinkagePositions(positions);
 
 		// set LinkageType
-		linkage.setParentLinkageType(checkLinkageTypeOfMAP(_subst, _ms));
+		try {
+			linkage.setParentLinkageType(checkLinkageTypeOfMAP(_subst, _ms));
+		} catch (StringIndexOutOfBoundsException ex) {
+			throw new WURCSToGlycanException(WURCSToGlycanException.badSubstituentMessage,_subst.getMAP(),ex);			
+		}
 		linkage.setChildLinkageType(LinkageType.NONMONOSACCHARID);
 
 		// set probability annotation
@@ -157,11 +167,15 @@ public class SUBSTAnalyzer {
 	private void analyzeBRIDGE(BRIDGE _bridge, Residue _residue) throws Exception {
 		Linkage linkage = new Linkage();
 		MAPAnalyzer mapAnalyzer = new MAPAnalyzer();
-		mapAnalyzer.start(_bridge.getMAP().equals("") ? "*O*" : _bridge.getMAP());
+		try {
+			mapAnalyzer.start(_bridge.getMAP().equals("") ? "*O*" : _bridge.getMAP());
+		} catch (NullPointerException ex) {
+			throw new WURCSToGlycanException(WURCSToGlycanException.badSubstituentMessage,(_bridge.getMAP().equals("") ? "*O*" : _bridge.getMAP()),ex);
+		}
 		BaseCrossLinkedTemplate crossTemp = mapAnalyzer.getCrossTemplate();
 
 		if (crossTemp == null)
-			throw new Exception("This MAP is not support in the GlycanBuilder2:" + _bridge.getMAP());
+			throw new WURCSToGlycanException(WURCSToGlycanException.badSubstituentMessage,(_bridge.getMAP().equals("") ? "*O*" : _bridge.getMAP()));
 
 		char[] startPos = this.makePosition(_bridge.getStartPositions());
 		char[] endPos = this.makePosition(_bridge.getEndPositions());

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/TrivialNameConverter.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/TrivialNameConverter.java
@@ -85,7 +85,7 @@ public class TrivialNameConverter {
             ExtendedConverter extConv = new ExtendedConverter();
             this.fullName = extConv.start(_node);
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException("Failed to convert to IUPAC notation");
         }
     }
 

--- a/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/WURCSSequence2ToGlycan.java
+++ b/src/main/java/org/glycoinfo/application/glycanbuilder/util/exchange/importer/WURCSSequence2ToGlycan.java
@@ -13,6 +13,8 @@ import org.glycoinfo.WURCSFramework.wurcs.sequence2.GLIN;
 import org.glycoinfo.WURCSFramework.wurcs.sequence2.GRES;
 import org.glycoinfo.WURCSFramework.wurcs.sequence2.WURCSSequence2;
 
+import org.glycoinfo.application.glycanbuilder.util.exchange.WURCSToGlycanException;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 
@@ -127,15 +129,28 @@ public class WURCSSequence2ToGlycan {
 	}
 
 	private void analyzeGRES(GRES _gres) throws Exception {
-		GRESToResidue gres2residue = new GRESToResidue();
-
-		gres2residue.start(_gres);
+		GRESToResidue gres2residue;
+		try {
+			gres2residue = new GRESToResidue();
+			gres2residue.start(_gres);
+		} catch (WURCSToGlycanException ex) {
+			throw ex;
+		} catch (Exception ex) {
+			throw new WURCSToGlycanException(WURCSToGlycanException.badResidueMessage,_gres.getMS().getString(),ex);
+		}
 		Residue residue = gres2residue.getResidue();
 		this.gres2residue.put(_gres, residue);
 
 		// add substituent as child residue
 		SUBSTAnalyzer substAnalyzer = new SUBSTAnalyzer(gres2residue.getModifications());
-		substAnalyzer.start(_gres, residue);
+		try {
+			substAnalyzer.start(_gres, residue);
+		} catch (WURCSToGlycanException ex) {
+			throw ex;
+		} catch (Exception ex) {
+			throw new WURCSToGlycanException(WURCSToGlycanException.badResidueMessage,_gres.getMS().getString(),ex);
+		}
+		
 	}
 
 	private void analyzeCompositionGLIN (GRES _gres) {
@@ -153,8 +168,16 @@ public class WURCSSequence2ToGlycan {
 	}
 
 	private void analyzeGLIN(GRES _gres, LinkedList<LIN> _lins) throws Exception {
-		GLINToLinkage glin2linkage = new GLINToLinkage(this.gres2residue.get(_gres), _lins);
-		glin2linkage.start(_gres);
+		GLINToLinkage glin2linkage;
+		try {
+			glin2linkage = new GLINToLinkage(this.gres2residue.get(_gres), _lins);
+			glin2linkage.start(_gres);
+		} catch (WURCSToGlycanException ex) {
+			throw ex;
+		} catch (Exception ex) {
+			throw new WURCSToGlycanException("Failed to convert linkage",ex);
+		}
+		
 
 		// define glycosidic bond
 		Residue donor = this.gres2residue.get(_gres);
@@ -162,8 +185,13 @@ public class WURCSSequence2ToGlycan {
 				this.gres2residue.get(glin2linkage.getParents().get(0)) : null;
 		Residue start = this.gres2residue.get(glin2linkage.getStartRepeatingGRES());
 
-		LinkageConnector linkageConnector = new LinkageConnector(donor, acceptor, start);
-		linkageConnector.start(glin2linkage);
+		LinkageConnector linkageConnector;
+		try {
+			linkageConnector = new LinkageConnector(donor, acceptor, start);
+			linkageConnector.start(glin2linkage);
+		} catch (Exception ex) {
+			throw new WURCSToGlycanException("Failed to convert linkage",ex);
+		}
 
 		// set parents for fragments
 		if(glin2linkage.getParents().size() > 1) {

--- a/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsErrorTranslationTest.java
+++ b/src/test/java/org/glycoinfo/WURCSFramework/Glycan/WurcsErrorTranslationTest.java
@@ -40,17 +40,35 @@ public class WurcsErrorTranslationTest {
 		try {
 			new WURCS2Parser().readGlycan(POSITION_PAST_THE_SUGAR, new MassOptions());
 			fail("it converted");
-		} catch (StringIndexOutOfBoundsException raw) {
-			fail("still a raw StringIndexOutOfBoundsException");
 		} catch (WURCSToGlycanException translated) {
 			assertTrue(translated.getMessage(),
-					translated.getMessage().contains("could not convert this WURCS"));
-			assertTrue("does not say what kind of failure it was",
-					translated.getMessage().contains("StringIndexOutOfBounds"));
-			assertTrue("does not name the sequence",
-					translated.getMessage().contains("WURCS=2.0/1,1,0/[axxxxh"));
+					translated.getMessage().contains(WURCSToGlycanException.badSubstituentMessage));
+			assertTrue(translated.getMessage(),
+					translated.getMessage().contains("*OSO/3=O/3=O"));
 			assertTrue("the original trace was lost",
-					translated.getCause() instanceof StringIndexOutOfBoundsException);
+					translated.getCause() != null);
+		} catch (Exception raw) {
+			fail("still a raw Exception: "+raw.getClass().getSimpleName());
+		}
+	}
+
+	/** The failure names the failure, the sequence, and carries the original underneath. */
+	@Test
+	public void aConversionFailureSpeaksWurcs2() throws Exception {
+		try {
+			// G00028QS // in analyzeGRES use in WURCSSequence2ToGlycan.start
+			new WURCS2Parser().readGlycan("WURCS=2.0/3,3,2/[AUdxxxxh][AUxxxxxh][uxxxh_4*NCC/3=O]/1-2-3/a?|b?|c?}-{a?|b?|c?_a?|b?|c?}-{a?|b?|c?", 
+				new MassOptions());
+			fail("it converted");
+		} catch (WURCSToGlycanException translated) {
+			assertTrue(translated.getMessage(),
+					translated.getMessage().contains(WURCSToGlycanException.badResidueMessage));
+			assertTrue(translated.getMessage(),
+					translated.getMessage().contains("AUdxxxxh"));
+			assertTrue("the original trace was lost",
+			 		translated.getCause() != null);
+		} catch (Exception raw) {
+			fail("still a raw Exception: "+raw.getClass().getSimpleName());
 		}
 	}
 
@@ -81,9 +99,12 @@ public class WurcsErrorTranslationTest {
 					"WURCS=2.0/1,1,0/[a2122h-1b_1-5_2*XYZQW]/1/", new MassOptions());
 			fail("it converted");
 		} catch (WURCSToGlycanException wrapped) {
-			fail("a descriptive checked failure was rewrapped: " + wrapped.getMessage());
-		} catch (Exception descriptive) {
-			assertTrue(descriptive.getMessage(), descriptive.getMessage().contains("*XYZQW"));
+			assertTrue("does not indicate a bad substituent", 
+				wrapped.getMessage().contains(WURCSToGlycanException.badSubstituentMessage));
+			assertTrue("does not indicate the problematic substituent", 
+				wrapped.getMessage().contains("*XYZQW"));
+		} catch (Exception ex) {
+			fail("a generic exception was raised: " + ex.getMessage());
 		}
 	}
 


### PR DESCRIPTION
This PR catches all Java Exceptions that result from parsing the GlyTouCan collection of WURCS sequences using the readGlycan method of the WURCS2Parser.java class. WURCS conversion errors are shown in a consistent way, show the problematic (string) element, and have a predictable exception class. Where the error was the result of catching NullPointer or StringIndexOutOfBounds the original stack trace is captured too, for later debugging. Testing of the readGlycan method is augmented with another test case, and the success criteria updated too. 